### PR TITLE
Updating jackson-databind for CVE-2020-36518

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -124,6 +124,7 @@ dependencies {
 
     val opensearchVersion = "1.2.4"
     val jacksonVersion = "2.12.6"
+    val jacksonDatabindVersion = "2.12.6.1"
 
     // Apache 2.0
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)
@@ -149,7 +150,7 @@ dependencies {
     // Apache 2.0
 
     implementation("com.fasterxml.jackson.core", "jackson-core", jacksonVersion)
-    implementation("com.fasterxml.jackson.core", "jackson-databind", "2.12.6.1")
+    implementation("com.fasterxml.jackson.core", "jackson-databind", jacksonDatabindVersion)
     testImplementation("com.fasterxml.jackson.datatype", "jackson-datatype-jakarta-jsonp", jacksonVersion)
 
     // EPL-2.0 OR BSD-3-Clause

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -149,7 +149,7 @@ dependencies {
     // Apache 2.0
 
     implementation("com.fasterxml.jackson.core", "jackson-core", jacksonVersion)
-    implementation("com.fasterxml.jackson.core", "jackson-databind", jacksonVersion)
+    implementation("com.fasterxml.jackson.core", "jackson-databind", "2.12.6.1")
     testImplementation("com.fasterxml.jackson.datatype", "jackson-datatype-jakarta-jsonp", jacksonVersion)
 
     // EPL-2.0 OR BSD-3-Clause


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Updating `jackson-databind` to `2.12.6.1` for CVE-2020-36518.
 
### Issues Resolved
#121 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
