### PR TITLE
Adding OpenSearch version 1.3.1 to CI and compatibility matrix

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -24,6 +24,7 @@ jobs:
           - { opensearch_version: 1.2.3, java: 11 }
           - { opensearch_version: 1.2.4, java: 11 }
           - { opensearch_version: 1.3.0, java: 11 }
+          - { opensearch_version: 1.3.1, java: 11 }
     steps:
       - name: Set up JDK ${{ matrix.entry.java }}
         uses: actions/setup-java@v1

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -15,3 +15,4 @@ The below matrix shows the compatibility of the [`opensearch-java-client`](https
 | 1.2.3 | 1.0.0 |
 | 1.2.4 | 1.0.0 |
 | 1.3.0 | 1.0.0 |
+| 1.3.1 | 1.0.0 |


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Adding OpenSearch version `1.3.1` to the CI workflow and compatibility matrix.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
