### PR TITLE
Replace co.elastic.clients with org.opensearch.client

### DIFF
--- a/java-client/src/main/java/org/opensearch/client/opensearch/OpenSearchAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/OpenSearchAsyncClient.java
@@ -658,7 +658,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpensearchTransport, OpenSe
 		JsonEndpoint<ExplainRequest, ExplainResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<ExplainRequest, ExplainResponse<TDocument>, ErrorResponse>) ExplainRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.explain.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.explain.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
 	}
@@ -744,7 +744,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpensearchTransport, OpenSe
 		JsonEndpoint<GetRequest, GetResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<GetRequest, GetResponse<TDocument>, ErrorResponse>) GetRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.get.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.get.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
 	}
@@ -847,7 +847,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpensearchTransport, OpenSe
 		JsonEndpoint<GetSourceRequest, GetSourceResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<GetSourceRequest, GetSourceResponse<TDocument>, ErrorResponse>) GetSourceRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.get_source.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.get_source.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
 	}
@@ -934,7 +934,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpensearchTransport, OpenSe
 		JsonEndpoint<MgetRequest, MgetResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<MgetRequest, MgetResponse<TDocument>, ErrorResponse>) MgetRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.mget.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.mget.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
 	}
@@ -972,7 +972,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpensearchTransport, OpenSe
 		JsonEndpoint<MsearchRequest, MsearchResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<MsearchRequest, MsearchResponse<TDocument>, ErrorResponse>) MsearchRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.msearch.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.msearch.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
 	}
@@ -1012,7 +1012,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpensearchTransport, OpenSe
 				(JsonEndpoint<MsearchTemplateRequest, MsearchTemplateResponse<TDocument>, ErrorResponse>)
 						MsearchTemplateRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.msearch_template.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.msearch_template.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
 	}
@@ -1368,7 +1368,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpensearchTransport, OpenSe
 				(JsonEndpoint<ScriptsPainlessExecuteRequest, ScriptsPainlessExecuteResponse<TResult>, ErrorResponse>)
 						ScriptsPainlessExecuteRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.scripts_painless_execute.TResult",
+				"org.opensearch.client:Deserializer:_global.scripts_painless_execute.TResult",
 				getDeserializer(tResultClass));
 
 		return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
@@ -1404,7 +1404,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpensearchTransport, OpenSe
 		JsonEndpoint<ScrollRequest, ScrollResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<ScrollRequest, ScrollResponse<TDocument>, ErrorResponse>) ScrollRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.scroll.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.scroll.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
 	}
@@ -1439,7 +1439,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpensearchTransport, OpenSe
 		JsonEndpoint<SearchRequest, SearchResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<SearchRequest, SearchResponse<TDocument>, ErrorResponse>) SearchRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.search.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.search.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
 	}
@@ -1530,7 +1530,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpensearchTransport, OpenSe
 				(JsonEndpoint<SearchTemplateRequest, SearchTemplateResponse<TDocument>, ErrorResponse>)
 						SearchTemplateRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.search_template.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.search_template.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
 	}
@@ -1647,7 +1647,7 @@ public class OpenSearchAsyncClient extends ApiClient<OpensearchTransport, OpenSe
 		JsonEndpoint<UpdateRequest<?, ?>, UpdateResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<UpdateRequest<?, ?>, UpdateResponse<TDocument>, ErrorResponse>) UpdateRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.update.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.update.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
 	}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/OpenSearchClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/OpenSearchClient.java
@@ -651,7 +651,7 @@ public class OpenSearchClient extends ApiClient<OpensearchTransport, OpenSearchC
 		JsonEndpoint<ExplainRequest, ExplainResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<ExplainRequest, ExplainResponse<TDocument>, ErrorResponse>) ExplainRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.explain.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.explain.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequest(request, endpoint, this.transportOptions);
 	}
@@ -739,7 +739,7 @@ public class OpenSearchClient extends ApiClient<OpensearchTransport, OpenSearchC
 		JsonEndpoint<GetRequest, GetResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<GetRequest, GetResponse<TDocument>, ErrorResponse>) GetRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.get.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.get.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequest(request, endpoint, this.transportOptions);
 	}
