### PR TITLE
Upgrading checkstyle to latest version

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -51,6 +51,10 @@ plugins {
     id("com.github.jk1.dependency-license-report") version "1.17"
 }
 
+checkstyle {
+    toolVersion = "10.0"
+}
+
 java {
     targetCompatibility = JavaVersion.VERSION_1_8
     sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Upgrading checkstyle to latest version to resolve [CVE-2020-8908](https://vuln.whitesourcesoftware.com/vulnerability/CVE-2020-8908). Checkstyle [`10.0`](https://mvnrepository.com/artifact/com.puppycrawl.tools/checkstyle/10.0) uses the latest guava [`31.0.1-jre`](https://mvnrepository.com/artifact/com.google.guava/guava/31.0.1-jre).
 
### Issues Resolved
#113 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
