### PR TITLE
Add utf-8 encoding settings in gradle settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,14 @@ allprojects {
     apply(plugin = "checkstyle")
 }
 
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
+}
+tasks.withType<Test> {
+    systemProperty("file.encoding", "UTF-8")
+}
+
+
 // Find git information.
 // The ".git" directory may not exist when resolving dependencies in the Docker image build
 if (File(rootProject.rootDir, ".git").exists()) {


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Add utf-8 encoding settings in gradle settings.
Similar to https://github.com/opensearch-project/anomaly-detection/pull/245
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
