### PR TITLE
Bump Opensearch version to 1.2.2

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -110,7 +110,7 @@ val integrationTest = task<Test>("integrationTest") {
 }
 
 dependencies {
-    val opensearchVersion = "1.2.1"
+    val opensearchVersion = "1.2.2"
     val jacksonVersion = "2.12.5"
 
     // Apache 2.0


### PR DESCRIPTION
Signed-off-by: Rishab Nahata <rnnahata@amazon.com>

### Description
Bump Opensearch version to 1.2.2
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
