### PR TITLE
Update the docker image

### DIFF
--- a/jenkins/stage-maven-release/JenkinsFile
+++ b/jenkins/stage-maven-release/JenkinsFile
@@ -2,7 +2,7 @@ pipeline {
     agent {
             docker {
                 label 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host'
-                image 'opensearchstaging/ci-runner:al2-x64-arm64-jdk14-node10.24.1-cypress6.9.1-20211005'
+                image 'opensearchstaging/ci-runner:al2-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211019'
                 // Unlike freestyle docker, pipeline docker does not login to the container and run commands
                 // It use executes which does not source the docker container internal ENV VAR
                 args '-e JAVA_HOME=/usr/lib/jvm/adoptopenjdk-14-hotspot'


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Update the docker image since old one is not existed. 
Ref: https://hub.docker.com/layers/opensearchstaging/ci-runner/al2-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211019/images/sha256-9e0770fd933f399de9ef0cf5314eb448fe591106ffda4d1df1a9edd503647fca?context=explore
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
