### PR TITLE
Run security-enabled integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Docker
         run: |
-          docker build -t opensearch-search:test -f .ci/Dockerfile.server --build-arg "SECURE_INTEGRATION=false" .
+          docker build -t opensearch-search:test -f .ci/Dockerfile.server --build-arg "SECURE_INTEGRATION=true" .
           docker run -p 9200:9200 -p 9600:9600 -d -e "discovery.type=single-node" opensearch-search:test
           sleep 90
       - name: Run Unit Test
@@ -38,4 +38,4 @@ jobs:
       - name: Run Integration Test
         run: ./gradlew clean integrationTest
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew clean build -x test

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -93,10 +93,14 @@ val unitTest = task<Test>("unitTest") {
 }
 
 val integrationTest = task<Test>("integrationTest") {
-    systemProperty("tests.security.manager", "false")
     filter {
         includeTestsMatching("org.opensearch.clients.opensearch.integTest.*")
     }
+    systemProperty("tests.security.manager", "false")
+    // Basic auth settings for integration test
+    systemProperty("https", System.getProperty("https", "true"))
+    systemProperty("user", System.getProperty("user", "admin"))
+    systemProperty("password", System.getProperty("password", "admin"))
 }
 
 publishing {


### PR DESCRIPTION
Signed-off-by: Mital Awachat <awachatm@amazon.com>

### Description
* Configure integration test to be run with security-plugin enabled
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-java/issues/12
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
