### PR TITLE
Rename maven-metadata-local.xml to maven-metadata.xml

### DIFF
--- a/jenkins/stage-maven-release/JenkinsFile
+++ b/jenkins/stage-maven-release/JenkinsFile
@@ -46,6 +46,9 @@ pipeline {
 
                 //publish to maven local
                 sh('./gradlew publishtoMavenLocal')
+
+                //Rename maven-metadata-local.xml to maven-metadata.xml
+                sh('mv /usr/share/opensearch/.m2/repository/org/opensearch/client/opensearch-java/maven-metadata-local.xml /usr/share/opensearch/.m2/repository/org/opensearch/client/opensearch-java/maven-metadata.xml')
             }
         }      
         stage('Sign') {
@@ -91,7 +94,7 @@ pipeline {
                     sh('cp -r /usr/share/opensearch/.m2/repository/org/opensearch $OUTPUT_DIR/org/')
                     sh('bash -O extglob -c "rm -rf $OUTPUT_DIR/org/opensearch/!(client)"')
                     sh '''
-                    for file in $(find \$OUTPUT_DIR/org/opensearch/client/opensearch-java/\${VERSION} -type f)
+                    for file in $(find \$OUTPUT_DIR/org/opensearch/client/opensearch-java/ -type f)
                         do
                         if [ \${file##*.} != "asc" ]
                         then


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Since we are uploading from maven-local the maven metadata file being created is `maven-metadata-local.xml`. Renaming it to `maven-metadata.xml`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
