### PR TITLE
Add SECURE_INTEGRATION to build step

### DIFF
--- a/.ci/Dockerfile.server
+++ b/.ci/Dockerfile.server
@@ -1,3 +1,7 @@
-FROM opensearchproject/opensearch:1.0.0
-RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security
-COPY --chown=opensearch:opensearch .ci/opensearch.yml /usr/share/opensearch/config/
+FROM opensearchproject/opensearch:latest
+
+ARG opensearch_path=/usr/share/opensearch
+ARG opensearch_yml=$opensearch_path/config/opensearch.yml
+
+ARG SECURE_INTEGRATION
+RUN if [ "$SECURE_INTEGRATION" != "true" ] ; then echo "plugins.security.disabled: true" >> $opensearch_yml; fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Docker
         run: |
-          docker build -t opensearch-search:test -f .ci/Dockerfile.server .
+          docker build -t opensearch-search:test -f .ci/Dockerfile.server --build-arg "SECURE_INTEGRATION=false" .
           docker run -p 9200:9200 -p 9600:9600 -d -e "discovery.type=single-node" opensearch-search:test
-          sleep 60
+          sleep 90
       - name: Run Unit Test
         run: ./gradlew clean unitTest
       - name: Run Integration Test


### PR DESCRIPTION
Signed-off-by: Mital Awachat <awachatm@amazon.com>

### Description
* Add `SECURE_INTEGRATION` to ci build step
* Use `opensearch:latest` for ci
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-java/issues/11
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
