### PR TITLE
Add OpenSearch 2.0 to the test matrix and dependency

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -25,6 +25,7 @@ jobs:
           - { opensearch_version: 1.2.4, java: 11 }
           - { opensearch_version: 1.3.0, java: 11 }
           - { opensearch_version: 1.3.1, java: 11 }
+          - { opensearch_version: 2.0.0, java: 11 }
     steps:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -123,7 +123,7 @@ val integrationTest = task<Test>("integrationTest") {
 
 dependencies {
 
-    val opensearchVersion = "2.0.0-alpha1-SNAPSHOT"
+    val opensearchVersion = "2.0.0"
     val jacksonVersion = "2.12.6"
     val jacksonDatabindVersion = "2.12.6.1"
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -124,8 +124,8 @@ val integrationTest = task<Test>("integrationTest") {
 dependencies {
 
     val opensearchVersion = "2.0.0"
-    val jacksonVersion = "2.12.6"
-    val jacksonDatabindVersion = "2.12.6.1"
+    val jacksonVersion = "2.13.2"
+    val jacksonDatabindVersion = "2.13.2.2"
 
     // Apache 2.0
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Adding OpenSearch 2.0 to the test matrix. Also updating the rest-client dependency to 2.0.

*Note*: The artifact is not yet available on maven so leaving this PR in a draft state for now.

### Issues Resolved
#159 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
