### PR TITLE
Adding integration tests for multiple versions of OpenSearch

### DIFF
--- a/.ci/opensearch/Dockerfile
+++ b/.ci/opensearch/Dockerfile
@@ -1,4 +1,5 @@
-FROM opensearchproject/opensearch:latest
+ARG OPENSEARCH_VERSION
+FROM opensearchproject/opensearch:$OPENSEARCH_VERSION
 
 ARG opensearch_path=/usr/share/opensearch
 ARG opensearch_yml=$opensearch_path/config/opensearch.yml

--- a/.ci/opensearch/docker-compose.yml
+++ b/.ci/opensearch/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+
+  opensearch:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - SECURE_INTEGRATION=${SECURE_INTEGRATION:-true}
+        - OPENSEARCH_VERSION=${OPENSEARCH_VERSION}
+    environment:
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+    ports:
+      - "9200:9200"
+    user: opensearch

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -2,7 +2,7 @@ name: Code style and license headers
 
 on: [pull_request]
 jobs:
-  build:
+  checkstyle:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,0 +1,47 @@
+name: Integration
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        opensearch_version:
+          - 1.0.0
+          - 1.0.1
+          - 1.1.0
+          - 1.2.0
+          - 1.2.1
+          - 1.2.2
+          - 1.2.3
+          - 1.2.4
+          - 1.3.0
+    steps:
+      - name: Set up JDK 14
+        uses: actions/setup-java@v2
+        with:
+          java-version: '14'
+          distribution: 'adopt'
+
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+
+      - name: Run Docker
+        run: |
+          docker-compose --project-directory .ci/opensearch build --build-arg OPENSEARCH_VERSION=${{ matrix.opensearch_version }}
+          docker-compose --project-directory .ci/opensearch up -d
+          sleep 60
+
+      - name: Run Integration Test
+        run: ./gradlew clean integrationTest
+
+      - name: Stop Docker
+        run: |
+          docker-compose --project-directory .ci/opensearch down

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Unit
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - "*"
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 14
@@ -20,5 +20,5 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
 
-      - name: Build with Gradle
-        run: ./gradlew clean build -x test
+      - name: Run Unit Test
+        run: ./gradlew clean unitTest

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,7 @@ gradle-app.setting
 .idea
 *.iml
 
+# vscode
+.vscode/
+
 .ci/output

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,17 @@
+- [Compatibility with OpenSearch](#compatibility-with-opensearch)
+
+## Compatibility with OpenSearch
+
+The below matrix shows the compatibility of the [`opensearch-java-client`](https://search.maven.org/artifact/org.opensearch.client/opensearch-java) with versions of [`OpenSearch`](https://opensearch.org/downloads.html#opensearch).
+
+| OpenSearch Version | Client Version |
+| --- | --- |
+| 1.0.0 | 1.0.0 |
+| 1.0.1 | 1.0.0 |
+| 1.1.0 | 1.0.0 |
+| 1.2.0 | 1.0.0 |
+| 1.2.1 | 1.0.0 |
+| 1.2.2 | 1.0.0 |
+| 1.2.3 | 1.0.0 |
+| 1.2.4 | 1.0.0 |
+| 1.3.0 | 1.0.0 |

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ OpenSearch Java Client
 - [Welcome!](#welcome)
 - [Project Resources](#project-resources)
 - [Code of Conduct](#code-of-conduct)
+- [Compatibility with OpenSearch](#compatibility-with-opensearch)
 - [Security](#security)
 - [License](#license)
 - [Copyright](#copyright)
@@ -38,6 +39,9 @@ This client is meant to replace the existing [OpenSearch Java High Level REST Cl
 
 This project has adopted the [Amazon Open Source Code of Conduct](CODE_OF_CONDUCT.md). For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq), or contact [opensource-codeofconduct@amazon.com](mailto:opensource-codeofconduct@amazon.com) with any additional questions or comments.
 
+## Compatibility with OpenSearch
+
+See [Compatibility](COMPATIBILITY.md).
 ## Security
 
 If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email to aws-security@amazon.com. Please do **not** create a public GitHub issue.


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Adding support for integration tests to run against all versions of OpenSearch. Also adding compatibility matrix for the client.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