@@ -839,7 +839,7 @@ public class OpenSearchClient extends ApiClient<OpensearchTransport, OpenSearchC
 				(JsonEndpoint<GetSourceRequest, GetSourceResponse<TDocument>, ErrorResponse>)
 						GetSourceRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.get_source.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.get_source.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequest(request, endpoint, this.transportOptions);
 	}
@@ -925,7 +925,7 @@ public class OpenSearchClient extends ApiClient<OpensearchTransport, OpenSearchC
 		JsonEndpoint<MgetRequest, MgetResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<MgetRequest, MgetResponse<TDocument>, ErrorResponse>) MgetRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.mget.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.mget.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequest(request, endpoint, this.transportOptions);
 	}
@@ -962,7 +962,7 @@ public class OpenSearchClient extends ApiClient<OpensearchTransport, OpenSearchC
 		JsonEndpoint<MsearchRequest, MsearchResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<MsearchRequest, MsearchResponse<TDocument>, ErrorResponse>) MsearchRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.msearch.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.msearch.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequest(request, endpoint, this.transportOptions);
 	}
@@ -1001,7 +1001,7 @@ public class OpenSearchClient extends ApiClient<OpensearchTransport, OpenSearchC
 				(JsonEndpoint<MsearchTemplateRequest, MsearchTemplateResponse<TDocument>, ErrorResponse>)
 						MsearchTemplateRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.msearch_template.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.msearch_template.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequest(request, endpoint, this.transportOptions);
 	}
@@ -1349,7 +1349,7 @@ public class OpenSearchClient extends ApiClient<OpensearchTransport, OpenSearchC
 				(JsonEndpoint<ScriptsPainlessExecuteRequest, ScriptsPainlessExecuteResponse<TResult>, ErrorResponse>)
 						ScriptsPainlessExecuteRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.scripts_painless_execute.TResult",
+				"org.opensearch.client:Deserializer:_global.scripts_painless_execute.TResult",
 				getDeserializer(tResultClass));
 
 		return this.transport.performRequest(request, endpoint, this.transportOptions);
@@ -1385,7 +1385,7 @@ public class OpenSearchClient extends ApiClient<OpensearchTransport, OpenSearchC
 		JsonEndpoint<ScrollRequest, ScrollResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<ScrollRequest, ScrollResponse<TDocument>, ErrorResponse>) ScrollRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.scroll.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.scroll.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequest(request, endpoint, this.transportOptions);
 	}
@@ -1420,7 +1420,7 @@ public class OpenSearchClient extends ApiClient<OpensearchTransport, OpenSearchC
 		JsonEndpoint<SearchRequest, SearchResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<SearchRequest, SearchResponse<TDocument>, ErrorResponse>) SearchRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.search.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.search.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequest(request, endpoint, this.transportOptions);
 	}
@@ -1510,9 +1510,8 @@ public class OpenSearchClient extends ApiClient<OpensearchTransport, OpenSearchC
 				(JsonEndpoint<SearchTemplateRequest, SearchTemplateResponse<TDocument>, ErrorResponse>)
 						SearchTemplateRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.search_template.TDocument",
+				"org.opensearch.client:Deserializer:_global.search_template.TDocument",
 				getDeserializer(tDocumentClass));
-
 		return this.transport.performRequest(request, endpoint, this.transportOptions);
 	}
 
@@ -1626,7 +1625,7 @@ public class OpenSearchClient extends ApiClient<OpensearchTransport, OpenSearchC
 		JsonEndpoint<UpdateRequest<?, ?>, UpdateResponse<TDocument>, ErrorResponse> endpoint =
 				(JsonEndpoint<UpdateRequest<?, ?>, UpdateResponse<TDocument>, ErrorResponse>) UpdateRequest._ENDPOINT;
 		endpoint = new EndpointWithResponseMapperAttr<>(endpoint,
-				"co.elastic.clients:Deserializer:_global.update.TDocument", getDeserializer(tDocumentClass));
+				"org.opensearch.client:Deserializer:_global.update.TDocument", getDeserializer(tDocumentClass));
 
 		return this.transport.performRequest(request, endpoint, this.transportOptions);
 	}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/ExplainResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/ExplainResponse.java
