### PR TITLE
Removing jcenter references

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,6 @@ allprojects {
         mavenCentral()
         mavenLocal()
         maven(url = "https://plugins.gradle.org/m2/")
-        jcenter()
     }
 
     apply(plugin = "checkstyle")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,5 +38,4 @@ repositories {
     mavenCentral()
     mavenLocal()
     maven(url = "https://plugins.gradle.org/m2/")
-    jcenter()
 }

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -39,7 +39,6 @@ buildscript {
         mavenCentral()
         mavenLocal()
         maven(url = "https://plugins.gradle.org/m2/")
-        jcenter()
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Removing deprecated jcenter references. 
 
### Issues Resolved
#114 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
