### PR TITLE
Use try-with-resource for input stream in RestClientTransport

### DIFF
--- a/java-client/src/main/java/org/opensearch/clients/base/RestClientTransport.java
+++ b/java-client/src/main/java/org/opensearch/clients/base/RestClientTransport.java
@@ -183,9 +183,10 @@ public class RestClientTransport implements Transport {
             JsonpDeserializer<ResponseT> responseParser = endpoint.responseParser();
             if (responseParser != null) {
                 // Expecting a body
-                InputStream content = clientResp.getEntity().getContent();
-                JsonParser parser = mapper.jsonpProvider().createParser(content);
-                response = responseParser.deserialize(parser, mapper);
+                try (InputStream content = clientResp.getEntity().getContent()) {
+                    JsonParser parser = mapper.jsonpProvider().createParser(content);
+                    response = responseParser.deserialize(parser, mapper);
+                }
             }
             return response;
         }


### PR DESCRIPTION
Signed-off-by: Mital Awachat <awachatm@amazon.com>

### Description
Fix resource leak in RestClientTransport.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
