### PR TITLE
Adding JDK matrix for integration tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         opensearch_version:
           - 1.0.0
@@ -23,12 +24,16 @@ jobs:
           - 1.2.3
           - 1.2.4
           - 1.3.0
+        java:
+          - 8
+          - 14
+          - 15
+          - 17
     steps:
-      - name: Set up JDK 14
-        uses: actions/setup-java@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
         with:
-          java-version: '14'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
 
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -34,13 +34,6 @@ Download and install [Docker](https://docs.docker.com/install/), required for ru
 
 ### Build
 
-To build the java-client, start an OpenSearch cluster using docker:
-
-```
-docker build -t opensearch-search:test -f .ci/opensearch/Dockerfile --build-arg "SECURE_INTEGRATION=true" .
-docker run -p 9200:9200 -p 9600:9600 -d -e "discovery.type=single-node" opensearch-search:test
-```
-
 To build the java-client:
 
 ```
@@ -59,11 +52,11 @@ To run unit tests for the java-client:
 
 #### Integration Tests
 
-To run integration tests for the java-client, start an OpenSearch cluster using docker:
+To run integration tests for the java-client, start an OpenSearch cluster using docker and pass the OpenSearch version:
 
 ```
-docker build -t opensearch-search:test -f .ci/opensearch/Dockerfile --build-arg "SECURE_INTEGRATION=true" .
-docker run -p 9200:9200 -p 9600:9600 -d -e "discovery.type=single-node" opensearch-search:test
+docker-compose --project-directory .ci/opensearch build --build-arg OPENSEARCH_VERSION=1.3.0
+docker-compose --project-directory .ci/opensearch up -d
 ```
 
 Run integration tests after starting OpenSearch cluster:


### PR DESCRIPTION
### Description
Adding JDK 8, 14, 15 and 17 in the matrix for integration tests. Also updating the developer guide with docker-compose commands added in PR #122.
 
### Issues Resolved
Closes #124 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
