### PR TITLE
Adding documentation for backport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ gradle-app.setting
 .vscode/
 
 .ci/output
+java-client/bin

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,15 +1,16 @@
 - [Overview](#overview)
 - [Current Maintainers](#current-maintainers)
 - [Maintainer Responsibilities](#maintainer-responsibilities)
-    - [Uphold Code of Conduct](#uphold-code-of-conduct)
-    - [Prioritize Security](#prioritize-security)
-    - [Review Pull Requests](#review-pull-requests)
-    - [Triage Open Issues](#triage-open-issues)
-    - [Be Responsive](#be-responsive)
-    - [Maintain Overall Health of the Repo](#maintain-overall-health-of-the-repo)
-    - [Use Semver](#use-semver)
-    - [Release Frequently](#release-frequently)
-    - [Promote Other Maintainers](#promote-other-maintainers)
+  - [Uphold Code of Conduct](#uphold-code-of-conduct)
+  - [Prioritize Security](#prioritize-security)
+  - [Review Pull Requests](#review-pull-requests)
+  - [Triage Open Issues](#triage-open-issues)
+  - [Backports](#backports)
+  - [Be Responsive](#be-responsive)
+  - [Maintain Overall Health of the Repo](#maintain-overall-health-of-the-repo)
+  - [Use Semver](#use-semver)
+  - [Release Frequently](#release-frequently)
+  - [Promote Other Maintainers](#promote-other-maintainers)
 
 ## Overview
 
@@ -50,6 +51,10 @@ Manage labels, review issues regularly, and triage by labelling them.
 All repositories in this organization have a standard set of labels, including `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `blocker`, `invalid`, `question`, `wontfix`, and `untriaged`, along with release labels, such as `v1.0.0`, `v1.1.0` and `v2.0.0`, and `backport`.
 
 Use labels to target an issue or a PR for a given release, add `help wanted` to good issues for new community members, and `blocker` for issues that scare you or need immediate attention. Request for more information from a submitter if an issue is not clear. Create new labels as needed by the project.
+
+### Backports
+
+The Github workflow in [backport.yml](.github/workflows/backport.yml) creates backport PRs automatically when the original PR with an appropriate label `backport <backport-branch-name>` is merged to main. To backport a PR to `1.x`, add a label `backport 1.x` to the PR, once this PR is merged to main, the workflow will create a backport PR to the `1.x` branch.
 
 ### Be Responsive
 


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Adding documentation for auto backport.
 
### Issues Resolved
Part of #142 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
