### PR TITLE
Fixing flaky Cluster integration tests

### DIFF
--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/ClusterClientIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/ClusterClientIT.java
@@ -127,7 +127,7 @@ public class ClusterClientIT extends OpenSearchRestHighLevelClientTestCase {
 
         GetClusterSettingsResponse getSettingsResponse = openSearchClient.cluster()
                 .getSettings(new GetClusterSettingsRequest.Builder().build());
-        assertEquals(1, getSettingsResponse.persistent().size());
+        assertTrue(getSettingsResponse.persistent().containsKey("cluster"));
         assertEquals(1, getSettingsResponse.transient_().size());
         assertEquals(0, getSettingsResponse.defaults().size());
     }
@@ -155,8 +155,7 @@ public class ClusterClientIT extends OpenSearchRestHighLevelClientTestCase {
 
         GetClusterSettingsResponse getSettingsResponse = openSearchClient.cluster().getSettings(new GetClusterSettingsRequest.Builder()
                 .includeDefaults(true).build());
-
-        assertEquals(1, getSettingsResponse.persistent().size());
+        assertTrue(getSettingsResponse.persistent().containsKey("cluster"));
         assertEquals(1, getSettingsResponse.transient_().size());
         assertTrue(getSettingsResponse.defaults().size()>0);
     }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/ClusterClientIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/ClusterClientIT.java
@@ -128,6 +128,13 @@ public class ClusterClientIT extends OpenSearchRestHighLevelClientTestCase {
         GetClusterSettingsResponse getSettingsResponse = openSearchClient.cluster()
                 .getSettings(new GetClusterSettingsRequest.Builder().build());
         assertTrue(getSettingsResponse.persistent().containsKey("cluster"));
+        assertEquals(
+                getSettingsResponse.persistent().get("cluster").toJson().asJsonObject()
+                        .getJsonObject("routing")
+                        .getJsonObject("allocation")
+                        .getString("enable"),
+                persistentSettingValue
+        );
         assertEquals(1, getSettingsResponse.transient_().size());
         assertEquals(0, getSettingsResponse.defaults().size());
     }
@@ -156,6 +163,13 @@ public class ClusterClientIT extends OpenSearchRestHighLevelClientTestCase {
         GetClusterSettingsResponse getSettingsResponse = openSearchClient.cluster().getSettings(new GetClusterSettingsRequest.Builder()
                 .includeDefaults(true).build());
         assertTrue(getSettingsResponse.persistent().containsKey("cluster"));
+        assertEquals(
+                getSettingsResponse.persistent().get("cluster").toJson().asJsonObject()
+                        .getJsonObject("routing")
+                        .getJsonObject("allocation")
+                        .getString("enable"),
+                persistentSettingValue
+        );
         assertEquals(1, getSettingsResponse.transient_().size());
         assertTrue(getSettingsResponse.defaults().size()>0);
     }


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
`testClusterGetSettings` and `testClusterGetSettingsWithDefault` fail intermittently. On debugging, found that the cluster settings contains `plugins={"index_state_management":{"metadata_migration":{"status":"1"},"template_migration":{"control":"-1"}}}` along with `cluster={"routing":{"allocation":{"enable":"NONE"}}}` during failures. Updating both the test assertions to fix the flaky test.
 
### Issues Resolved
Closes #127 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
