### PR TITLE
Remove elastic documentation references

### DIFF
--- a/java-client/src/main/java/org/opensearch/client/json/ExternallyTaggedUnion.java
+++ b/java-client/src/main/java/org/opensearch/client/json/ExternallyTaggedUnion.java
@@ -47,9 +47,6 @@ import static jakarta.json.stream.JsonParser.Event;
  * Utilities for union types whose discriminant is not directly part of the structure, either as an enclosing property name or as
  * an inner property. This is used for Elasticsearch aggregation results and suggesters, using the {@code typed_keys} parameter that
  * encodes a name+type in a single JSON property.
- *
- * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html#return-agg-type">
- *      Documentation of the <code>typed_keys</code> parameter.</a>
  */
 public interface ExternallyTaggedUnion {
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/OpenSearchAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/OpenSearchAsyncClient.java
@@ -201,9 +201,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Allows to perform multiple index/update/delete operations in a single
      * request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<BulkResponse> bulk(BulkRequest request) throws IOException, OpensearchException {
@@ -216,9 +214,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link BulkRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<BulkResponse> bulk(Function<BulkRequest.Builder, ObjectBuilder<BulkRequest>> fn)
@@ -230,9 +226,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Allows to perform multiple index/update/delete operations in a single
      * request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<BulkResponse> bulk() throws IOException, OpensearchException {
@@ -245,9 +239,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Explicitly clears the search context for a scroll.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<ClearScrollResponse> clearScroll(ClearScrollRequest request)
@@ -260,9 +252,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ClearScrollRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<ClearScrollResponse> clearScroll(
@@ -274,9 +264,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Explicitly clears the search context for a scroll.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<ClearScrollResponse> clearScroll() throws IOException, OpensearchException {
@@ -289,9 +277,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Close a point in time
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<ClosePointInTimeResponse> closePointInTime(ClosePointInTimeRequest request)
@@ -304,9 +290,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ClosePointInTimeRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<ClosePointInTimeResponse> closePointInTime(
@@ -320,9 +304,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns number of documents matching a query.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<CountResponse> count(CountRequest request) throws IOException, OpensearchException {
@@ -334,9 +316,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link CountRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<CountResponse> count(Function<CountRequest.Builder, ObjectBuilder<CountRequest>> fn)
@@ -347,9 +327,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns number of documents matching a query.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<CountResponse> count() throws IOException, OpensearchException {
@@ -365,9 +343,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Returns a 409 response when a document with a same ID already exists in the
      * index.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CompletableFuture<CreateResponse> create(CreateRequest<TDocument> request)
@@ -383,9 +359,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link CreateRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CompletableFuture<CreateResponse> create(
@@ -399,9 +373,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Removes a document from the index.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<DeleteResponse> delete(DeleteRequest request) throws IOException, OpensearchException {
@@ -413,9 +385,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link DeleteRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<DeleteResponse> delete(
@@ -429,9 +399,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Deletes documents matching the provided query.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<DeleteByQueryResponse> deleteByQuery(DeleteByQueryRequest request)
@@ -444,9 +412,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link DeleteByQueryRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<DeleteByQueryResponse> deleteByQuery(
@@ -461,9 +427,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Changes the number of requests per second for a particular Delete By Query
      * operation.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<DeleteByQueryRethrottleResponse> deleteByQueryRethrottle(
@@ -478,9 +442,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link DeleteByQueryRethrottleRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<DeleteByQueryRethrottleResponse> deleteByQueryRethrottle(
@@ -494,9 +456,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Deletes a script.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<DeleteScriptResponse> deleteScript(DeleteScriptRequest request)
@@ -509,9 +469,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link DeleteScriptRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<DeleteScriptResponse> deleteScript(
@@ -525,9 +483,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns information about whether a document exists in an index.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<BooleanResponse> exists(ExistsRequest request) throws IOException, OpensearchException {
@@ -539,9 +495,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ExistsRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<BooleanResponse> exists(
@@ -555,9 +509,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns information about whether a document source exists in an index.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<BooleanResponse> existsSource(ExistsSourceRequest request)
@@ -570,9 +522,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ExistsSourceRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<BooleanResponse> existsSource(
@@ -586,9 +536,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns information about why a specific matches (or doesn't match) a query.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CompletableFuture<ExplainResponse<TDocument>> explain(ExplainRequest request,
@@ -602,9 +550,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ExplainRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CompletableFuture<ExplainResponse<TDocument>> explain(
@@ -619,9 +565,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Returns the information about the capabilities of fields among multiple
      * indices.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<FieldCapsResponse> fieldCaps(FieldCapsRequest request)
@@ -635,9 +579,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link FieldCapsRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<FieldCapsResponse> fieldCaps(
@@ -650,9 +592,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Returns the information about the capabilities of fields among multiple
      * indices.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<FieldCapsResponse> fieldCaps() throws IOException, OpensearchException {
@@ -665,9 +605,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns a document.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CompletableFuture<GetResponse<TDocument>> get(GetRequest request,
@@ -681,9 +619,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link GetRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CompletableFuture<GetResponse<TDocument>> get(
@@ -697,9 +633,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns a script.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<GetScriptResponse> getScript(GetScriptRequest request)
@@ -712,9 +646,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link GetScriptRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<GetScriptResponse> getScript(
@@ -728,9 +660,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns all script contexts.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html">Documentation
-     * on elastic.co</a>
+     * 
      */
     public CompletableFuture<GetScriptContextResponse> getScriptContext() throws IOException, OpensearchException {
         return this.transport.performRequestAsync(GetScriptContextRequest._INSTANCE, GetScriptContextRequest.ENDPOINT,
@@ -742,9 +672,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns available script types, languages and contexts
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
     public CompletableFuture<GetScriptLanguagesResponse> getScriptLanguages()
             throws IOException, OpensearchException {
@@ -757,9 +685,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns the source of a document.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CompletableFuture<GetSourceResponse<TDocument>> getSource(GetSourceRequest request,
@@ -773,9 +699,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link GetSourceRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CompletableFuture<GetSourceResponse<TDocument>> getSource(
@@ -789,9 +713,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Creates or updates a document in an index.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CompletableFuture<IndexResponse> index(IndexRequest<TDocument> request)
@@ -804,9 +726,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link IndexRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CompletableFuture<IndexResponse> index(
@@ -820,9 +740,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns basic information about the cluster.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html">Documentation
-     * on elastic.co</a>
+     * 
      */
     public CompletableFuture<InfoResponse> info() throws IOException, OpensearchException {
         return this.transport.performRequestAsync(InfoRequest._INSTANCE, InfoRequest.ENDPOINT, this.transportOptions);
@@ -833,9 +751,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Performs a kNN search.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CompletableFuture<KnnSearchResponse<TDocument>> knnSearch(KnnSearchRequest request,
@@ -849,9 +765,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link KnnSearchRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CompletableFuture<KnnSearchResponse<TDocument>> knnSearch(
@@ -865,9 +779,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Allows to get multiple documents in one request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CompletableFuture<MgetResponse<TDocument>> mget(MgetRequest request,
@@ -881,9 +793,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link MgetRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CompletableFuture<MgetResponse<TDocument>> mget(
@@ -897,9 +807,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Allows to execute several search operations in one request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CompletableFuture<MsearchResponse<TDocument>> msearch(MsearchRequest request,
@@ -913,9 +821,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link MsearchRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CompletableFuture<MsearchResponse<TDocument>> msearch(
@@ -929,9 +835,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Allows to execute several search template operations in one request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CompletableFuture<MsearchTemplateResponse<TDocument>> msearchTemplate(
@@ -947,9 +851,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link MsearchTemplateRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CompletableFuture<MsearchTemplateResponse<TDocument>> msearchTemplate(
@@ -963,9 +865,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns multiple termvectors in one request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<MtermvectorsResponse> mtermvectors(MtermvectorsRequest request)
@@ -978,9 +878,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link MtermvectorsRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<MtermvectorsResponse> mtermvectors(
@@ -992,9 +890,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns multiple termvectors in one request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<MtermvectorsResponse> mtermvectors() throws IOException, OpensearchException {
@@ -1007,9 +903,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Open a point in time that can be used in subsequent searches
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<OpenPointInTimeResponse> openPointInTime(OpenPointInTimeRequest request)
@@ -1022,9 +916,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link OpenPointInTimeRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<OpenPointInTimeResponse> openPointInTime(
@@ -1038,9 +930,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns whether the cluster is running.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html">Documentation
-     * on elastic.co</a>
+     * 
      */
     public CompletableFuture<BooleanResponse> ping() throws IOException, OpensearchException {
         return this.transport.performRequestAsync(PingRequest._INSTANCE, PingRequest.ENDPOINT, this.transportOptions);
@@ -1051,9 +941,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Creates or updates a script.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<PutScriptResponse> putScript(PutScriptRequest request)
@@ -1066,9 +954,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link PutScriptRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<PutScriptResponse> putScript(
@@ -1083,9 +969,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Allows to evaluate the quality of ranked search results over a set of typical
      * search queries
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<RankEvalResponse> rankEval(RankEvalRequest request)
@@ -1099,9 +983,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link RankEvalRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<RankEvalResponse> rankEval(
@@ -1117,9 +999,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * source documents by a query, changing the destination index settings, or
      * fetching the documents from a remote cluster.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<ReindexResponse> reindex(ReindexRequest request)
@@ -1134,9 +1014,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ReindexRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<ReindexResponse> reindex(
@@ -1150,9 +1028,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * source documents by a query, changing the destination index settings, or
      * fetching the documents from a remote cluster.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<ReindexResponse> reindex() throws IOException, OpensearchException {
@@ -1165,9 +1041,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Changes the number of requests per second for a particular Reindex operation.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<ReindexRethrottleResponse> reindexRethrottle(ReindexRethrottleRequest request)
@@ -1180,9 +1054,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ReindexRethrottleRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<ReindexRethrottleResponse> reindexRethrottle(
@@ -1196,9 +1068,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Allows an arbitrary script to be executed and a result to be returned
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TResult> CompletableFuture<ScriptsPainlessExecuteResponse<TResult>> scriptsPainlessExecute(
@@ -1214,9 +1084,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ScriptsPainlessExecuteRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TResult> CompletableFuture<ScriptsPainlessExecuteResponse<TResult>> scriptsPainlessExecute(
@@ -1230,9 +1098,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Returns results matching a query.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CompletableFuture<SearchResponse<TDocument>> search(SearchRequest request,
@@ -1246,9 +1112,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link SearchRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CompletableFuture<SearchResponse<TDocument>> search(
@@ -1263,9 +1127,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Searches a vector tile for geospatial values. Returns results as a binary
      * Mapbox vector tile.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<SearchMvtResponse> searchMvt(SearchMvtRequest request)
@@ -1279,9 +1141,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link SearchMvtRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<SearchMvtResponse> searchMvt(
@@ -1296,9 +1156,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Returns information about the indices and shards that a search request would
      * be executed against.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<SearchShardsResponse> searchShards(SearchShardsRequest request)
@@ -1312,9 +1170,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link SearchShardsRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<SearchShardsResponse> searchShards(
@@ -1327,9 +1183,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Returns information about the indices and shards that a search request would
      * be executed against.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<SearchShardsResponse> searchShards() throws IOException, OpensearchException {
@@ -1342,9 +1196,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Allows to use the Mustache language to pre-render a search definition.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CompletableFuture<SearchTemplateResponse<TDocument>> searchTemplate(
@@ -1359,9 +1211,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link SearchTemplateRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CompletableFuture<SearchTemplateResponse<TDocument>> searchTemplate(
@@ -1377,9 +1227,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * the provided string. It is designed for low-latency look-ups used in
      * auto-complete scenarios.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-terms-enum.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<TermsEnumResponse> termsEnum(TermsEnumRequest request)
@@ -1394,9 +1242,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link TermsEnumRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-terms-enum.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<TermsEnumResponse> termsEnum(
@@ -1411,9 +1257,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Returns information and statistics about terms in the fields of a particular
      * document.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CompletableFuture<TermvectorsResponse> termvectors(TermvectorsRequest<TDocument> request)
@@ -1427,9 +1271,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link TermvectorsRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CompletableFuture<TermvectorsResponse> termvectors(
@@ -1443,9 +1285,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
     /**
      * Updates a document with a script or partial document.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument, TPartialDocument> CompletableFuture<UpdateResponse<TDocument>> update(
@@ -1460,9 +1300,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link UpdateRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument, TPartialDocument> CompletableFuture<UpdateResponse<TDocument>> update(
@@ -1477,9 +1315,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Performs an update on every document in the index without changing the
      * source, for example to pick up a mapping change.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<UpdateByQueryResponse> updateByQuery(UpdateByQueryRequest request)
@@ -1493,9 +1329,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link UpdateByQueryRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<UpdateByQueryResponse> updateByQuery(
@@ -1510,9 +1344,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      * Changes the number of requests per second for a particular Update By Query
      * operation.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CompletableFuture<UpdateByQueryRethrottleResponse> updateByQueryRethrottle(
@@ -1527,9 +1359,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpenSearchAsyncClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link UpdateByQueryRethrottleRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CompletableFuture<UpdateByQueryRethrottleResponse> updateByQueryRethrottle(

--- a/java-client/src/main/java/org/opensearch/client/opensearch/OpenSearchClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/OpenSearchClient.java
@@ -200,9 +200,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Allows to perform multiple index/update/delete operations in a single
      * request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public BulkResponse bulk(BulkRequest request) throws IOException, OpensearchException {
@@ -215,9 +213,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link BulkRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final BulkResponse bulk(Function<BulkRequest.Builder, ObjectBuilder<BulkRequest>> fn)
@@ -229,9 +225,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Allows to perform multiple index/update/delete operations in a single
      * request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public BulkResponse bulk() throws IOException, OpensearchException {
@@ -244,9 +238,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Explicitly clears the search context for a scroll.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public ClearScrollResponse clearScroll(ClearScrollRequest request) throws IOException, OpensearchException {
@@ -258,9 +250,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ClearScrollRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final ClearScrollResponse clearScroll(
@@ -272,9 +262,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Explicitly clears the search context for a scroll.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public ClearScrollResponse clearScroll() throws IOException, OpensearchException {
@@ -287,9 +275,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Close a point in time
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public ClosePointInTimeResponse closePointInTime(ClosePointInTimeRequest request)
@@ -302,9 +288,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ClosePointInTimeRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final ClosePointInTimeResponse closePointInTime(
@@ -318,9 +302,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns number of documents matching a query.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CountResponse count(CountRequest request) throws IOException, OpensearchException {
@@ -332,9 +314,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link CountRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final CountResponse count(Function<CountRequest.Builder, ObjectBuilder<CountRequest>> fn)
@@ -345,9 +325,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns number of documents matching a query.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public CountResponse count() throws IOException, OpensearchException {
@@ -363,9 +341,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Returns a 409 response when a document with a same ID already exists in the
      * index.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> CreateResponse create(CreateRequest<TDocument> request)
@@ -381,9 +357,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link CreateRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> CreateResponse create(
@@ -397,9 +371,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Removes a document from the index.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public DeleteResponse delete(DeleteRequest request) throws IOException, OpensearchException {
@@ -411,9 +383,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link DeleteRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final DeleteResponse delete(Function<DeleteRequest.Builder, ObjectBuilder<DeleteRequest>> fn)
@@ -426,9 +396,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Deletes documents matching the provided query.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public DeleteByQueryResponse deleteByQuery(DeleteByQueryRequest request)
@@ -441,9 +409,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link DeleteByQueryRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final DeleteByQueryResponse deleteByQuery(
@@ -458,9 +424,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Changes the number of requests per second for a particular Delete By Query
      * operation.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public DeleteByQueryRethrottleResponse deleteByQueryRethrottle(DeleteByQueryRethrottleRequest request)
@@ -474,9 +438,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link DeleteByQueryRethrottleRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final DeleteByQueryRethrottleResponse deleteByQueryRethrottle(
@@ -490,9 +452,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Deletes a script.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public DeleteScriptResponse deleteScript(DeleteScriptRequest request) throws IOException, OpensearchException {
@@ -504,9 +464,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link DeleteScriptRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final DeleteScriptResponse deleteScript(
@@ -520,9 +478,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns information about whether a document exists in an index.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public BooleanResponse exists(ExistsRequest request) throws IOException, OpensearchException {
@@ -534,9 +490,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ExistsRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final BooleanResponse exists(Function<ExistsRequest.Builder, ObjectBuilder<ExistsRequest>> fn)
@@ -549,9 +503,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns information about whether a document source exists in an index.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public BooleanResponse existsSource(ExistsSourceRequest request) throws IOException, OpensearchException {
@@ -563,9 +515,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ExistsSourceRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final BooleanResponse existsSource(
@@ -579,9 +529,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns information about why a specific matches (or doesn't match) a query.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> ExplainResponse<TDocument> explain(ExplainRequest request, Class<TDocument> tDocumentClass)
@@ -595,9 +543,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ExplainRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> ExplainResponse<TDocument> explain(
@@ -612,9 +558,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Returns the information about the capabilities of fields among multiple
      * indices.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public FieldCapsResponse fieldCaps(FieldCapsRequest request) throws IOException, OpensearchException {
@@ -627,9 +571,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link FieldCapsRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final FieldCapsResponse fieldCaps(Function<FieldCapsRequest.Builder, ObjectBuilder<FieldCapsRequest>> fn)
@@ -641,9 +583,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Returns the information about the capabilities of fields among multiple
      * indices.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public FieldCapsResponse fieldCaps() throws IOException, OpensearchException {
@@ -656,9 +596,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns a document.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> GetResponse<TDocument> get(GetRequest request, Class<TDocument> tDocumentClass)
@@ -672,9 +610,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link GetRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> GetResponse<TDocument> get(Function<GetRequest.Builder, ObjectBuilder<GetRequest>> fn,
@@ -687,9 +623,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns a script.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public GetScriptResponse getScript(GetScriptRequest request) throws IOException, OpensearchException {
@@ -701,9 +635,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link GetScriptRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final GetScriptResponse getScript(Function<GetScriptRequest.Builder, ObjectBuilder<GetScriptRequest>> fn)
@@ -716,9 +648,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns all script contexts.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html">Documentation
-     * on elastic.co</a>
+     * 
      */
     public GetScriptContextResponse getScriptContext() throws IOException, OpensearchException {
         return this.transport.performRequest(GetScriptContextRequest._INSTANCE, GetScriptContextRequest.ENDPOINT,
@@ -730,9 +660,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns available script types, languages and contexts
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
     public GetScriptLanguagesResponse getScriptLanguages() throws IOException, OpensearchException {
         return this.transport.performRequest(GetScriptLanguagesRequest._INSTANCE, GetScriptLanguagesRequest.ENDPOINT,
@@ -744,9 +672,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns the source of a document.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> GetSourceResponse<TDocument> getSource(GetSourceRequest request, Class<TDocument> tDocumentClass)
@@ -760,9 +686,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link GetSourceRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> GetSourceResponse<TDocument> getSource(
@@ -776,9 +700,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Creates or updates a document in an index.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> IndexResponse index(IndexRequest<TDocument> request) throws IOException, OpensearchException {
@@ -790,9 +712,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link IndexRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> IndexResponse index(
@@ -806,9 +726,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns basic information about the cluster.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html">Documentation
-     * on elastic.co</a>
+     * 
      */
     public InfoResponse info() throws IOException, OpensearchException {
         return this.transport.performRequest(InfoRequest._INSTANCE, InfoRequest.ENDPOINT, this.transportOptions);
@@ -819,9 +737,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Performs a kNN search.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> KnnSearchResponse<TDocument> knnSearch(KnnSearchRequest request, Class<TDocument> tDocumentClass)
@@ -835,9 +751,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link KnnSearchRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> KnnSearchResponse<TDocument> knnSearch(
@@ -851,9 +765,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Allows to get multiple documents in one request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> MgetResponse<TDocument> mget(MgetRequest request, Class<TDocument> tDocumentClass)
@@ -867,9 +779,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link MgetRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> MgetResponse<TDocument> mget(Function<MgetRequest.Builder, ObjectBuilder<MgetRequest>> fn,
@@ -882,9 +792,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Allows to execute several search operations in one request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> MsearchResponse<TDocument> msearch(MsearchRequest request, Class<TDocument> tDocumentClass)
@@ -898,9 +806,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link MsearchRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> MsearchResponse<TDocument> msearch(
@@ -914,9 +820,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Allows to execute several search template operations in one request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> MsearchTemplateResponse<TDocument> msearchTemplate(MsearchTemplateRequest request,
@@ -931,9 +835,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link MsearchTemplateRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> MsearchTemplateResponse<TDocument> msearchTemplate(
@@ -947,9 +849,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns multiple termvectors in one request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public MtermvectorsResponse mtermvectors(MtermvectorsRequest request) throws IOException, OpensearchException {
@@ -961,9 +861,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link MtermvectorsRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final MtermvectorsResponse mtermvectors(
@@ -975,9 +873,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns multiple termvectors in one request.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public MtermvectorsResponse mtermvectors() throws IOException, OpensearchException {
@@ -990,9 +886,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Open a point in time that can be used in subsequent searches
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public OpenPointInTimeResponse openPointInTime(OpenPointInTimeRequest request)
@@ -1005,9 +899,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link OpenPointInTimeRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final OpenPointInTimeResponse openPointInTime(
@@ -1021,9 +913,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns whether the cluster is running.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html">Documentation
-     * on elastic.co</a>
+     * 
      */
     public BooleanResponse ping() throws IOException, OpensearchException {
         return this.transport.performRequest(PingRequest._INSTANCE, PingRequest.ENDPOINT, this.transportOptions);
@@ -1034,9 +924,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Creates or updates a script.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public PutScriptResponse putScript(PutScriptRequest request) throws IOException, OpensearchException {
@@ -1048,9 +936,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link PutScriptRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final PutScriptResponse putScript(Function<PutScriptRequest.Builder, ObjectBuilder<PutScriptRequest>> fn)
@@ -1064,9 +950,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Allows to evaluate the quality of ranked search results over a set of typical
      * search queries
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public RankEvalResponse rankEval(RankEvalRequest request) throws IOException, OpensearchException {
@@ -1079,9 +963,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link RankEvalRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final RankEvalResponse rankEval(Function<RankEvalRequest.Builder, ObjectBuilder<RankEvalRequest>> fn)
@@ -1096,9 +978,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * source documents by a query, changing the destination index settings, or
      * fetching the documents from a remote cluster.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public ReindexResponse reindex(ReindexRequest request) throws IOException, OpensearchException {
@@ -1112,9 +992,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ReindexRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final ReindexResponse reindex(Function<ReindexRequest.Builder, ObjectBuilder<ReindexRequest>> fn)
@@ -1127,9 +1005,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * source documents by a query, changing the destination index settings, or
      * fetching the documents from a remote cluster.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public ReindexResponse reindex() throws IOException, OpensearchException {
@@ -1142,9 +1018,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Changes the number of requests per second for a particular Reindex operation.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public ReindexRethrottleResponse reindexRethrottle(ReindexRethrottleRequest request)
@@ -1157,9 +1031,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ReindexRethrottleRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final ReindexRethrottleResponse reindexRethrottle(
@@ -1173,9 +1045,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Allows an arbitrary script to be executed and a result to be returned
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TResult> ScriptsPainlessExecuteResponse<TResult> scriptsPainlessExecute(
@@ -1191,9 +1061,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link ScriptsPainlessExecuteRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TResult> ScriptsPainlessExecuteResponse<TResult> scriptsPainlessExecute(
@@ -1207,9 +1075,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Returns results matching a query.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> SearchResponse<TDocument> search(SearchRequest request, Class<TDocument> tDocumentClass)
@@ -1223,9 +1089,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link SearchRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> SearchResponse<TDocument> search(
@@ -1240,9 +1104,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Searches a vector tile for geospatial values. Returns results as a binary
      * Mapbox vector tile.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public SearchMvtResponse searchMvt(SearchMvtRequest request) throws IOException, OpensearchException {
@@ -1255,9 +1117,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link SearchMvtRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final SearchMvtResponse searchMvt(Function<SearchMvtRequest.Builder, ObjectBuilder<SearchMvtRequest>> fn)
@@ -1271,9 +1131,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Returns information about the indices and shards that a search request would
      * be executed against.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public SearchShardsResponse searchShards(SearchShardsRequest request) throws IOException, OpensearchException {
@@ -1286,9 +1144,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link SearchShardsRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final SearchShardsResponse searchShards(
@@ -1301,9 +1157,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Returns information about the indices and shards that a search request would
      * be executed against.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public SearchShardsResponse searchShards() throws IOException, OpensearchException {
@@ -1316,9 +1170,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Allows to use the Mustache language to pre-render a search definition.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> SearchTemplateResponse<TDocument> searchTemplate(SearchTemplateRequest request,
@@ -1333,9 +1185,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link SearchTemplateRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> SearchTemplateResponse<TDocument> searchTemplate(
@@ -1351,9 +1201,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * the provided string. It is designed for low-latency look-ups used in
      * auto-complete scenarios.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-terms-enum.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public TermsEnumResponse termsEnum(TermsEnumRequest request) throws IOException, OpensearchException {
@@ -1367,9 +1215,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link TermsEnumRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-terms-enum.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final TermsEnumResponse termsEnum(Function<TermsEnumRequest.Builder, ObjectBuilder<TermsEnumRequest>> fn)
@@ -1383,9 +1229,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Returns information and statistics about terms in the fields of a particular
      * document.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument> TermvectorsResponse termvectors(TermvectorsRequest<TDocument> request)
@@ -1399,9 +1243,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link TermvectorsRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument> TermvectorsResponse termvectors(
@@ -1415,9 +1257,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
     /**
      * Updates a document with a script or partial document.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public <TDocument, TPartialDocument> UpdateResponse<TDocument> update(
@@ -1432,9 +1272,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link UpdateRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final <TDocument, TPartialDocument> UpdateResponse<TDocument> update(
@@ -1449,9 +1287,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Performs an update on every document in the index without changing the
      * source, for example to pick up a mapping change.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public UpdateByQueryResponse updateByQuery(UpdateByQueryRequest request)
@@ -1465,9 +1301,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link UpdateByQueryRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final UpdateByQueryResponse updateByQuery(
@@ -1482,9 +1316,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      * Changes the number of requests per second for a particular Update By Query
      * operation.
      *
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public UpdateByQueryRethrottleResponse updateByQueryRethrottle(UpdateByQueryRethrottleRequest request)
@@ -1498,9 +1330,7 @@ public class OpenSearchClient extends ApiClient<OpenSearchClient> {
      *
      * @param fn a function that initializes a builder to create the
      *           {@link UpdateByQueryRethrottleRequest}
-     * @see <a href=
-     * "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">Documentation
-     * on elastic.co</a>
+     * 
      */
 
     public final UpdateByQueryRethrottleResponse updateByQueryRethrottle(

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cat/OpensearchCatAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cat/OpensearchCatAsyncClient.java
@@ -70,9 +70,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Shows information about currently configured aliases to indices including
 	 * filter and routing infos.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<AliasesResponse> aliases(AliasesRequest request)
@@ -87,9 +85,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link AliasesRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<AliasesResponse> aliases(
@@ -102,9 +98,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Shows information about currently configured aliases to indices including
 	 * filter and routing infos.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<AliasesResponse> aliases() throws IOException, OpensearchException {
@@ -118,9 +112,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Provides a snapshot of how many shards are allocated to each data node and
 	 * how much disk space they are using.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<AllocationResponse> allocation(AllocationRequest request)
@@ -135,9 +127,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link AllocationRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<AllocationResponse> allocation(
@@ -150,9 +140,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Provides a snapshot of how many shards are allocated to each data node and
 	 * how much disk space they are using.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<AllocationResponse> allocation() throws IOException, OpensearchException {
@@ -166,9 +154,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Provides quick access to the document count of the entire cluster, or
 	 * individual indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<CountResponse> count(CountRequest request) throws IOException, OpensearchException {
@@ -182,9 +168,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CountRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<CountResponse> count(Function<CountRequest.Builder, ObjectBuilder<CountRequest>> fn)
@@ -196,9 +180,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Provides quick access to the document count of the entire cluster, or
 	 * individual indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<CountResponse> count() throws IOException, OpensearchException {
@@ -212,9 +194,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Shows how much heap memory is currently being used by fielddata on every data
 	 * node in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<FielddataResponse> fielddata(FielddataRequest request)
@@ -229,9 +209,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link FielddataRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<FielddataResponse> fielddata(
@@ -244,9 +222,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Shows how much heap memory is currently being used by fielddata on every data
 	 * node in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<FielddataResponse> fielddata() throws IOException, OpensearchException {
@@ -259,9 +235,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns a concise representation of the cluster health.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<HealthResponse> health(HealthRequest request) throws IOException, OpensearchException {
@@ -274,9 +248,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link HealthRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<HealthResponse> health(
@@ -288,9 +260,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns a concise representation of the cluster health.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<HealthResponse> health() throws IOException, OpensearchException {
@@ -303,9 +273,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns help for the Cat APIs.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 	public CompletableFuture<HelpResponse> help() throws IOException, OpensearchException {
 		return this.transport.performRequestAsync(HelpRequest._INSTANCE, HelpRequest.ENDPOINT, this.transportOptions);
@@ -317,9 +285,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Returns information about indices: number of primaries and replicas, document
 	 * counts, disk size, ...
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<IndicesResponse> indices(IndicesRequest request)
@@ -334,9 +300,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link IndicesRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<IndicesResponse> indices(
@@ -349,9 +313,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Returns information about indices: number of primaries and replicas, document
 	 * counts, disk size, ...
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<IndicesResponse> indices() throws IOException, OpensearchException {
@@ -364,9 +326,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns information about the master node.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public CompletableFuture<MasterResponse> master() throws IOException, OpensearchException {
 		return this.transport.performRequestAsync(MasterRequest._INSTANCE, MasterRequest.ENDPOINT,
@@ -378,9 +337,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns information about custom node attributes.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 	public CompletableFuture<NodeattrsResponse> nodeattrs() throws IOException, OpensearchException {
 		return this.transport.performRequestAsync(NodeattrsRequest._INSTANCE, NodeattrsRequest.ENDPOINT,
@@ -392,9 +349,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns basic statistics about performance of cluster nodes.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<NodesResponse> nodes(NodesRequest request) throws IOException, OpensearchException {
@@ -407,9 +362,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link NodesRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<NodesResponse> nodes(Function<NodesRequest.Builder, ObjectBuilder<NodesRequest>> fn)
@@ -420,9 +373,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns basic statistics about performance of cluster nodes.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<NodesResponse> nodes() throws IOException, OpensearchException {
@@ -435,9 +386,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns a concise representation of the cluster pending tasks.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 	public CompletableFuture<PendingTasksResponse> pendingTasks() throws IOException, OpensearchException {
 		return this.transport.performRequestAsync(PendingTasksRequest._INSTANCE, PendingTasksRequest.ENDPOINT,
@@ -449,9 +398,7 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns information about installed plugins across nodes node.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 	public CompletableFuture<PluginsResponse> plugins() throws IOException, OpensearchException {
 		return this.transport.performRequestAsync(PluginsRequest._INSTANCE, PluginsRequest.ENDPOINT,
@@ -463,9 +410,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns information about index shard recoveries, both on-going completed.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<RecoveryResponse> recovery(RecoveryRequest request)
@@ -479,9 +423,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link RecoveryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<RecoveryResponse> recovery(
@@ -493,9 +434,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns information about index shard recoveries, both on-going completed.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<RecoveryResponse> recovery() throws IOException, OpensearchException {
@@ -508,9 +446,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns information about snapshot repositories registered in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public CompletableFuture<RepositoriesResponse> repositories() throws IOException, OpensearchException {
 		return this.transport.performRequestAsync(RepositoriesRequest._INSTANCE, RepositoriesRequest.ENDPOINT,
@@ -522,9 +457,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Provides low-level information about the segments in the shards of an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<SegmentsResponse> segments(SegmentsRequest request)
@@ -538,9 +470,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SegmentsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<SegmentsResponse> segments(
@@ -551,10 +480,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 
 	/**
 	 * Provides low-level information about the segments in the shards of an index.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<SegmentsResponse> segments() throws IOException, OpensearchException {
@@ -567,9 +492,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Provides a detailed view of shard allocation on nodes.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<ShardsResponse> shards(ShardsRequest request) throws IOException, OpensearchException {
@@ -582,9 +504,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ShardsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<ShardsResponse> shards(
@@ -596,9 +515,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Provides a detailed view of shard allocation on nodes.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<ShardsResponse> shards() throws IOException, OpensearchException {
@@ -611,9 +527,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns all snapshots in a specific repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<SnapshotsResponse> snapshots(SnapshotsRequest request)
@@ -627,9 +540,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SnapshotsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<SnapshotsResponse> snapshots(
@@ -641,9 +551,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns all snapshots in a specific repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<SnapshotsResponse> snapshots() throws IOException, OpensearchException {
@@ -657,9 +564,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Returns information about the tasks currently executing on one or more nodes
 	 * in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<TasksResponse> tasks(TasksRequest request) throws IOException, OpensearchException {
@@ -673,9 +577,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link TasksRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<TasksResponse> tasks(Function<TasksRequest.Builder, ObjectBuilder<TasksRequest>> fn)
@@ -687,9 +588,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Returns information about the tasks currently executing on one or more nodes
 	 * in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<TasksResponse> tasks() throws IOException, OpensearchException {
@@ -702,9 +600,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	/**
 	 * Returns information about existing templates.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<TemplatesResponse> templates(TemplatesRequest request)
@@ -718,9 +613,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link TemplatesRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<TemplatesResponse> templates(
@@ -731,10 +623,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 
 	/**
 	 * Returns information about existing templates.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<TemplatesResponse> templates() throws IOException, OpensearchException {
@@ -748,9 +636,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Returns cluster-wide thread pool statistics per node. By default the active,
 	 * queue and rejected statistics are returned for all thread pools.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<ThreadPoolResponse> threadPool(ThreadPoolRequest request)
@@ -765,9 +650,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ThreadPoolRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<ThreadPoolResponse> threadPool(
@@ -780,9 +662,6 @@ public class OpensearchCatAsyncClient extends ApiClient<OpensearchCatAsyncClient
 	 * Returns cluster-wide thread pool statistics per node. By default the active,
 	 * queue and rejected statistics are returned for all thread pools.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<ThreadPoolResponse> threadPool() throws IOException, OpensearchException {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cat/OpensearchCatClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cat/OpensearchCatClient.java
@@ -68,10 +68,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Shows information about currently configured aliases to indices including
 	 * filter and routing infos.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public AliasesResponse aliases(AliasesRequest request) throws IOException, OpensearchException {
@@ -85,9 +81,7 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link AliasesRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final AliasesResponse aliases(Function<AliasesRequest.Builder, ObjectBuilder<AliasesRequest>> fn)
@@ -98,10 +92,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Shows information about currently configured aliases to indices including
 	 * filter and routing infos.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public AliasesResponse aliases() throws IOException, OpensearchException {
@@ -115,9 +105,7 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * Provides a snapshot of how many shards are allocated to each data node and
 	 * how much disk space they are using.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public AllocationResponse allocation(AllocationRequest request) throws IOException, OpensearchException {
@@ -131,9 +119,7 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link AllocationRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final AllocationResponse allocation(Function<AllocationRequest.Builder, ObjectBuilder<AllocationRequest>> fn)
@@ -145,9 +131,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * Provides a snapshot of how many shards are allocated to each data node and
 	 * how much disk space they are using.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public AllocationResponse allocation() throws IOException, OpensearchException {
@@ -161,9 +144,7 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * Provides quick access to the document count of the entire cluster, or
 	 * individual indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CountResponse count(CountRequest request) throws IOException, OpensearchException {
@@ -177,9 +158,7 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CountRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CountResponse count(Function<CountRequest.Builder, ObjectBuilder<CountRequest>> fn)
@@ -191,9 +170,7 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * Provides quick access to the document count of the entire cluster, or
 	 * individual indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CountResponse count() throws IOException, OpensearchException {
@@ -207,9 +184,7 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * Shows how much heap memory is currently being used by fielddata on every data
 	 * node in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public FielddataResponse fielddata(FielddataRequest request) throws IOException, OpensearchException {
@@ -223,9 +198,7 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link FielddataRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final FielddataResponse fielddata(Function<FielddataRequest.Builder, ObjectBuilder<FielddataRequest>> fn)
@@ -237,9 +210,7 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * Shows how much heap memory is currently being used by fielddata on every data
 	 * node in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public FielddataResponse fielddata() throws IOException, OpensearchException {
@@ -252,9 +223,7 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Returns a concise representation of the cluster health.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public HealthResponse health(HealthRequest request) throws IOException, OpensearchException {
@@ -267,9 +236,7 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link HealthRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final HealthResponse health(Function<HealthRequest.Builder, ObjectBuilder<HealthRequest>> fn)
@@ -280,9 +247,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Returns a concise representation of the cluster health.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public HealthResponse health() throws IOException, OpensearchException {
@@ -294,10 +258,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 
 	/**
 	 * Returns help for the Cat APIs.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public HelpResponse help() throws IOException, OpensearchException {
 		return this.transport.performRequest(HelpRequest._INSTANCE, HelpRequest.ENDPOINT, this.transportOptions);
@@ -309,9 +269,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * Returns information about indices: number of primaries and replicas, document
 	 * counts, disk size, ...
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public IndicesResponse indices(IndicesRequest request) throws IOException, OpensearchException {
@@ -325,9 +282,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link IndicesRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final IndicesResponse indices(Function<IndicesRequest.Builder, ObjectBuilder<IndicesRequest>> fn)
@@ -339,9 +293,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * Returns information about indices: number of primaries and replicas, document
 	 * counts, disk size, ...
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public IndicesResponse indices() throws IOException, OpensearchException {
@@ -354,9 +305,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Returns information about the master node.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public MasterResponse master() throws IOException, OpensearchException {
 		return this.transport.performRequest(MasterRequest._INSTANCE, MasterRequest.ENDPOINT, this.transportOptions);
@@ -366,10 +314,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 
 	/**
 	 * Returns information about custom node attributes.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public NodeattrsResponse nodeattrs() throws IOException, OpensearchException {
 		return this.transport.performRequest(NodeattrsRequest._INSTANCE, NodeattrsRequest.ENDPOINT,
@@ -381,9 +325,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Returns basic statistics about performance of cluster nodes.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public NodesResponse nodes(NodesRequest request) throws IOException, OpensearchException {
@@ -396,9 +337,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link NodesRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final NodesResponse nodes(Function<NodesRequest.Builder, ObjectBuilder<NodesRequest>> fn)
@@ -408,10 +346,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 
 	/**
 	 * Returns basic statistics about performance of cluster nodes.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public NodesResponse nodes() throws IOException, OpensearchException {
@@ -424,9 +358,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Returns a concise representation of the cluster pending tasks.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public PendingTasksResponse pendingTasks() throws IOException, OpensearchException {
 		return this.transport.performRequest(PendingTasksRequest._INSTANCE, PendingTasksRequest.ENDPOINT,
@@ -437,10 +368,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 
 	/**
 	 * Returns information about installed plugins across nodes node.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public PluginsResponse plugins() throws IOException, OpensearchException {
 		return this.transport.performRequest(PluginsRequest._INSTANCE, PluginsRequest.ENDPOINT, this.transportOptions);
@@ -450,10 +377,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 
 	/**
 	 * Returns information about index shard recoveries, both on-going completed.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public RecoveryResponse recovery(RecoveryRequest request) throws IOException, OpensearchException {
@@ -466,9 +389,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link RecoveryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final RecoveryResponse recovery(Function<RecoveryRequest.Builder, ObjectBuilder<RecoveryRequest>> fn)
@@ -479,9 +399,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Returns information about index shard recoveries, both on-going completed.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public RecoveryResponse recovery() throws IOException, OpensearchException {
@@ -494,9 +411,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Returns information about snapshot repositories registered in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public RepositoriesResponse repositories() throws IOException, OpensearchException {
 		return this.transport.performRequest(RepositoriesRequest._INSTANCE, RepositoriesRequest.ENDPOINT,
@@ -507,10 +421,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 
 	/**
 	 * Provides low-level information about the segments in the shards of an index.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public SegmentsResponse segments(SegmentsRequest request) throws IOException, OpensearchException {
@@ -523,9 +433,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SegmentsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final SegmentsResponse segments(Function<SegmentsRequest.Builder, ObjectBuilder<SegmentsRequest>> fn)
@@ -535,10 +442,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 
 	/**
 	 * Provides low-level information about the segments in the shards of an index.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public SegmentsResponse segments() throws IOException, OpensearchException {
@@ -551,9 +454,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Provides a detailed view of shard allocation on nodes.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public ShardsResponse shards(ShardsRequest request) throws IOException, OpensearchException {
@@ -566,9 +466,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ShardsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final ShardsResponse shards(Function<ShardsRequest.Builder, ObjectBuilder<ShardsRequest>> fn)
@@ -579,9 +476,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Provides a detailed view of shard allocation on nodes.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public ShardsResponse shards() throws IOException, OpensearchException {
@@ -593,10 +487,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 
 	/**
 	 * Returns all snapshots in a specific repository.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public SnapshotsResponse snapshots(SnapshotsRequest request) throws IOException, OpensearchException {
@@ -609,9 +499,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SnapshotsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final SnapshotsResponse snapshots(Function<SnapshotsRequest.Builder, ObjectBuilder<SnapshotsRequest>> fn)
@@ -622,9 +509,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Returns all snapshots in a specific repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public SnapshotsResponse snapshots() throws IOException, OpensearchException {
@@ -637,10 +521,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Returns information about the tasks currently executing on one or more nodes
 	 * in the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public TasksResponse tasks(TasksRequest request) throws IOException, OpensearchException {
@@ -654,9 +534,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link TasksRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final TasksResponse tasks(Function<TasksRequest.Builder, ObjectBuilder<TasksRequest>> fn)
@@ -667,10 +544,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Returns information about the tasks currently executing on one or more nodes
 	 * in the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public TasksResponse tasks() throws IOException, OpensearchException {
@@ -682,10 +555,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 
 	/**
 	 * Returns information about existing templates.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public TemplatesResponse templates(TemplatesRequest request) throws IOException, OpensearchException {
@@ -694,13 +563,10 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 
 	/**
 	 * Returns information about existing templates.
-	 * 
+	 *
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link TemplatesRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final TemplatesResponse templates(Function<TemplatesRequest.Builder, ObjectBuilder<TemplatesRequest>> fn)
@@ -710,10 +576,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 
 	/**
 	 * Returns information about existing templates.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public TemplatesResponse templates() throws IOException, OpensearchException {
@@ -726,10 +588,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Returns cluster-wide thread pool statistics per node. By default the active,
 	 * queue and rejected statistics are returned for all thread pools.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public ThreadPoolResponse threadPool(ThreadPoolRequest request) throws IOException, OpensearchException {
@@ -743,9 +601,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ThreadPoolRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final ThreadPoolResponse threadPool(Function<ThreadPoolRequest.Builder, ObjectBuilder<ThreadPoolRequest>> fn)
@@ -756,10 +611,6 @@ public class OpensearchCatClient extends ApiClient<OpensearchCatClient> {
 	/**
 	 * Returns cluster-wide thread pool statistics per node. By default the active,
 	 * queue and rejected statistics are returned for all thread pools.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public ThreadPoolResponse threadPool() throws IOException, OpensearchException {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/OpensearchClusterAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/OpensearchClusterAsyncClient.java
@@ -70,9 +70,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	/**
 	 * Provides explanations for shard allocations in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<AllocationExplainResponse> allocationExplain(AllocationExplainRequest request)
@@ -86,9 +83,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link AllocationExplainRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<AllocationExplainResponse> allocationExplain(
@@ -99,10 +93,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Provides explanations for shard allocations in the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<AllocationExplainResponse> allocationExplain() throws IOException, OpensearchException {
@@ -114,10 +104,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Deletes a component template
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<DeleteComponentTemplateResponse> deleteComponentTemplate(
@@ -132,9 +118,7 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteComponentTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<DeleteComponentTemplateResponse> deleteComponentTemplate(
@@ -147,10 +131,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Clears cluster voting config exclusions.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<BooleanResponse> deleteVotingConfigExclusions(DeleteVotingConfigExclusionsRequest request)
@@ -165,9 +145,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteVotingConfigExclusionsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<BooleanResponse> deleteVotingConfigExclusions(
@@ -179,9 +156,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	/**
 	 * Clears cluster voting config exclusions.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<BooleanResponse> deleteVotingConfigExclusions()
@@ -194,10 +168,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Returns information about whether a particular component template exist
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<BooleanResponse> existsComponentTemplate(ExistsComponentTemplateRequest request)
@@ -212,9 +182,7 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ExistsComponentTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<BooleanResponse> existsComponentTemplate(
@@ -227,10 +195,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Returns one or more component templates
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<GetComponentTemplateResponse> getComponentTemplate(GetComponentTemplateRequest request)
@@ -244,9 +208,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetComponentTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<GetComponentTemplateResponse> getComponentTemplate(
@@ -257,10 +218,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Returns one or more component templates
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<GetComponentTemplateResponse> getComponentTemplate()
@@ -273,10 +230,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Returns cluster settings.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<GetSettingsResponse> getSettings(GetSettingsRequest request)
@@ -290,9 +243,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetSettingsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<GetSettingsResponse> getSettings(
@@ -303,10 +253,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Returns cluster settings.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<GetSettingsResponse> getSettings() throws IOException, OpensearchException {
@@ -318,10 +264,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Returns basic information about the health of the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<HealthResponse> health(HealthRequest request) throws IOException, OpensearchException {
@@ -334,9 +276,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link HealthRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<HealthResponse> health(
@@ -347,10 +286,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Returns basic information about the health of the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<HealthResponse> health() throws IOException, OpensearchException {
@@ -363,10 +298,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	/**
 	 * Returns a list of any cluster-level changes (e.g. create index, update
 	 * mapping, allocate or fail shard) which have not yet been executed.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<PendingTasksResponse> pendingTasks(PendingTasksRequest request)
@@ -381,9 +312,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PendingTasksRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<PendingTasksResponse> pendingTasks(
@@ -396,9 +324,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * Returns a list of any cluster-level changes (e.g. create index, update
 	 * mapping, allocate or fail shard) which have not yet been executed.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<PendingTasksResponse> pendingTasks() throws IOException, OpensearchException {
@@ -410,10 +335,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Updates the cluster voting config exclusions by node ids or node names.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<BooleanResponse> postVotingConfigExclusions(PostVotingConfigExclusionsRequest request)
@@ -428,9 +349,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PostVotingConfigExclusionsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<BooleanResponse> postVotingConfigExclusions(
@@ -442,9 +360,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	/**
 	 * Updates the cluster voting config exclusions by node ids or node names.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<BooleanResponse> postVotingConfigExclusions() throws IOException, OpensearchException {
@@ -456,10 +371,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Creates or updates a component template
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<PutComponentTemplateResponse> putComponentTemplate(PutComponentTemplateRequest request)
@@ -473,9 +384,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutComponentTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<PutComponentTemplateResponse> putComponentTemplate(
@@ -489,9 +397,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	/**
 	 * Updates the cluster settings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<PutSettingsResponse> putSettings(PutSettingsRequest request)
@@ -505,9 +410,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutSettingsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<PutSettingsResponse> putSettings(
@@ -518,10 +420,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Updates the cluster settings.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<PutSettingsResponse> putSettings() throws IOException, OpensearchException {
@@ -533,10 +431,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Returns the information about configured remote clusters.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public CompletableFuture<RemoteInfoResponse> remoteInfo() throws IOException, OpensearchException {
 		return this.transport.performRequestAsync(RemoteInfoRequest._INSTANCE, RemoteInfoRequest.ENDPOINT,
@@ -547,10 +441,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Allows to manually change the allocation of individual shards in the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<RerouteResponse> reroute(RerouteRequest request)
@@ -564,9 +454,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link RerouteRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<RerouteResponse> reroute(
@@ -578,9 +465,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	/**
 	 * Allows to manually change the allocation of individual shards in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<RerouteResponse> reroute() throws IOException, OpensearchException {
@@ -593,9 +477,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	/**
 	 * Returns a comprehensive information about the state of the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<StateResponse> state(StateRequest request) throws IOException, OpensearchException {
@@ -608,9 +489,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link StateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<StateResponse> state(Function<StateRequest.Builder, ObjectBuilder<StateRequest>> fn)
@@ -620,10 +498,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Returns a comprehensive information about the state of the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<StateResponse> state() throws IOException, OpensearchException {
@@ -635,10 +509,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Returns high-level overview of cluster statistics.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<ClusterStatsResponse> stats(ClusterStatsRequest request)
@@ -652,9 +522,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ClusterStatsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<ClusterStatsResponse> stats(
@@ -665,10 +532,6 @@ public class OpensearchClusterAsyncClient extends ApiClient<OpensearchClusterAsy
 
 	/**
 	 * Returns high-level overview of cluster statistics.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<ClusterStatsResponse> stats() throws IOException, OpensearchException {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/OpensearchClusterClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/OpensearchClusterClient.java
@@ -68,10 +68,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Provides explanations for shard allocations in the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public AllocationExplainResponse allocationExplain(AllocationExplainRequest request)
@@ -85,9 +81,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link AllocationExplainRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final AllocationExplainResponse allocationExplain(
@@ -98,10 +91,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Provides explanations for shard allocations in the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public AllocationExplainResponse allocationExplain() throws IOException, OpensearchException {
@@ -113,10 +102,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Deletes a component template
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public DeleteComponentTemplateResponse deleteComponentTemplate(DeleteComponentTemplateRequest request)
@@ -130,9 +115,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteComponentTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final DeleteComponentTemplateResponse deleteComponentTemplate(
@@ -145,10 +127,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Clears cluster voting config exclusions.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public BooleanResponse deleteVotingConfigExclusions(DeleteVotingConfigExclusionsRequest request)
@@ -163,9 +141,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteVotingConfigExclusionsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final BooleanResponse deleteVotingConfigExclusions(
@@ -176,10 +151,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Clears cluster voting config exclusions.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public BooleanResponse deleteVotingConfigExclusions() throws IOException, OpensearchException {
@@ -191,10 +162,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Returns information about whether a particular component template exist
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public BooleanResponse existsComponentTemplate(ExistsComponentTemplateRequest request)
@@ -208,9 +175,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ExistsComponentTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final BooleanResponse existsComponentTemplate(
@@ -223,10 +187,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Returns one or more component templates
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public GetComponentTemplateResponse getComponentTemplate(GetComponentTemplateRequest request)
@@ -240,9 +200,7 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetComponentTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetComponentTemplateResponse getComponentTemplate(
@@ -253,10 +211,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Returns one or more component templates
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public GetComponentTemplateResponse getComponentTemplate() throws IOException, OpensearchException {
@@ -268,10 +222,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Returns cluster settings.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public GetSettingsResponse getSettings(GetSettingsRequest request) throws IOException, OpensearchException {
@@ -284,9 +234,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetSettingsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final GetSettingsResponse getSettings(
@@ -297,10 +244,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Returns cluster settings.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public GetSettingsResponse getSettings() throws IOException, OpensearchException {
@@ -312,10 +255,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Returns basic information about the health of the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public HealthResponse health(HealthRequest request) throws IOException, OpensearchException {
@@ -328,9 +267,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link HealthRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final HealthResponse health(Function<HealthRequest.Builder, ObjectBuilder<HealthRequest>> fn)
@@ -341,9 +277,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	/**
 	 * Returns basic information about the health of the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public HealthResponse health() throws IOException, OpensearchException {
@@ -356,10 +289,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	/**
 	 * Returns a list of any cluster-level changes (e.g. create index, update
 	 * mapping, allocate or fail shard) which have not yet been executed.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public PendingTasksResponse pendingTasks(PendingTasksRequest request) throws IOException, OpensearchException {
@@ -373,9 +302,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PendingTasksRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final PendingTasksResponse pendingTasks(
@@ -387,10 +313,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	/**
 	 * Returns a list of any cluster-level changes (e.g. create index, update
 	 * mapping, allocate or fail shard) which have not yet been executed.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public PendingTasksResponse pendingTasks() throws IOException, OpensearchException {
@@ -402,10 +324,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Updates the cluster voting config exclusions by node ids or node names.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public BooleanResponse postVotingConfigExclusions(PostVotingConfigExclusionsRequest request)
@@ -420,9 +338,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PostVotingConfigExclusionsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final BooleanResponse postVotingConfigExclusions(
@@ -433,10 +348,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Updates the cluster voting config exclusions by node ids or node names.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public BooleanResponse postVotingConfigExclusions() throws IOException, OpensearchException {
@@ -448,10 +359,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Creates or updates a component template
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public PutComponentTemplateResponse putComponentTemplate(PutComponentTemplateRequest request)
@@ -465,9 +372,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutComponentTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final PutComponentTemplateResponse putComponentTemplate(
@@ -481,9 +385,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	/**
 	 * Updates the cluster settings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public PutSettingsResponse putSettings(PutSettingsRequest request) throws IOException, OpensearchException {
@@ -496,9 +397,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutSettingsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final PutSettingsResponse putSettings(
@@ -510,9 +408,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	/**
 	 * Updates the cluster settings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public PutSettingsResponse putSettings() throws IOException, OpensearchException {
@@ -524,10 +419,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Returns the information about configured remote clusters.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public RemoteInfoResponse remoteInfo() throws IOException, OpensearchException {
 		return this.transport.performRequest(RemoteInfoRequest._INSTANCE, RemoteInfoRequest.ENDPOINT,
@@ -538,10 +429,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Allows to manually change the allocation of individual shards in the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public RerouteResponse reroute(RerouteRequest request) throws IOException, OpensearchException {
@@ -554,9 +441,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link RerouteRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final RerouteResponse reroute(Function<RerouteRequest.Builder, ObjectBuilder<RerouteRequest>> fn)
@@ -566,10 +450,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Allows to manually change the allocation of individual shards in the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public RerouteResponse reroute() throws IOException, OpensearchException {
@@ -581,10 +461,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Returns a comprehensive information about the state of the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public StateResponse state(StateRequest request) throws IOException, OpensearchException {
@@ -597,9 +473,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link StateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final StateResponse state(Function<StateRequest.Builder, ObjectBuilder<StateRequest>> fn)
@@ -609,10 +482,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Returns a comprehensive information about the state of the cluster.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public StateResponse state() throws IOException, OpensearchException {
@@ -624,10 +493,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Returns high-level overview of cluster statistics.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public ClusterStatsResponse stats(ClusterStatsRequest request) throws IOException, OpensearchException {
@@ -640,9 +505,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ClusterStatsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final ClusterStatsResponse stats(
@@ -653,10 +515,6 @@ public class OpensearchClusterClient extends ApiClient<OpensearchClusterClient> 
 
 	/**
 	 * Returns high-level overview of cluster statistics.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public ClusterStatsResponse stats() throws IOException, OpensearchException {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/dangling_indices/OpensearchDanglingIndicesAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/dangling_indices/OpensearchDanglingIndicesAsyncClient.java
@@ -69,9 +69,7 @@ public class OpensearchDanglingIndicesAsyncClient extends ApiClient<OpensearchDa
 	/**
 	 * Deletes the specified dangling index
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<DeleteDanglingIndexResponse> deleteDanglingIndex(DeleteDanglingIndexRequest request)
@@ -85,9 +83,7 @@ public class OpensearchDanglingIndicesAsyncClient extends ApiClient<OpensearchDa
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteDanglingIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<DeleteDanglingIndexResponse> deleteDanglingIndex(
@@ -101,9 +97,7 @@ public class OpensearchDanglingIndicesAsyncClient extends ApiClient<OpensearchDa
 	/**
 	 * Imports the specified dangling index
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ImportDanglingIndexResponse> importDanglingIndex(ImportDanglingIndexRequest request)
@@ -117,9 +111,7 @@ public class OpensearchDanglingIndicesAsyncClient extends ApiClient<OpensearchDa
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ImportDanglingIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<ImportDanglingIndexResponse> importDanglingIndex(
@@ -133,9 +125,7 @@ public class OpensearchDanglingIndicesAsyncClient extends ApiClient<OpensearchDa
 	/**
 	 * Returns all dangling indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 	public CompletableFuture<ListDanglingIndicesResponse> listDanglingIndices()
 			throws IOException, OpensearchException {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/dangling_indices/OpensearchDanglingIndicesClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/dangling_indices/OpensearchDanglingIndicesClient.java
@@ -68,9 +68,7 @@ public class OpensearchDanglingIndicesClient extends ApiClient<OpensearchDanglin
 	/**
 	 * Deletes the specified dangling index
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public DeleteDanglingIndexResponse deleteDanglingIndex(DeleteDanglingIndexRequest request)
@@ -84,9 +82,7 @@ public class OpensearchDanglingIndicesClient extends ApiClient<OpensearchDanglin
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteDanglingIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final DeleteDanglingIndexResponse deleteDanglingIndex(
@@ -100,9 +96,7 @@ public class OpensearchDanglingIndicesClient extends ApiClient<OpensearchDanglin
 	/**
 	 * Imports the specified dangling index
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ImportDanglingIndexResponse importDanglingIndex(ImportDanglingIndexRequest request)
@@ -116,9 +110,7 @@ public class OpensearchDanglingIndicesClient extends ApiClient<OpensearchDanglin
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ImportDanglingIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final ImportDanglingIndexResponse importDanglingIndex(
@@ -132,9 +124,7 @@ public class OpensearchDanglingIndicesClient extends ApiClient<OpensearchDanglin
 	/**
 	 * Returns all dangling indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 	public ListDanglingIndicesResponse listDanglingIndices() throws IOException, OpensearchException {
 		return this.transport.performRequest(ListDanglingIndicesRequest._INSTANCE, ListDanglingIndicesRequest.ENDPOINT,

--- a/java-client/src/main/java/org/opensearch/client/opensearch/features/OpensearchFeaturesAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/features/OpensearchFeaturesAsyncClient.java
@@ -67,10 +67,6 @@ public class OpensearchFeaturesAsyncClient extends ApiClient<OpensearchFeaturesA
 	/**
 	 * Gets a list of features which can be included in snapshots using the
 	 * feature_states field when creating a snapshot
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-features-api.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public CompletableFuture<GetFeaturesResponse> getFeatures() throws IOException, OpensearchException {
 		return this.transport.performRequestAsync(GetFeaturesRequest._INSTANCE, GetFeaturesRequest.ENDPOINT,
@@ -81,10 +77,6 @@ public class OpensearchFeaturesAsyncClient extends ApiClient<OpensearchFeaturesA
 
 	/**
 	 * Resets the internal state of features, usually by deleting system indices
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public CompletableFuture<ResetFeaturesResponse> resetFeatures() throws IOException, OpensearchException {
 		return this.transport.performRequestAsync(ResetFeaturesRequest._INSTANCE, ResetFeaturesRequest.ENDPOINT,

--- a/java-client/src/main/java/org/opensearch/client/opensearch/features/OpensearchFeaturesClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/features/OpensearchFeaturesClient.java
@@ -66,10 +66,6 @@ public class OpensearchFeaturesClient extends ApiClient<OpensearchFeaturesClient
 	/**
 	 * Gets a list of features which can be included in snapshots using the
 	 * feature_states field when creating a snapshot
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-features-api.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public GetFeaturesResponse getFeatures() throws IOException, OpensearchException {
 		return this.transport.performRequest(GetFeaturesRequest._INSTANCE, GetFeaturesRequest.ENDPOINT,
@@ -80,10 +76,6 @@ public class OpensearchFeaturesClient extends ApiClient<OpensearchFeaturesClient
 
 	/**
 	 * Resets the internal state of features, usually by deleting system indices
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
 	 */
 	public ResetFeaturesResponse resetFeatures() throws IOException, OpensearchException {
 		return this.transport.performRequest(ResetFeaturesRequest._INSTANCE, ResetFeaturesRequest.ENDPOINT,

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/OpensearchIndicesAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/OpensearchIndicesAsyncClient.java
@@ -70,9 +70,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Adds a block to an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<AddBlockResponse> addBlock(AddBlockRequest request)
@@ -86,9 +84,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link AddBlockRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<AddBlockResponse> addBlock(
@@ -103,9 +99,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * Performs the analysis process on a text and return the tokens breakdown of
 	 * the text.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<AnalyzeResponse> analyze(AnalyzeRequest request)
@@ -120,9 +114,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link AnalyzeRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<AnalyzeResponse> analyze(
@@ -135,9 +127,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * Performs the analysis process on a text and return the tokens breakdown of
 	 * the text.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<AnalyzeResponse> analyze() throws IOException, OpensearchException {
@@ -150,9 +140,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Clears all or specific caches for one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ClearCacheResponse> clearCache(ClearCacheRequest request)
@@ -166,9 +154,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ClearCacheRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<ClearCacheResponse> clearCache(
@@ -180,9 +166,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Clears all or specific caches for one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ClearCacheResponse> clearCache() throws IOException, OpensearchException {
@@ -195,9 +179,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Clones an index
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<CloneIndexResponse> clone(CloneIndexRequest request)
@@ -211,9 +193,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CloneIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<CloneIndexResponse> clone(
@@ -227,9 +207,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Closes an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<CloseIndexResponse> close(CloseIndexRequest request)
@@ -243,9 +221,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CloseIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<CloseIndexResponse> close(
@@ -259,9 +235,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Creates an index with optional settings and mappings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<CreateIndexResponse> create(CreateIndexRequest request)
@@ -275,9 +249,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CreateIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<CreateIndexResponse> create(
@@ -291,9 +263,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Deletes an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<DeleteIndexResponse> delete(DeleteIndexRequest request)
@@ -307,9 +277,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<DeleteIndexResponse> delete(
@@ -323,9 +291,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Deletes an alias.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<DeleteAliasResponse> deleteAlias(DeleteAliasRequest request)
@@ -339,9 +305,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteAliasRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<DeleteAliasResponse> deleteAlias(
@@ -354,10 +318,6 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 
 	/**
 	 * Deletes an index template.
-	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<DeleteIndexTemplateResponse> deleteIndexTemplate(DeleteIndexTemplateRequest request)
@@ -371,9 +331,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteIndexTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<DeleteIndexTemplateResponse> deleteIndexTemplate(
@@ -387,9 +345,6 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Deletes an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public CompletableFuture<DeleteTemplateResponse> deleteTemplate(DeleteTemplateRequest request)
@@ -403,9 +358,6 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
 	 */
 
 	public final CompletableFuture<DeleteTemplateResponse> deleteTemplate(
@@ -419,9 +371,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Analyzes the disk usage of each field of an index or data stream
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-disk-usage.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<DiskUsageResponse> diskUsage(DiskUsageRequest request)
@@ -435,9 +385,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DiskUsageRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-disk-usage.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<DiskUsageResponse> diskUsage(
@@ -451,9 +399,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns information about whether a particular index exists.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<BooleanResponse> exists(ExistsRequest request) throws IOException, OpensearchException {
@@ -466,9 +412,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ExistsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<BooleanResponse> exists(
@@ -482,9 +426,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns information about whether a particular alias exists.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<BooleanResponse> existsAlias(ExistsAliasRequest request)
@@ -498,9 +440,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ExistsAliasRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<BooleanResponse> existsAlias(
@@ -514,9 +454,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns information about whether a particular index template exists.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<BooleanResponse> existsIndexTemplate(ExistsIndexTemplateRequest request)
@@ -530,9 +468,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ExistsIndexTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<BooleanResponse> existsIndexTemplate(
@@ -546,9 +482,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns information about whether a particular index template exists.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<BooleanResponse> existsTemplate(ExistsTemplateRequest request)
@@ -562,9 +496,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ExistsTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<BooleanResponse> existsTemplate(
@@ -579,9 +511,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * Returns information about whether a particular document type exists.
 	 * (DEPRECATED)
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<BooleanResponse> existsType(ExistsTypeRequest request)
@@ -596,9 +526,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ExistsTypeRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<BooleanResponse> existsType(
@@ -612,9 +540,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Performs the flush operation on one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<FlushResponse> flush(FlushRequest request) throws IOException, OpensearchException {
@@ -627,9 +553,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link FlushRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<FlushResponse> flush(Function<FlushRequest.Builder, ObjectBuilder<FlushRequest>> fn)
@@ -640,9 +564,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Performs the flush operation on one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<FlushResponse> flush() throws IOException, OpensearchException {
@@ -655,9 +577,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Performs the force merge operation on one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ForcemergeResponse> forcemerge(ForcemergeRequest request)
@@ -671,9 +591,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ForcemergeRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<ForcemergeResponse> forcemerge(
@@ -685,9 +603,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Performs the force merge operation on one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ForcemergeResponse> forcemerge() throws IOException, OpensearchException {
@@ -700,9 +616,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns information about one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetIndexResponse> get(GetIndexRequest request) throws IOException, OpensearchException {
@@ -715,9 +629,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<GetIndexResponse> get(
@@ -731,9 +643,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns an alias.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetAliasResponse> getAlias(GetAliasRequest request)
@@ -747,9 +657,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetAliasRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<GetAliasResponse> getAlias(
@@ -761,9 +669,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns an alias.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetAliasResponse> getAlias() throws IOException, OpensearchException {
@@ -776,9 +682,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns mapping for one or more fields.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetFieldMappingResponse> getFieldMapping(GetFieldMappingRequest request)
@@ -792,9 +696,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetFieldMappingRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<GetFieldMappingResponse> getFieldMapping(
@@ -808,9 +710,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetIndexTemplateResponse> getIndexTemplate(GetIndexTemplateRequest request)
@@ -824,9 +724,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetIndexTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<GetIndexTemplateResponse> getIndexTemplate(
@@ -838,9 +736,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetIndexTemplateResponse> getIndexTemplate() throws IOException, OpensearchException {
@@ -853,9 +749,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns mappings for one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetMappingResponse> getMapping(GetMappingRequest request)
@@ -869,9 +763,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetMappingRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<GetMappingResponse> getMapping(
@@ -883,9 +775,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns mappings for one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetMappingResponse> getMapping() throws IOException, OpensearchException {
@@ -898,9 +788,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns settings for one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetSettingsResponse> getSettings(GetSettingsRequest request)
@@ -914,9 +802,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetSettingsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<GetSettingsResponse> getSettings(
@@ -928,9 +814,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns settings for one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetSettingsResponse> getSettings() throws IOException, OpensearchException {
@@ -943,9 +827,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetTemplateResponse> getTemplate(GetTemplateRequest request)
@@ -959,9 +841,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<GetTemplateResponse> getTemplate(
@@ -973,9 +853,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetTemplateResponse> getTemplate() throws IOException, OpensearchException {
@@ -988,9 +866,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Opens an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<OpenResponse> open(OpenRequest request) throws IOException, OpensearchException {
@@ -1003,9 +879,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link OpenRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<OpenResponse> open(Function<OpenRequest.Builder, ObjectBuilder<OpenRequest>> fn)
@@ -1018,9 +892,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Creates or updates an alias.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<PutAliasResponse> putAlias(PutAliasRequest request)
@@ -1034,9 +906,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutAliasRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<PutAliasResponse> putAlias(
@@ -1050,9 +920,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Creates or updates an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<PutIndexTemplateResponse> putIndexTemplate(PutIndexTemplateRequest request)
@@ -1066,9 +934,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutIndexTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<PutIndexTemplateResponse> putIndexTemplate(
@@ -1082,9 +948,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Updates the index mappings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<PutMappingResponse> putMapping(PutMappingRequest request)
@@ -1098,9 +962,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutMappingRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<PutMappingResponse> putMapping(
@@ -1114,9 +976,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Updates the index settings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<PutSettingsResponse> putSettings(PutSettingsRequest request)
@@ -1130,9 +990,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutSettingsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<PutSettingsResponse> putSettings(
@@ -1144,9 +1002,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Updates the index settings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<PutSettingsResponse> putSettings() throws IOException, OpensearchException {
@@ -1159,9 +1015,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Creates or updates an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<PutTemplateResponse> putTemplate(PutTemplateRequest request)
@@ -1175,9 +1029,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<PutTemplateResponse> putTemplate(
@@ -1191,9 +1043,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns information about ongoing index shard recoveries.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<RecoveryResponse> recovery(RecoveryRequest request)
@@ -1207,9 +1057,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link RecoveryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<RecoveryResponse> recovery(
@@ -1221,9 +1069,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns information about ongoing index shard recoveries.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<RecoveryResponse> recovery() throws IOException, OpensearchException {
@@ -1236,9 +1082,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Performs the refresh operation in one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<RefreshResponse> refresh(RefreshRequest request)
@@ -1252,9 +1096,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link RefreshRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<RefreshResponse> refresh(
@@ -1266,9 +1108,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Performs the refresh operation in one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<RefreshResponse> refresh() throws IOException, OpensearchException {
@@ -1281,9 +1121,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Returns information about any matching indices, aliases, and data streams
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ResolveIndexResponse> resolveIndex(ResolveIndexRequest request)
@@ -1297,9 +1135,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ResolveIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<ResolveIndexResponse> resolveIndex(
@@ -1314,9 +1150,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * Updates an alias to point to a new index when the existing index is
 	 * considered to be too large or too old.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<RolloverResponse> rollover(RolloverRequest request)
@@ -1331,9 +1165,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link RolloverRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<RolloverResponse> rollover(
@@ -1347,9 +1179,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Provides low-level information about segments in a Lucene index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<SegmentsResponse> segments(SegmentsRequest request)
@@ -1363,9 +1193,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SegmentsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<SegmentsResponse> segments(
@@ -1377,9 +1205,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Provides low-level information about segments in a Lucene index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<SegmentsResponse> segments() throws IOException, OpensearchException {
@@ -1392,9 +1218,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Provides store information for shard copies of indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ShardStoresResponse> shardStores(ShardStoresRequest request)
@@ -1408,9 +1232,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ShardStoresRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<ShardStoresResponse> shardStores(
@@ -1422,9 +1244,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Provides store information for shard copies of indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ShardStoresResponse> shardStores() throws IOException, OpensearchException {
@@ -1437,9 +1257,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Allow to shrink an existing index into a new index with fewer primary shards.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ShrinkResponse> shrink(ShrinkRequest request) throws IOException, OpensearchException {
@@ -1452,9 +1270,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ShrinkRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<ShrinkResponse> shrink(
@@ -1469,9 +1285,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * Simulate matching the given index name against the index templates in the
 	 * system
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<SimulateIndexTemplateResponse> simulateIndexTemplate(SimulateIndexTemplateRequest request)
@@ -1487,9 +1301,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SimulateIndexTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<SimulateIndexTemplateResponse> simulateIndexTemplate(
@@ -1503,9 +1315,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Simulate resolving the given template name or body
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<SimulateTemplateResponse> simulateTemplate(SimulateTemplateRequest request)
@@ -1519,9 +1329,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SimulateTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<SimulateTemplateResponse> simulateTemplate(
@@ -1533,9 +1341,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Simulate resolving the given template name or body
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<SimulateTemplateResponse> simulateTemplate() throws IOException, OpensearchException {
@@ -1549,9 +1355,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * Allows you to split an existing index into a new index with more primary
 	 * shards.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<SplitResponse> split(SplitRequest request) throws IOException, OpensearchException {
@@ -1565,9 +1369,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SplitRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<SplitResponse> split(Function<SplitRequest.Builder, ObjectBuilder<SplitRequest>> fn)
@@ -1580,9 +1382,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Provides statistics on operations happening in an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<IndicesStatsResponse> stats(IndicesStatsRequest request)
@@ -1596,9 +1396,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link IndicesStatsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<IndicesStatsResponse> stats(
@@ -1610,9 +1408,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Provides statistics on operations happening in an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<IndicesStatsResponse> stats() throws IOException, OpensearchException {
@@ -1625,9 +1421,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Updates index aliases.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<UpdateAliasesResponse> updateAliases(UpdateAliasesRequest request)
@@ -1641,9 +1435,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link UpdateAliasesRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<UpdateAliasesResponse> updateAliases(
@@ -1655,9 +1447,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Updates index aliases.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<UpdateAliasesResponse> updateAliases() throws IOException, OpensearchException {
@@ -1670,9 +1460,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Allows a user to validate a potentially expensive query without executing it.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ValidateQueryResponse> validateQuery(ValidateQueryRequest request)
@@ -1686,9 +1474,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ValidateQueryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<ValidateQueryResponse> validateQuery(
@@ -1700,9 +1486,7 @@ public class OpensearchIndicesAsyncClient extends ApiClient<OpensearchIndicesAsy
 	/**
 	 * Allows a user to validate a potentially expensive query without executing it.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ValidateQueryResponse> validateQuery() throws IOException, OpensearchException {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/OpensearchIndicesClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/OpensearchIndicesClient.java
@@ -69,9 +69,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Adds a block to an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public AddBlockResponse addBlock(AddBlockRequest request) throws IOException, OpensearchException {
@@ -84,9 +82,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link AddBlockRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final AddBlockResponse addBlock(Function<AddBlockRequest.Builder, ObjectBuilder<AddBlockRequest>> fn)
@@ -100,9 +96,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * Performs the analysis process on a text and return the tokens breakdown of
 	 * the text.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public AnalyzeResponse analyze(AnalyzeRequest request) throws IOException, OpensearchException {
@@ -116,9 +110,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link AnalyzeRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final AnalyzeResponse analyze(Function<AnalyzeRequest.Builder, ObjectBuilder<AnalyzeRequest>> fn)
@@ -130,9 +122,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * Performs the analysis process on a text and return the tokens breakdown of
 	 * the text.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public AnalyzeResponse analyze() throws IOException, OpensearchException {
@@ -145,9 +135,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Clears all or specific caches for one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ClearCacheResponse clearCache(ClearCacheRequest request) throws IOException, OpensearchException {
@@ -160,9 +148,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ClearCacheRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final ClearCacheResponse clearCache(Function<ClearCacheRequest.Builder, ObjectBuilder<ClearCacheRequest>> fn)
@@ -173,9 +159,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Clears all or specific caches for one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ClearCacheResponse clearCache() throws IOException, OpensearchException {
@@ -188,9 +172,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Clones an index
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CloneIndexResponse clone(CloneIndexRequest request) throws IOException, OpensearchException {
@@ -203,9 +185,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CloneIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CloneIndexResponse clone(Function<CloneIndexRequest.Builder, ObjectBuilder<CloneIndexRequest>> fn)
@@ -218,9 +198,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Closes an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CloseIndexResponse close(CloseIndexRequest request) throws IOException, OpensearchException {
@@ -233,9 +211,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CloseIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CloseIndexResponse close(Function<CloseIndexRequest.Builder, ObjectBuilder<CloseIndexRequest>> fn)
@@ -248,9 +224,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Creates an index with optional settings and mappings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CreateIndexResponse create(CreateIndexRequest request) throws IOException, OpensearchException {
@@ -263,9 +237,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CreateIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CreateIndexResponse create(Function<CreateIndexRequest.Builder, ObjectBuilder<CreateIndexRequest>> fn)
@@ -278,9 +250,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Deletes an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public DeleteIndexResponse delete(DeleteIndexRequest request) throws IOException, OpensearchException {
@@ -293,9 +263,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final DeleteIndexResponse delete(Function<DeleteIndexRequest.Builder, ObjectBuilder<DeleteIndexRequest>> fn)
@@ -308,9 +276,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Deletes an alias.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public DeleteAliasResponse deleteAlias(DeleteAliasRequest request) throws IOException, OpensearchException {
@@ -323,9 +289,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteAliasRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final DeleteAliasResponse deleteAlias(
@@ -339,9 +303,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Deletes an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public DeleteIndexTemplateResponse deleteIndexTemplate(DeleteIndexTemplateRequest request)
@@ -355,9 +317,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteIndexTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final DeleteIndexTemplateResponse deleteIndexTemplate(
@@ -371,9 +331,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Deletes an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public DeleteTemplateResponse deleteTemplate(DeleteTemplateRequest request)
@@ -387,9 +345,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final DeleteTemplateResponse deleteTemplate(
@@ -403,9 +359,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Analyzes the disk usage of each field of an index or data stream
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-disk-usage.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public DiskUsageResponse diskUsage(DiskUsageRequest request) throws IOException, OpensearchException {
@@ -418,9 +372,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DiskUsageRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-disk-usage.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final DiskUsageResponse diskUsage(Function<DiskUsageRequest.Builder, ObjectBuilder<DiskUsageRequest>> fn)
@@ -433,9 +385,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns information about whether a particular index exists.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public BooleanResponse exists(ExistsRequest request) throws IOException, OpensearchException {
@@ -448,9 +398,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ExistsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final BooleanResponse exists(Function<ExistsRequest.Builder, ObjectBuilder<ExistsRequest>> fn)
@@ -463,9 +411,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns information about whether a particular alias exists.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public BooleanResponse existsAlias(ExistsAliasRequest request) throws IOException, OpensearchException {
@@ -478,9 +424,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ExistsAliasRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final BooleanResponse existsAlias(Function<ExistsAliasRequest.Builder, ObjectBuilder<ExistsAliasRequest>> fn)
@@ -493,9 +437,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns information about whether a particular index template exists.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public BooleanResponse existsIndexTemplate(ExistsIndexTemplateRequest request)
@@ -509,9 +451,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ExistsIndexTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final BooleanResponse existsIndexTemplate(
@@ -525,9 +465,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns information about whether a particular index template exists.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public BooleanResponse existsTemplate(ExistsTemplateRequest request) throws IOException, OpensearchException {
@@ -540,9 +478,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ExistsTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final BooleanResponse existsTemplate(
@@ -557,9 +493,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * Returns information about whether a particular document type exists.
 	 * (DEPRECATED)
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public BooleanResponse existsType(ExistsTypeRequest request) throws IOException, OpensearchException {
@@ -573,9 +507,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ExistsTypeRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final BooleanResponse existsType(Function<ExistsTypeRequest.Builder, ObjectBuilder<ExistsTypeRequest>> fn)
@@ -588,9 +520,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Performs the flush operation on one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public FlushResponse flush(FlushRequest request) throws IOException, OpensearchException {
@@ -603,9 +533,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link FlushRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final FlushResponse flush(Function<FlushRequest.Builder, ObjectBuilder<FlushRequest>> fn)
@@ -616,9 +544,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Performs the flush operation on one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public FlushResponse flush() throws IOException, OpensearchException {
@@ -631,9 +557,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Performs the force merge operation on one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ForcemergeResponse forcemerge(ForcemergeRequest request) throws IOException, OpensearchException {
@@ -646,9 +570,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ForcemergeRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final ForcemergeResponse forcemerge(Function<ForcemergeRequest.Builder, ObjectBuilder<ForcemergeRequest>> fn)
@@ -659,9 +581,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Performs the force merge operation on one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ForcemergeResponse forcemerge() throws IOException, OpensearchException {
@@ -674,9 +594,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns information about one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetIndexResponse get(GetIndexRequest request) throws IOException, OpensearchException {
@@ -689,9 +607,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetIndexResponse get(Function<GetIndexRequest.Builder, ObjectBuilder<GetIndexRequest>> fn)
@@ -704,9 +620,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns an alias.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetAliasResponse getAlias(GetAliasRequest request) throws IOException, OpensearchException {
@@ -719,9 +633,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetAliasRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetAliasResponse getAlias(Function<GetAliasRequest.Builder, ObjectBuilder<GetAliasRequest>> fn)
@@ -732,9 +644,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns an alias.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetAliasResponse getAlias() throws IOException, OpensearchException {
@@ -747,9 +657,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns mapping for one or more fields.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetFieldMappingResponse getFieldMapping(GetFieldMappingRequest request)
@@ -763,9 +671,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetFieldMappingRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetFieldMappingResponse getFieldMapping(
@@ -779,9 +685,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetIndexTemplateResponse getIndexTemplate(GetIndexTemplateRequest request)
@@ -795,9 +699,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetIndexTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetIndexTemplateResponse getIndexTemplate(
@@ -809,9 +711,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetIndexTemplateResponse getIndexTemplate() throws IOException, OpensearchException {
@@ -824,9 +724,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns mappings for one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetMappingResponse getMapping(GetMappingRequest request) throws IOException, OpensearchException {
@@ -839,9 +737,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetMappingRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetMappingResponse getMapping(Function<GetMappingRequest.Builder, ObjectBuilder<GetMappingRequest>> fn)
@@ -852,9 +748,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns mappings for one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetMappingResponse getMapping() throws IOException, OpensearchException {
@@ -867,9 +761,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns settings for one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetSettingsResponse getSettings(GetSettingsRequest request) throws IOException, OpensearchException {
@@ -882,9 +774,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetSettingsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetSettingsResponse getSettings(
@@ -896,9 +786,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns settings for one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetSettingsResponse getSettings() throws IOException, OpensearchException {
@@ -911,9 +799,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetTemplateResponse getTemplate(GetTemplateRequest request) throws IOException, OpensearchException {
@@ -926,9 +812,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetTemplateResponse getTemplate(
@@ -940,9 +824,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetTemplateResponse getTemplate() throws IOException, OpensearchException {
@@ -955,9 +837,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Opens an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public OpenResponse open(OpenRequest request) throws IOException, OpensearchException {
@@ -970,9 +850,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link OpenRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final OpenResponse open(Function<OpenRequest.Builder, ObjectBuilder<OpenRequest>> fn)
@@ -985,9 +863,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Creates or updates an alias.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public PutAliasResponse putAlias(PutAliasRequest request) throws IOException, OpensearchException {
@@ -1000,9 +876,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutAliasRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final PutAliasResponse putAlias(Function<PutAliasRequest.Builder, ObjectBuilder<PutAliasRequest>> fn)
@@ -1015,9 +889,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Creates or updates an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public PutIndexTemplateResponse putIndexTemplate(PutIndexTemplateRequest request)
@@ -1031,9 +903,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutIndexTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final PutIndexTemplateResponse putIndexTemplate(
@@ -1047,9 +917,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Updates the index mappings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public PutMappingResponse putMapping(PutMappingRequest request) throws IOException, OpensearchException {
@@ -1062,9 +930,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutMappingRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final PutMappingResponse putMapping(Function<PutMappingRequest.Builder, ObjectBuilder<PutMappingRequest>> fn)
@@ -1077,9 +943,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Updates the index settings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public PutSettingsResponse putSettings(PutSettingsRequest request) throws IOException, OpensearchException {
@@ -1092,9 +956,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutSettingsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final PutSettingsResponse putSettings(
@@ -1106,9 +968,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Updates the index settings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public PutSettingsResponse putSettings() throws IOException, OpensearchException {
@@ -1121,9 +981,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Creates or updates an index template.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public PutTemplateResponse putTemplate(PutTemplateRequest request) throws IOException, OpensearchException {
@@ -1136,9 +994,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final PutTemplateResponse putTemplate(
@@ -1152,9 +1008,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns information about ongoing index shard recoveries.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public RecoveryResponse recovery(RecoveryRequest request) throws IOException, OpensearchException {
@@ -1167,9 +1021,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link RecoveryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final RecoveryResponse recovery(Function<RecoveryRequest.Builder, ObjectBuilder<RecoveryRequest>> fn)
@@ -1180,9 +1032,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns information about ongoing index shard recoveries.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public RecoveryResponse recovery() throws IOException, OpensearchException {
@@ -1195,9 +1045,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Performs the refresh operation in one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public RefreshResponse refresh(RefreshRequest request) throws IOException, OpensearchException {
@@ -1210,9 +1058,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link RefreshRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final RefreshResponse refresh(Function<RefreshRequest.Builder, ObjectBuilder<RefreshRequest>> fn)
@@ -1223,9 +1069,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Performs the refresh operation in one or more indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public RefreshResponse refresh() throws IOException, OpensearchException {
@@ -1238,9 +1082,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Returns information about any matching indices, aliases, and data streams
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ResolveIndexResponse resolveIndex(ResolveIndexRequest request) throws IOException, OpensearchException {
@@ -1253,9 +1095,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ResolveIndexRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final ResolveIndexResponse resolveIndex(
@@ -1270,9 +1110,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * Updates an alias to point to a new index when the existing index is
 	 * considered to be too large or too old.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public RolloverResponse rollover(RolloverRequest request) throws IOException, OpensearchException {
@@ -1286,9 +1124,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link RolloverRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final RolloverResponse rollover(Function<RolloverRequest.Builder, ObjectBuilder<RolloverRequest>> fn)
@@ -1301,9 +1137,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Provides low-level information about segments in a Lucene index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public SegmentsResponse segments(SegmentsRequest request) throws IOException, OpensearchException {
@@ -1316,9 +1150,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SegmentsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final SegmentsResponse segments(Function<SegmentsRequest.Builder, ObjectBuilder<SegmentsRequest>> fn)
@@ -1329,9 +1161,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Provides low-level information about segments in a Lucene index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public SegmentsResponse segments() throws IOException, OpensearchException {
@@ -1344,9 +1174,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Provides store information for shard copies of indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ShardStoresResponse shardStores(ShardStoresRequest request) throws IOException, OpensearchException {
@@ -1359,9 +1187,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ShardStoresRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final ShardStoresResponse shardStores(
@@ -1373,9 +1199,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Provides store information for shard copies of indices.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ShardStoresResponse shardStores() throws IOException, OpensearchException {
@@ -1388,9 +1212,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Allow to shrink an existing index into a new index with fewer primary shards.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ShrinkResponse shrink(ShrinkRequest request) throws IOException, OpensearchException {
@@ -1403,9 +1225,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ShrinkRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final ShrinkResponse shrink(Function<ShrinkRequest.Builder, ObjectBuilder<ShrinkRequest>> fn)
@@ -1419,9 +1239,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * Simulate matching the given index name against the index templates in the
 	 * system
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public SimulateIndexTemplateResponse simulateIndexTemplate(SimulateIndexTemplateRequest request)
@@ -1436,9 +1254,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SimulateIndexTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final SimulateIndexTemplateResponse simulateIndexTemplate(
@@ -1452,9 +1268,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Simulate resolving the given template name or body
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public SimulateTemplateResponse simulateTemplate(SimulateTemplateRequest request)
@@ -1468,9 +1282,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SimulateTemplateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final SimulateTemplateResponse simulateTemplate(
@@ -1482,9 +1294,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Simulate resolving the given template name or body
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public SimulateTemplateResponse simulateTemplate() throws IOException, OpensearchException {
@@ -1498,9 +1308,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * Allows you to split an existing index into a new index with more primary
 	 * shards.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public SplitResponse split(SplitRequest request) throws IOException, OpensearchException {
@@ -1514,9 +1322,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SplitRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final SplitResponse split(Function<SplitRequest.Builder, ObjectBuilder<SplitRequest>> fn)
@@ -1529,9 +1335,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Provides statistics on operations happening in an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public IndicesStatsResponse stats(IndicesStatsRequest request) throws IOException, OpensearchException {
@@ -1544,9 +1348,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link IndicesStatsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final IndicesStatsResponse stats(
@@ -1558,9 +1360,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Provides statistics on operations happening in an index.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public IndicesStatsResponse stats() throws IOException, OpensearchException {
@@ -1573,9 +1373,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Updates index aliases.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public UpdateAliasesResponse updateAliases(UpdateAliasesRequest request)
@@ -1589,9 +1387,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link UpdateAliasesRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final UpdateAliasesResponse updateAliases(
@@ -1603,9 +1399,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Updates index aliases.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public UpdateAliasesResponse updateAliases() throws IOException, OpensearchException {
@@ -1618,9 +1412,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Allows a user to validate a potentially expensive query without executing it.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ValidateQueryResponse validateQuery(ValidateQueryRequest request)
@@ -1634,9 +1426,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ValidateQueryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final ValidateQueryResponse validateQuery(
@@ -1648,9 +1438,7 @@ public class OpensearchIndicesClient extends ApiClient<OpensearchIndicesClient> 
 	/**
 	 * Allows a user to validate a potentially expensive query without executing it.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ValidateQueryResponse validateQuery() throws IOException, OpensearchException {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/ingest/OpensearchIngestAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/ingest/OpensearchIngestAsyncClient.java
@@ -68,9 +68,7 @@ public class OpensearchIngestAsyncClient extends ApiClient<OpensearchIngestAsync
 	/**
 	 * Deletes a pipeline.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<DeletePipelineResponse> deletePipeline(DeletePipelineRequest request)
@@ -84,9 +82,7 @@ public class OpensearchIngestAsyncClient extends ApiClient<OpensearchIngestAsync
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeletePipelineRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<DeletePipelineResponse> deletePipeline(
@@ -100,9 +96,7 @@ public class OpensearchIngestAsyncClient extends ApiClient<OpensearchIngestAsync
 	/**
 	 * Returns statistical information about geoip databases
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-stats-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 	public CompletableFuture<GeoIpStatsResponse> geoIpStats() throws IOException, OpensearchException {
 		return this.transport.performRequestAsync(GeoIpStatsRequest._INSTANCE, GeoIpStatsRequest.ENDPOINT,
@@ -114,9 +108,7 @@ public class OpensearchIngestAsyncClient extends ApiClient<OpensearchIngestAsync
 	/**
 	 * Returns a pipeline.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetPipelineResponse> getPipeline(GetPipelineRequest request)
@@ -130,9 +122,7 @@ public class OpensearchIngestAsyncClient extends ApiClient<OpensearchIngestAsync
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetPipelineRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<GetPipelineResponse> getPipeline(
@@ -144,9 +134,7 @@ public class OpensearchIngestAsyncClient extends ApiClient<OpensearchIngestAsync
 	/**
 	 * Returns a pipeline.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetPipelineResponse> getPipeline() throws IOException, OpensearchException {
@@ -159,9 +147,7 @@ public class OpensearchIngestAsyncClient extends ApiClient<OpensearchIngestAsync
 	/**
 	 * Returns a list of the built-in patterns.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 	public CompletableFuture<ProcessorGrokResponse> processorGrok() throws IOException, OpensearchException {
 		return this.transport.performRequestAsync(ProcessorGrokRequest._INSTANCE, ProcessorGrokRequest.ENDPOINT,
@@ -173,9 +159,7 @@ public class OpensearchIngestAsyncClient extends ApiClient<OpensearchIngestAsync
 	/**
 	 * Creates or updates a pipeline.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<PutPipelineResponse> putPipeline(PutPipelineRequest request)
@@ -189,9 +173,7 @@ public class OpensearchIngestAsyncClient extends ApiClient<OpensearchIngestAsync
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutPipelineRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<PutPipelineResponse> putPipeline(
@@ -205,9 +187,7 @@ public class OpensearchIngestAsyncClient extends ApiClient<OpensearchIngestAsync
 	/**
 	 * Allows to simulate a pipeline with example documents.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<SimulateResponse> simulate(SimulateRequest request)
@@ -221,9 +201,7 @@ public class OpensearchIngestAsyncClient extends ApiClient<OpensearchIngestAsync
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SimulateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<SimulateResponse> simulate(
@@ -235,9 +213,7 @@ public class OpensearchIngestAsyncClient extends ApiClient<OpensearchIngestAsync
 	/**
 	 * Allows to simulate a pipeline with example documents.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<SimulateResponse> simulate() throws IOException, OpensearchException {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/ingest/OpensearchIngestClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/ingest/OpensearchIngestClient.java
@@ -67,9 +67,7 @@ public class OpensearchIngestClient extends ApiClient<OpensearchIngestClient> {
 	/**
 	 * Deletes a pipeline.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public DeletePipelineResponse deletePipeline(DeletePipelineRequest request)
@@ -83,9 +81,7 @@ public class OpensearchIngestClient extends ApiClient<OpensearchIngestClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeletePipelineRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final DeletePipelineResponse deletePipeline(
@@ -99,9 +95,7 @@ public class OpensearchIngestClient extends ApiClient<OpensearchIngestClient> {
 	/**
 	 * Returns statistical information about geoip databases
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-stats-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 	public GeoIpStatsResponse geoIpStats() throws IOException, OpensearchException {
 		return this.transport.performRequest(GeoIpStatsRequest._INSTANCE, GeoIpStatsRequest.ENDPOINT,
@@ -113,9 +107,7 @@ public class OpensearchIngestClient extends ApiClient<OpensearchIngestClient> {
 	/**
 	 * Returns a pipeline.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetPipelineResponse getPipeline(GetPipelineRequest request) throws IOException, OpensearchException {
@@ -128,9 +120,7 @@ public class OpensearchIngestClient extends ApiClient<OpensearchIngestClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetPipelineRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetPipelineResponse getPipeline(
@@ -142,9 +132,7 @@ public class OpensearchIngestClient extends ApiClient<OpensearchIngestClient> {
 	/**
 	 * Returns a pipeline.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetPipelineResponse getPipeline() throws IOException, OpensearchException {
@@ -157,9 +145,7 @@ public class OpensearchIngestClient extends ApiClient<OpensearchIngestClient> {
 	/**
 	 * Returns a list of the built-in patterns.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 	public ProcessorGrokResponse processorGrok() throws IOException, OpensearchException {
 		return this.transport.performRequest(ProcessorGrokRequest._INSTANCE, ProcessorGrokRequest.ENDPOINT,
@@ -171,9 +157,7 @@ public class OpensearchIngestClient extends ApiClient<OpensearchIngestClient> {
 	/**
 	 * Creates or updates a pipeline.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public PutPipelineResponse putPipeline(PutPipelineRequest request) throws IOException, OpensearchException {
@@ -186,9 +170,7 @@ public class OpensearchIngestClient extends ApiClient<OpensearchIngestClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutPipelineRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final PutPipelineResponse putPipeline(
@@ -202,9 +184,7 @@ public class OpensearchIngestClient extends ApiClient<OpensearchIngestClient> {
 	/**
 	 * Allows to simulate a pipeline with example documents.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public SimulateResponse simulate(SimulateRequest request) throws IOException, OpensearchException {
@@ -217,9 +197,7 @@ public class OpensearchIngestClient extends ApiClient<OpensearchIngestClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link SimulateRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final SimulateResponse simulate(Function<SimulateRequest.Builder, ObjectBuilder<SimulateRequest>> fn)
@@ -230,9 +208,7 @@ public class OpensearchIngestClient extends ApiClient<OpensearchIngestClient> {
 	/**
 	 * Allows to simulate a pipeline with example documents.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public SimulateResponse simulate() throws IOException, OpensearchException {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/nodes/OpensearchNodesAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/nodes/OpensearchNodesAsyncClient.java
@@ -69,9 +69,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	/**
 	 * Returns information about hot threads on each node in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<HotThreadsResponse> hotThreads(HotThreadsRequest request)
@@ -85,9 +83,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link HotThreadsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<HotThreadsResponse> hotThreads(
@@ -99,9 +95,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	/**
 	 * Returns information about hot threads on each node in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<HotThreadsResponse> hotThreads() throws IOException, OpensearchException {
@@ -114,9 +108,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	/**
 	 * Returns information about nodes in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<NodesInfoResponse> info(NodesInfoRequest request)
@@ -130,9 +122,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link NodesInfoRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<NodesInfoResponse> info(
@@ -144,9 +134,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	/**
 	 * Returns information about nodes in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<NodesInfoResponse> info() throws IOException, OpensearchException {
@@ -159,9 +147,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	/**
 	 * Reloads secure settings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ReloadSecureSettingsResponse> reloadSecureSettings(ReloadSecureSettingsRequest request)
@@ -175,9 +161,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ReloadSecureSettingsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<ReloadSecureSettingsResponse> reloadSecureSettings(
@@ -189,9 +173,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	/**
 	 * Reloads secure settings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ReloadSecureSettingsResponse> reloadSecureSettings()
@@ -205,9 +187,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	/**
 	 * Returns statistical information about nodes in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<NodesStatsResponse> stats(NodesStatsRequest request)
@@ -221,9 +201,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link NodesStatsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<NodesStatsResponse> stats(
@@ -235,9 +213,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	/**
 	 * Returns statistical information about nodes in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<NodesStatsResponse> stats() throws IOException, OpensearchException {
@@ -250,9 +226,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	/**
 	 * Returns low-level information about REST actions usage on nodes.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<UsageResponse> usage(UsageRequest request) throws IOException, OpensearchException {
@@ -265,9 +239,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link UsageRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<UsageResponse> usage(Function<UsageRequest.Builder, ObjectBuilder<UsageRequest>> fn)
@@ -278,9 +250,7 @@ public class OpensearchNodesAsyncClient extends ApiClient<OpensearchNodesAsyncCl
 	/**
 	 * Returns low-level information about REST actions usage on nodes.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<UsageResponse> usage() throws IOException, OpensearchException {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/nodes/OpensearchNodesClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/nodes/OpensearchNodesClient.java
@@ -68,9 +68,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	/**
 	 * Returns information about hot threads on each node in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public HotThreadsResponse hotThreads(HotThreadsRequest request) throws IOException, OpensearchException {
@@ -83,9 +81,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link HotThreadsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final HotThreadsResponse hotThreads(Function<HotThreadsRequest.Builder, ObjectBuilder<HotThreadsRequest>> fn)
@@ -96,9 +92,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	/**
 	 * Returns information about hot threads on each node in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public HotThreadsResponse hotThreads() throws IOException, OpensearchException {
@@ -111,9 +105,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	/**
 	 * Returns information about nodes in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public NodesInfoResponse info(NodesInfoRequest request) throws IOException, OpensearchException {
@@ -126,9 +118,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link NodesInfoRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final NodesInfoResponse info(Function<NodesInfoRequest.Builder, ObjectBuilder<NodesInfoRequest>> fn)
@@ -139,9 +129,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	/**
 	 * Returns information about nodes in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public NodesInfoResponse info() throws IOException, OpensearchException {
@@ -154,9 +142,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	/**
 	 * Reloads secure settings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ReloadSecureSettingsResponse reloadSecureSettings(ReloadSecureSettingsRequest request)
@@ -170,9 +156,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ReloadSecureSettingsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final ReloadSecureSettingsResponse reloadSecureSettings(
@@ -184,9 +168,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	/**
 	 * Reloads secure settings.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ReloadSecureSettingsResponse reloadSecureSettings() throws IOException, OpensearchException {
@@ -199,9 +181,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	/**
 	 * Returns statistical information about nodes in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public NodesStatsResponse stats(NodesStatsRequest request) throws IOException, OpensearchException {
@@ -214,9 +194,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link NodesStatsRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final NodesStatsResponse stats(Function<NodesStatsRequest.Builder, ObjectBuilder<NodesStatsRequest>> fn)
@@ -227,9 +205,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	/**
 	 * Returns statistical information about nodes in the cluster.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public NodesStatsResponse stats() throws IOException, OpensearchException {
@@ -242,9 +218,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	/**
 	 * Returns low-level information about REST actions usage on nodes.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public UsageResponse usage(UsageRequest request) throws IOException, OpensearchException {
@@ -257,9 +231,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link UsageRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final UsageResponse usage(Function<UsageRequest.Builder, ObjectBuilder<UsageRequest>> fn)
@@ -270,9 +242,7 @@ public class OpensearchNodesClient extends ApiClient<OpensearchNodesClient> {
 	/**
 	 * Returns low-level information about REST actions usage on nodes.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public UsageResponse usage() throws IOException, OpensearchException {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/shutdown/OpensearchShutdownAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/shutdown/OpensearchShutdownAsyncClient.java
@@ -70,9 +70,7 @@ public class OpensearchShutdownAsyncClient extends ApiClient<OpensearchShutdownA
 	 * Removes a node from the shutdown list. Designed for indirect use by ECE/ESS
 	 * and ECK. Direct use is not supported.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<DeleteNodeResponse> deleteNode(DeleteNodeRequest request)
@@ -87,9 +85,7 @@ public class OpensearchShutdownAsyncClient extends ApiClient<OpensearchShutdownA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteNodeRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<DeleteNodeResponse> deleteNode(
@@ -105,9 +101,7 @@ public class OpensearchShutdownAsyncClient extends ApiClient<OpensearchShutdownA
 	 * down. Designed for indirect use by ECE/ESS and ECK. Direct use is not
 	 * supported.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetNodeResponse> getNode(GetNodeRequest request)
@@ -123,9 +117,7 @@ public class OpensearchShutdownAsyncClient extends ApiClient<OpensearchShutdownA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetNodeRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<GetNodeResponse> getNode(
@@ -139,9 +131,7 @@ public class OpensearchShutdownAsyncClient extends ApiClient<OpensearchShutdownA
 	 * down. Designed for indirect use by ECE/ESS and ECK. Direct use is not
 	 * supported.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetNodeResponse> getNode() throws IOException, OpensearchException {
@@ -155,9 +145,7 @@ public class OpensearchShutdownAsyncClient extends ApiClient<OpensearchShutdownA
 	 * Adds a node to be shut down. Designed for indirect use by ECE/ESS and ECK.
 	 * Direct use is not supported.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<PutNodeResponse> putNode(PutNodeRequest request)
@@ -172,9 +160,7 @@ public class OpensearchShutdownAsyncClient extends ApiClient<OpensearchShutdownA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutNodeRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<PutNodeResponse> putNode(

--- a/java-client/src/main/java/org/opensearch/client/opensearch/shutdown/OpensearchShutdownClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/shutdown/OpensearchShutdownClient.java
@@ -69,9 +69,7 @@ public class OpensearchShutdownClient extends ApiClient<OpensearchShutdownClient
 	 * Removes a node from the shutdown list. Designed for indirect use by ECE/ESS
 	 * and ECK. Direct use is not supported.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public DeleteNodeResponse deleteNode(DeleteNodeRequest request) throws IOException, OpensearchException {
@@ -85,9 +83,7 @@ public class OpensearchShutdownClient extends ApiClient<OpensearchShutdownClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteNodeRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final DeleteNodeResponse deleteNode(Function<DeleteNodeRequest.Builder, ObjectBuilder<DeleteNodeRequest>> fn)
@@ -102,9 +98,7 @@ public class OpensearchShutdownClient extends ApiClient<OpensearchShutdownClient
 	 * down. Designed for indirect use by ECE/ESS and ECK. Direct use is not
 	 * supported.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetNodeResponse getNode(GetNodeRequest request) throws IOException, OpensearchException {
@@ -119,9 +113,7 @@ public class OpensearchShutdownClient extends ApiClient<OpensearchShutdownClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetNodeRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetNodeResponse getNode(Function<GetNodeRequest.Builder, ObjectBuilder<GetNodeRequest>> fn)
@@ -134,9 +126,7 @@ public class OpensearchShutdownClient extends ApiClient<OpensearchShutdownClient
 	 * down. Designed for indirect use by ECE/ESS and ECK. Direct use is not
 	 * supported.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetNodeResponse getNode() throws IOException, OpensearchException {
@@ -150,9 +140,7 @@ public class OpensearchShutdownClient extends ApiClient<OpensearchShutdownClient
 	 * Adds a node to be shut down. Designed for indirect use by ECE/ESS and ECK.
 	 * Direct use is not supported.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public PutNodeResponse putNode(PutNodeRequest request) throws IOException, OpensearchException {
@@ -166,9 +154,7 @@ public class OpensearchShutdownClient extends ApiClient<OpensearchShutdownClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link PutNodeRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/current">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final PutNodeResponse putNode(Function<PutNodeRequest.Builder, ObjectBuilder<PutNodeRequest>> fn)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/OpensearchSnapshotAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/OpensearchSnapshotAsyncClient.java
@@ -69,9 +69,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	/**
 	 * Removes stale data from repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<CleanupRepositoryResponse> cleanupRepository(CleanupRepositoryRequest request)
@@ -85,9 +83,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CleanupRepositoryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<CleanupRepositoryResponse> cleanupRepository(
@@ -102,9 +98,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	 * Clones indices from one snapshot into another snapshot in the same
 	 * repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<CloneSnapshotResponse> clone(CloneSnapshotRequest request)
@@ -119,9 +113,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CloneSnapshotRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<CloneSnapshotResponse> clone(
@@ -135,9 +127,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	/**
 	 * Creates a snapshot in a repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<CreateSnapshotResponse> create(CreateSnapshotRequest request)
@@ -151,9 +141,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CreateSnapshotRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<CreateSnapshotResponse> create(
@@ -167,9 +155,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	/**
 	 * Creates a repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<CreateRepositoryResponse> createRepository(CreateRepositoryRequest request)
@@ -183,9 +169,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CreateRepositoryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<CreateRepositoryResponse> createRepository(
@@ -199,9 +183,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	/**
 	 * Deletes one or more snapshots.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<DeleteSnapshotResponse> delete(DeleteSnapshotRequest request)
@@ -215,9 +197,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteSnapshotRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<DeleteSnapshotResponse> delete(
@@ -231,9 +211,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	/**
 	 * Deletes a repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<DeleteRepositoryResponse> deleteRepository(DeleteRepositoryRequest request)
@@ -247,9 +225,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteRepositoryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<DeleteRepositoryResponse> deleteRepository(
@@ -263,9 +239,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	/**
 	 * Returns information about a snapshot.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetSnapshotResponse> get(GetSnapshotRequest request)
@@ -279,9 +253,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetSnapshotRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<GetSnapshotResponse> get(
@@ -295,9 +267,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	/**
 	 * Returns information about a repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetRepositoryResponse> getRepository(GetRepositoryRequest request)
@@ -311,9 +281,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetRepositoryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<GetRepositoryResponse> getRepository(
@@ -325,9 +293,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	/**
 	 * Returns information about a repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetRepositoryResponse> getRepository() throws IOException, OpensearchException {
@@ -340,9 +306,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	/**
 	 * Restores a snapshot.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<RestoreResponse> restore(RestoreRequest request)
@@ -356,9 +320,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link RestoreRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<RestoreResponse> restore(
@@ -372,9 +334,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	/**
 	 * Returns information about the status of a snapshot.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<StatusResponse> status(StatusRequest request) throws IOException, OpensearchException {
@@ -387,9 +347,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link StatusRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<StatusResponse> status(
@@ -401,9 +359,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	/**
 	 * Returns information about the status of a snapshot.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<StatusResponse> status() throws IOException, OpensearchException {
@@ -416,9 +372,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	/**
 	 * Verifies a repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<VerifyRepositoryResponse> verifyRepository(VerifyRepositoryRequest request)
@@ -432,9 +386,7 @@ public class OpensearchSnapshotAsyncClient extends ApiClient<OpensearchSnapshotA
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link VerifyRepositoryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<VerifyRepositoryResponse> verifyRepository(

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/OpensearchSnapshotClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/OpensearchSnapshotClient.java
@@ -68,9 +68,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	/**
 	 * Removes stale data from repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CleanupRepositoryResponse cleanupRepository(CleanupRepositoryRequest request)
@@ -84,9 +82,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CleanupRepositoryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CleanupRepositoryResponse cleanupRepository(
@@ -101,9 +97,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	 * Clones indices from one snapshot into another snapshot in the same
 	 * repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CloneSnapshotResponse clone(CloneSnapshotRequest request) throws IOException, OpensearchException {
@@ -117,9 +111,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CloneSnapshotRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CloneSnapshotResponse clone(
@@ -133,9 +125,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	/**
 	 * Creates a snapshot in a repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CreateSnapshotResponse create(CreateSnapshotRequest request) throws IOException, OpensearchException {
@@ -148,9 +138,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CreateSnapshotRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CreateSnapshotResponse create(
@@ -164,9 +152,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	/**
 	 * Creates a repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CreateRepositoryResponse createRepository(CreateRepositoryRequest request)
@@ -180,9 +166,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CreateRepositoryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CreateRepositoryResponse createRepository(
@@ -196,9 +180,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	/**
 	 * Deletes one or more snapshots.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public DeleteSnapshotResponse delete(DeleteSnapshotRequest request) throws IOException, OpensearchException {
@@ -211,9 +193,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteSnapshotRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final DeleteSnapshotResponse delete(
@@ -227,9 +207,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	/**
 	 * Deletes a repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public DeleteRepositoryResponse deleteRepository(DeleteRepositoryRequest request)
@@ -243,9 +221,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link DeleteRepositoryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final DeleteRepositoryResponse deleteRepository(
@@ -259,9 +235,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	/**
 	 * Returns information about a snapshot.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetSnapshotResponse get(GetSnapshotRequest request) throws IOException, OpensearchException {
@@ -274,9 +248,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetSnapshotRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetSnapshotResponse get(Function<GetSnapshotRequest.Builder, ObjectBuilder<GetSnapshotRequest>> fn)
@@ -289,9 +261,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	/**
 	 * Returns information about a repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetRepositoryResponse getRepository(GetRepositoryRequest request)
@@ -305,9 +275,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetRepositoryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetRepositoryResponse getRepository(
@@ -319,9 +287,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	/**
 	 * Returns information about a repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetRepositoryResponse getRepository() throws IOException, OpensearchException {
@@ -334,9 +300,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	/**
 	 * Restores a snapshot.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public RestoreResponse restore(RestoreRequest request) throws IOException, OpensearchException {
@@ -349,9 +313,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link RestoreRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final RestoreResponse restore(Function<RestoreRequest.Builder, ObjectBuilder<RestoreRequest>> fn)
@@ -364,9 +326,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	/**
 	 * Returns information about the status of a snapshot.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public StatusResponse status(StatusRequest request) throws IOException, OpensearchException {
@@ -379,9 +339,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link StatusRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final StatusResponse status(Function<StatusRequest.Builder, ObjectBuilder<StatusRequest>> fn)
@@ -392,9 +350,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	/**
 	 * Returns information about the status of a snapshot.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public StatusResponse status() throws IOException, OpensearchException {
@@ -407,9 +363,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	/**
 	 * Verifies a repository.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public VerifyRepositoryResponse verifyRepository(VerifyRepositoryRequest request)
@@ -423,9 +377,7 @@ public class OpensearchSnapshotClient extends ApiClient<OpensearchSnapshotClient
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link VerifyRepositoryRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final VerifyRepositoryResponse verifyRepository(

--- a/java-client/src/main/java/org/opensearch/client/opensearch/tasks/OpensearchTasksAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/tasks/OpensearchTasksAsyncClient.java
@@ -69,9 +69,7 @@ public class OpensearchTasksAsyncClient extends ApiClient<OpensearchTasksAsyncCl
 	/**
 	 * Cancels a task, if it can be cancelled through an API.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<CancelResponse> cancel(CancelRequest request) throws IOException, OpensearchException {
@@ -84,9 +82,7 @@ public class OpensearchTasksAsyncClient extends ApiClient<OpensearchTasksAsyncCl
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CancelRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<CancelResponse> cancel(
@@ -98,9 +94,7 @@ public class OpensearchTasksAsyncClient extends ApiClient<OpensearchTasksAsyncCl
 	/**
 	 * Cancels a task, if it can be cancelled through an API.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<CancelResponse> cancel() throws IOException, OpensearchException {
@@ -113,9 +107,7 @@ public class OpensearchTasksAsyncClient extends ApiClient<OpensearchTasksAsyncCl
 	/**
 	 * Returns information about a task.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<GetTasksResponse> get(GetTasksRequest request) throws IOException, OpensearchException {
@@ -128,9 +120,7 @@ public class OpensearchTasksAsyncClient extends ApiClient<OpensearchTasksAsyncCl
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetTasksRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<GetTasksResponse> get(
@@ -144,9 +134,7 @@ public class OpensearchTasksAsyncClient extends ApiClient<OpensearchTasksAsyncCl
 	/**
 	 * Returns a list of tasks.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ListResponse> list(ListRequest request) throws IOException, OpensearchException {
@@ -159,9 +147,7 @@ public class OpensearchTasksAsyncClient extends ApiClient<OpensearchTasksAsyncCl
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ListRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CompletableFuture<ListResponse> list(Function<ListRequest.Builder, ObjectBuilder<ListRequest>> fn)
@@ -172,9 +158,7 @@ public class OpensearchTasksAsyncClient extends ApiClient<OpensearchTasksAsyncCl
 	/**
 	 * Returns a list of tasks.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CompletableFuture<ListResponse> list() throws IOException, OpensearchException {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/tasks/OpensearchTasksClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/tasks/OpensearchTasksClient.java
@@ -68,9 +68,7 @@ public class OpensearchTasksClient extends ApiClient<OpensearchTasksClient> {
 	/**
 	 * Cancels a task, if it can be cancelled through an API.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CancelResponse cancel(CancelRequest request) throws IOException, OpensearchException {
@@ -83,9 +81,7 @@ public class OpensearchTasksClient extends ApiClient<OpensearchTasksClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link CancelRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final CancelResponse cancel(Function<CancelRequest.Builder, ObjectBuilder<CancelRequest>> fn)
@@ -96,9 +92,7 @@ public class OpensearchTasksClient extends ApiClient<OpensearchTasksClient> {
 	/**
 	 * Cancels a task, if it can be cancelled through an API.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public CancelResponse cancel() throws IOException, OpensearchException {
@@ -111,9 +105,7 @@ public class OpensearchTasksClient extends ApiClient<OpensearchTasksClient> {
 	/**
 	 * Returns information about a task.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public GetTasksResponse get(GetTasksRequest request) throws IOException, OpensearchException {
@@ -126,9 +118,7 @@ public class OpensearchTasksClient extends ApiClient<OpensearchTasksClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link GetTasksRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final GetTasksResponse get(Function<GetTasksRequest.Builder, ObjectBuilder<GetTasksRequest>> fn)
@@ -141,9 +131,7 @@ public class OpensearchTasksClient extends ApiClient<OpensearchTasksClient> {
 	/**
 	 * Returns a list of tasks.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ListResponse list(ListRequest request) throws IOException, OpensearchException {
@@ -156,9 +144,7 @@ public class OpensearchTasksClient extends ApiClient<OpensearchTasksClient> {
 	 * @param fn
 	 *            a function that initializes a builder to create the
 	 *            {@link ListRequest}
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public final ListResponse list(Function<ListRequest.Builder, ObjectBuilder<ListRequest>> fn)
@@ -169,9 +155,7 @@ public class OpensearchTasksClient extends ApiClient<OpensearchTasksClient> {
 	/**
 	 * Returns a list of tasks.
 	 * 
-	 * @see <a href=
-	 *      "https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html">Documentation
-	 *      on elastic.co</a>
+	 * 
 	 */
 
 	public ListResponse list() throws IOException, OpensearchException {


### PR DESCRIPTION
Signed-off-by: Rishab Nahata <rnnahata@amazon.com>

### Description
This PR removes Elasticsearch documentation from repository.
 
### Issues Resolved
#43 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
