### PR TITLE
Reducing test matrix to use JDK 11 and/or 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11 ]
     steps:
-      - name: Set up JDK 14
-        uses: actions/setup-java@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
         with:
-          java-version: '14'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+
       - name: Checkout Branch
         uses: actions/checkout@v2
 

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -6,13 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 11 ]
+        java: [ 11 ]
     steps:
-      - name: Set up JDK 14
-        uses: actions/setup-java@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
         with:
-          java-version: '14'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+
       - uses: actions/checkout@v2
       - name: Check style and license headers
         run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -14,33 +14,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        opensearch_version:
-          - 1.0.0
-          - 1.0.1
-          - 1.1.0
-          - 1.2.0
-          - 1.2.1
-          - 1.2.2
-          - 1.2.3
-          - 1.2.4
-          - 1.3.0
-        java:
-          - 8
-          - 14
-          - 15
-          - 17
+        entry:
+          - { opensearch_version: 1.0.0, java: 11 }
+          - { opensearch_version: 1.0.1, java: 11 }
+          - { opensearch_version: 1.1.0, java: 11 }
+          - { opensearch_version: 1.2.0, java: 11 }
+          - { opensearch_version: 1.2.1, java: 11 }
+          - { opensearch_version: 1.2.2, java: 11 }
+          - { opensearch_version: 1.2.3, java: 11 }
+          - { opensearch_version: 1.2.4, java: 11 }
+          - { opensearch_version: 1.3.0, java: 11 }
     steps:
-      - name: Set up JDK ${{ matrix.java }}
+      - name: Set up JDK ${{ matrix.entry.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java }}
+          java-version: ${{ matrix.entry.java }}
 
       - name: Checkout Branch
         uses: actions/checkout@v2
 
       - name: Run Docker
         run: |
-          docker-compose --project-directory .ci/opensearch build --build-arg OPENSEARCH_VERSION=${{ matrix.opensearch_version }}
+          docker-compose --project-directory .ci/opensearch build --build-arg OPENSEARCH_VERSION=${{ matrix.entry.opensearch_version }}
           docker-compose --project-directory .ci/opensearch up -d
           sleep 60
 

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -11,12 +11,15 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11 ]
     steps:
-      - name: Set up JDK 14
-        uses: actions/setup-java@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
         with:
-          java-version: '14'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+
       - name: Checkout Branch
         uses: actions/checkout@v2
 


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Reducing test matrix to use JDK 11 or 17 across OpenSearch versions.
 
### Issues Resolved
#133 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