@@ -314,7 +314,7 @@ public class ExplainResponse<TDocument> implements JsonpSerializable {
 	 * provided by the calling {@code JsonMapper}.
 	 */
 	public static final JsonpDeserializer<ExplainResponse<Object>> _DESERIALIZER = createExplainResponseDeserializer(
-			new NamedDeserializer<>("co.elastic.clients:Deserializer:_global.explain.TDocument"));
+			new NamedDeserializer<>("org.opensearch.client:Deserializer:_global.explain.TDocument"));
 
 	protected static <TDocument> void setupExplainResponseDeserializer(
 			ObjectDeserializer<ExplainResponse.Builder<TDocument>> op,

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/GetResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/GetResponse.java
@@ -112,7 +112,7 @@ public class GetResponse<TDocument> extends GetResult<TDocument> {
 	 * provided by the calling {@code JsonMapper}.
 	 */
 	public static final JsonpDeserializer<GetResponse<Object>> _DESERIALIZER = createGetResponseDeserializer(
-			new NamedDeserializer<>("co.elastic.clients:Deserializer:_global.get.TDocument"));
+			new NamedDeserializer<>("org.opensearch.client:Deserializer:_global.get.TDocument"));
 
 	protected static <TDocument> void setupGetResponseDeserializer(
 			ObjectDeserializer<GetResponse.Builder<TDocument>> op, JsonpDeserializer<TDocument> tDocumentDeserializer) {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/GetSourceResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/GetSourceResponse.java
@@ -148,7 +148,7 @@ public class GetSourceResponse<TDocument> implements JsonpSerializable {
 	 * provided by the calling {@code JsonMapper}.
 	 */
 	public static final JsonpDeserializer<GetSourceResponse<Object>> _DESERIALIZER = createGetSourceResponseDeserializer(
-			new NamedDeserializer<>("co.elastic.clients:Deserializer:_global.get_source.TDocument"));
+			new NamedDeserializer<>("org.opensearch.client:Deserializer:_global.get_source.TDocument"));
 
 	public static <TDocument> JsonpDeserializer<GetSourceResponse<TDocument>> createGetSourceResponseDeserializer(
 			JsonpDeserializer<TDocument> tDocumentDeserializer) {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/MgetResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/MgetResponse.java
@@ -196,7 +196,7 @@ public class MgetResponse<TDocument> implements JsonpSerializable {
 	 * provided by the calling {@code JsonMapper}.
 	 */
 	public static final JsonpDeserializer<MgetResponse<Object>> _DESERIALIZER = createMgetResponseDeserializer(
-			new NamedDeserializer<>("co.elastic.clients:Deserializer:_global.mget.TDocument"));
+			new NamedDeserializer<>("org.opensearch.client:Deserializer:_global.mget.TDocument"));
 
 	protected static <TDocument> void setupMgetResponseDeserializer(
 			ObjectDeserializer<MgetResponse.Builder<TDocument>> op,

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/MsearchResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/MsearchResponse.java
@@ -106,7 +106,7 @@ public class MsearchResponse<TDocument> extends MultiSearchResult<TDocument> {
 	 * provided by the calling {@code JsonMapper}.
 	 */
 	public static final JsonpDeserializer<MsearchResponse<Object>> _DESERIALIZER = createMsearchResponseDeserializer(
-			new NamedDeserializer<>("co.elastic.clients:Deserializer:_global.msearch.TDocument"));
+			new NamedDeserializer<>("org.opensearch.client:Deserializer:_global.msearch.TDocument"));
 
 	protected static <TDocument> void setupMsearchResponseDeserializer(
 			ObjectDeserializer<MsearchResponse.Builder<TDocument>> op,

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/MsearchTemplateResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/MsearchTemplateResponse.java
@@ -106,7 +106,7 @@ public class MsearchTemplateResponse<TDocument> extends MultiSearchResult<TDocum
 	 * deserializers provided by the calling {@code JsonMapper}.
 	 */
 	public static final JsonpDeserializer<MsearchTemplateResponse<Object>> _DESERIALIZER = createMsearchTemplateResponseDeserializer(
-			new NamedDeserializer<>("co.elastic.clients:Deserializer:_global.msearch_template.TDocument"));
+			new NamedDeserializer<>("org.opensearch.client:Deserializer:_global.msearch_template.TDocument"));
 
 	protected static <TDocument> void setupMsearchTemplateResponseDeserializer(
 			ObjectDeserializer<MsearchTemplateResponse.Builder<TDocument>> op,

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/ScriptsPainlessExecuteResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/ScriptsPainlessExecuteResponse.java
@@ -162,7 +162,7 @@ public class ScriptsPainlessExecuteResponse<TResult> implements JsonpSerializabl
 	 */
 	public static final JsonpDeserializer<ScriptsPainlessExecuteResponse<Object>> _DESERIALIZER =
 			createScriptsPainlessExecuteResponseDeserializer(
-			new NamedDeserializer<>("co.elastic.clients:Deserializer:_global.scripts_painless_execute.TResult"));
+			new NamedDeserializer<>("org.opensearch.client:Deserializer:_global.scripts_painless_execute.TResult"));
 
 	protected static <TResult> void setupScriptsPainlessExecuteResponseDeserializer(
 			ObjectDeserializer<ScriptsPainlessExecuteResponse.Builder<TResult>> op,

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/ScrollResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/ScrollResponse.java
@@ -111,7 +111,7 @@ public class ScrollResponse<TDocument> extends SearchResponse<TDocument> {
 	 * provided by the calling {@code JsonMapper}.
 	 */
 	public static final JsonpDeserializer<ScrollResponse<Object>> _DESERIALIZER = createScrollResponseDeserializer(
-			new NamedDeserializer<>("co.elastic.clients:Deserializer:_global.scroll.TDocument"));
+			new NamedDeserializer<>("org.opensearch.client:Deserializer:_global.scroll.TDocument"));
 
 	protected static <TDocument> void setupScrollResponseDeserializer(
 			ObjectDeserializer<ScrollResponse.Builder<TDocument>> op,

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchResponse.java
@@ -668,7 +668,7 @@ public class SearchResponse<TDocument> implements JsonpSerializable {
 	 * provided by the calling {@code JsonMapper}.
 	 */
 	public static final JsonpDeserializer<SearchResponse<Object>> _DESERIALIZER = createSearchResponseDeserializer(
-			new NamedDeserializer<>("co.elastic.clients:Deserializer:_global.search.TDocument"));
+			new NamedDeserializer<>("org.opensearch.client:Deserializer:_global.search.TDocument"));
 
 	protected static <TDocument, BuilderT extends AbstractBuilder<TDocument, BuilderT>> void setupSearchResponseDeserializer(
 			ObjectDeserializer<BuilderT> op, JsonpDeserializer<TDocument> tDocumentDeserializer) {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchTemplateResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchTemplateResponse.java
@@ -245,7 +245,7 @@ public class SearchTemplateResponse<TDocument> implements JsonpSerializable {
 	 * deserializers provided by the calling {@code JsonMapper}.
 	 */
 	public static final JsonpDeserializer<SearchTemplateResponse<Object>> _DESERIALIZER = createSearchTemplateResponseDeserializer(
-			new NamedDeserializer<>("co.elastic.clients:Deserializer:_global.search_template.TDocument"));
+			new NamedDeserializer<>("org.opensearch.client:Deserializer:_global.search_template.TDocument"));
 
 	protected static <TDocument> void setupSearchTemplateResponseDeserializer(
 			ObjectDeserializer<SearchTemplateResponse.Builder<TDocument>> op,

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/UpdateResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/UpdateResponse.java
@@ -176,7 +176,7 @@ public class UpdateResponse<TDocument> extends WriteResponseBase {
 	 * provided by the calling {@code JsonMapper}.
 	 */
 	public static final JsonpDeserializer<UpdateResponse<Object>> _DESERIALIZER = createUpdateResponseDeserializer(
-			new NamedDeserializer<>("co.elastic.clients:Deserializer:_global.update.TDocument"));
+			new NamedDeserializer<>("org.opensearch.client:Deserializer:_global.update.TDocument"));
 
 	protected static <TDocument> void setupUpdateResponseDeserializer(
 			ObjectDeserializer<UpdateResponse.Builder<TDocument>> op,


### PR DESCRIPTION
### Description
Replace co.elastic.clients with org.opensearch.client
 
### Issues Resolved
#12 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
