### PR TITLE
Deprecating master terminology to support inclusive naming

### DIFF
--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/NodeRole.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/NodeRole.java
@@ -41,7 +41,10 @@ import org.opensearch.client.json.JsonpDeserializable;
 
 @JsonpDeserializable
 public enum NodeRole implements JsonEnum {
+	@Deprecated
 	Master("master"),
+
+	ClusterManager("cluster_manager"),
 
 	Data("data"),
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cat/ClusterManagerRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cat/ClusterManagerRequest.java
@@ -43,28 +43,28 @@ import org.opensearch.client.transport.endpoints.SimpleEndpoint;
 import java.util.HashMap;
 import java.util.Map;
 
-// typedef: cat.master.Request
+// typedef: cat.cluster_manager.Request
 
 /**
- * Returns information about the master node.
+ * Returns information about the cluster-manager node.
  *
  */
-
-public class MasterRequest extends CatRequestBase {
-	public MasterRequest() {
+public class ClusterManagerRequest extends CatRequestBase {
+	public ClusterManagerRequest() {
 	}
 
 	/**
-	 * Singleton instance for {@link MasterRequest}.
+	 * Singleton instance for {@link ClusterManagerRequest}.
 	 */
-	public static final MasterRequest _INSTANCE = new MasterRequest();
+	public static final ClusterManagerRequest _INSTANCE = new ClusterManagerRequest();
 
 	// ---------------------------------------------------------------------------------------------
 
 	/**
 	 * Endpoint "{@code cat.master}".
 	 */
-	public static final Endpoint<MasterRequest, MasterResponse, ErrorResponse> _ENDPOINT = new SimpleEndpoint<>(
+	@Deprecated
+	public static final Endpoint<ClusterManagerRequest, ClusterManagerResponse, ErrorResponse> _DEPRECATED_ENDPOINT = new SimpleEndpoint<>(
 
 			// Request method
 			request -> {
@@ -84,5 +84,30 @@ public class MasterRequest extends CatRequestBase {
 				params.put("format", "json");
 				return params;
 
-			}, SimpleEndpoint.emptyMap(), false, MasterResponse._DESERIALIZER);
+			}, SimpleEndpoint.emptyMap(), false, ClusterManagerResponse._DESERIALIZER);
+
+	/**
+	 * Endpoint "{@code cat.cluster_manager}".
+	 */
+	public static final Endpoint<ClusterManagerRequest, ClusterManagerResponse, ErrorResponse> _ENDPOINT = new SimpleEndpoint<>(
+
+			// Request method
+			request -> {
+				return "GET";
+
+			},
+
+			// Request path
+			request -> {
+				return "/_cat/cluster_manager";
+
+			},
+
+			// Request parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				params.put("format", "json");
+				return params;
+
+			}, SimpleEndpoint.emptyMap(), false, ClusterManagerResponse._DESERIALIZER);
 }

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cat/ClusterManagerResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cat/ClusterManagerResponse.java
@@ -36,11 +36,11 @@
 
 package org.opensearch.client.opensearch.cat;
 
-import org.opensearch.client.opensearch.cat.master.MasterRecord;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.opensearch.cat.cluster_manager.ClusterManagerRecord;
 import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.ObjectBuilder;
 import org.opensearch.client.util.ObjectBuilderBase;
@@ -49,21 +49,21 @@ import jakarta.json.stream.JsonGenerator;
 import java.util.List;
 import java.util.function.Function;
 
-// typedef: cat.master.Response
+// typedef: cat.cluster_manager.Response
 
 @JsonpDeserializable
-public class MasterResponse implements JsonpSerializable {
-	private final List<MasterRecord> valueBody;
+public class ClusterManagerResponse implements JsonpSerializable {
+	private final List<ClusterManagerRecord> valueBody;
 
 	// ---------------------------------------------------------------------------------------------
 
-	private MasterResponse(Builder builder) {
+	private ClusterManagerResponse(Builder builder) {
 
 		this.valueBody = ApiTypeHelper.unmodifiableRequired(builder.valueBody, this, "valueBody");
 
 	}
 
-	public static MasterResponse of(Function<Builder, ObjectBuilder<MasterResponse>> fn) {
+	public static ClusterManagerResponse of(Function<Builder, ObjectBuilder<ClusterManagerResponse>> fn) {
 		return fn.apply(new Builder()).build();
 	}
 
@@ -72,7 +72,7 @@ public class MasterResponse implements JsonpSerializable {
 	 * <p>
 	 * API name: {@code _value_body}
 	 */
-	public final List<MasterRecord> valueBody() {
+	public final List<ClusterManagerRecord> valueBody() {
 		return this.valueBody;
 	}
 
@@ -81,7 +81,7 @@ public class MasterResponse implements JsonpSerializable {
 	 */
 	public void serialize(JsonGenerator generator, JsonpMapper mapper) {
 		generator.writeStartArray();
-		for (MasterRecord item0 : this.valueBody) {
+		for (ClusterManagerRecord item0 : this.valueBody) {
 			item0.serialize(generator, mapper);
 
 		}
@@ -92,11 +92,11 @@ public class MasterResponse implements JsonpSerializable {
 	// ---------------------------------------------------------------------------------------------
 
 	/**
-	 * Builder for {@link MasterResponse}.
+	 * Builder for {@link ClusterManagerResponse}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<MasterResponse> {
-		private List<MasterRecord> valueBody;
+	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ClusterManagerResponse> {
+		private List<ClusterManagerRecord> valueBody;
 
 		/**
 		 * Required - Response value.
@@ -105,7 +105,7 @@ public class MasterResponse implements JsonpSerializable {
 		 * <p>
 		 * Adds all elements of <code>list</code> to <code>valueBody</code>.
 		 */
-		public final Builder valueBody(List<MasterRecord> list) {
+		public final Builder valueBody(List<ClusterManagerRecord> list) {
 			this.valueBody = _listAddAll(this.valueBody, list);
 			return this;
 		}
@@ -117,7 +117,7 @@ public class MasterResponse implements JsonpSerializable {
 		 * <p>
 		 * Adds one or more values to <code>valueBody</code>.
 		 */
-		public final Builder valueBody(MasterRecord value, MasterRecord... values) {
+		public final Builder valueBody(ClusterManagerRecord value, ClusterManagerRecord... values) {
 			this.valueBody = _listAdd(this.valueBody, value, values);
 			return this;
 		}
@@ -129,28 +129,28 @@ public class MasterResponse implements JsonpSerializable {
 		 * <p>
 		 * Adds a value to <code>valueBody</code> using a builder lambda.
 		 */
-		public final Builder valueBody(Function<MasterRecord.Builder, ObjectBuilder<MasterRecord>> fn) {
-			return valueBody(fn.apply(new MasterRecord.Builder()).build());
+		public final Builder valueBody(Function<ClusterManagerRecord.Builder, ObjectBuilder<ClusterManagerRecord>> fn) {
+			return valueBody(fn.apply(new ClusterManagerRecord.Builder()).build());
 		}
 
 		/**
-		 * Builds a {@link MasterResponse}.
+		 * Builds a {@link ClusterManagerResponse}.
 		 *
 		 * @throws NullPointerException
 		 *             if some of the required fields are null.
 		 */
-		public MasterResponse build() {
+		public ClusterManagerResponse build() {
 			_checkSingleUse();
 
-			return new MasterResponse(this);
+			return new ClusterManagerResponse(this);
 		}
 	}
 
-	public static final JsonpDeserializer<MasterResponse> _DESERIALIZER = createMasterResponseDeserializer();
-	protected static JsonpDeserializer<MasterResponse> createMasterResponseDeserializer() {
+	public static final JsonpDeserializer<ClusterManagerResponse> _DESERIALIZER = createClusterManagerResponseDeserializer();
+	protected static JsonpDeserializer<ClusterManagerResponse> createClusterManagerResponseDeserializer() {
 
-		JsonpDeserializer<List<MasterRecord>> valueDeserializer = JsonpDeserializer
-				.arrayDeserializer(MasterRecord._DESERIALIZER);
+		JsonpDeserializer<List<ClusterManagerRecord>> valueDeserializer = JsonpDeserializer
+				.arrayDeserializer(ClusterManagerRecord._DESERIALIZER);
 
 		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
 				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cat/OpenSearchCatAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cat/OpenSearchCatAsyncClient.java
@@ -355,8 +355,21 @@ public class OpenSearchCatAsyncClient extends ApiClient<OpenSearchTransport, Ope
 	 * 
 	 *
 	 */
-	public CompletableFuture<MasterResponse> master() throws IOException, OpenSearchException {
-		return this.transport.performRequestAsync(MasterRequest._INSTANCE, MasterRequest._ENDPOINT,
+	@Deprecated
+	public CompletableFuture<ClusterManagerResponse> master() throws IOException, OpenSearchException {
+		return this.transport.performRequestAsync(ClusterManagerRequest._INSTANCE, ClusterManagerRequest._DEPRECATED_ENDPOINT,
+				this.transportOptions);
+	}
+
+	// ----- Endpoint: cat.cluster_manager
+
+	/**
+	 * Returns information about the cluster-manager node.
+	 * 
+	 *
+	 */
+	public CompletableFuture<ClusterManagerResponse> clusterManager() throws IOException, OpenSearchException {
+		return this.transport.performRequestAsync(ClusterManagerRequest._INSTANCE, ClusterManagerRequest._ENDPOINT,
 				this.transportOptions);
 	}
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cat/OpenSearchCatClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cat/OpenSearchCatClient.java
@@ -345,8 +345,20 @@ public class OpenSearchCatClient extends ApiClient<OpenSearchTransport, OpenSear
 	 * 
 	 *
 	 */
-	public MasterResponse master() throws IOException, OpenSearchException {
-		return this.transport.performRequest(MasterRequest._INSTANCE, MasterRequest._ENDPOINT, this.transportOptions);
+	@Deprecated
+	public ClusterManagerResponse master() throws IOException, OpenSearchException {
+		return this.transport.performRequest(ClusterManagerRequest._INSTANCE, ClusterManagerRequest._DEPRECATED_ENDPOINT, this.transportOptions);
+	}
+
+	// ----- Endpoint: cat.cluster_manager
+
+	/**
+	 * Returns information about the cluster-manager node.
+	 * 
+	 *
+	 */
+	public ClusterManagerResponse clusterManager() throws IOException, OpenSearchException {
+		return this.transport.performRequest(ClusterManagerRequest._INSTANCE, ClusterManagerRequest._ENDPOINT, this.transportOptions);
 	}
 
 	// ----- Endpoint: cat.nodeattrs

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cat/cluster_manager/ClusterManagerRecord.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cat/cluster_manager/ClusterManagerRecord.java
@@ -34,7 +34,7 @@
 // THIS CODE IS GENERATED. MANUAL EDITS WILL BE LOST.
 //----------------------------------------------------
 
-package org.opensearch.client.opensearch.cat.master;
+package org.opensearch.client.opensearch.cat.cluster_manager;
 
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -48,11 +48,11 @@ import jakarta.json.stream.JsonGenerator;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
-// typedef: cat.master.MasterRecord
+// typedef: cat.cluster_manager.ClusterManagerRecord
 
 
 @JsonpDeserializable
-public class MasterRecord implements JsonpSerializable {
+public class ClusterManagerRecord implements JsonpSerializable {
 	@Nullable
 	private final String id;
 
@@ -67,7 +67,7 @@ public class MasterRecord implements JsonpSerializable {
 
 	// ---------------------------------------------------------------------------------------------
 
-	private MasterRecord(Builder builder) {
+	private ClusterManagerRecord(Builder builder) {
 
 		this.id = builder.id;
 		this.host = builder.host;
@@ -76,7 +76,7 @@ public class MasterRecord implements JsonpSerializable {
 
 	}
 
-	public static MasterRecord of(Function<Builder, ObjectBuilder<MasterRecord>> fn) {
+	public static ClusterManagerRecord of(Function<Builder, ObjectBuilder<ClusterManagerRecord>> fn) {
 		return fn.apply(new Builder()).build();
 	}
 
@@ -157,10 +157,10 @@ public class MasterRecord implements JsonpSerializable {
 	// ---------------------------------------------------------------------------------------------
 
 	/**
-	 * Builder for {@link MasterRecord}.
+	 * Builder for {@link ClusterManagerRecord}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<MasterRecord> {
+	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ClusterManagerRecord> {
 		@Nullable
 		private String id;
 
@@ -214,27 +214,27 @@ public class MasterRecord implements JsonpSerializable {
 		}
 
 		/**
-		 * Builds a {@link MasterRecord}.
+		 * Builds a {@link ClusterManagerRecord}.
 		 *
 		 * @throws NullPointerException
 		 *             if some of the required fields are null.
 		 */
-		public MasterRecord build() {
+		public ClusterManagerRecord build() {
 			_checkSingleUse();
 
-			return new MasterRecord(this);
+			return new ClusterManagerRecord(this);
 		}
 	}
 
 	// ---------------------------------------------------------------------------------------------
 
 	/**
-	 * Json deserializer for {@link MasterRecord}
+	 * Json deserializer for {@link ClusterManagerRecord}
 	 */
-	public static final JsonpDeserializer<MasterRecord> _DESERIALIZER = ObjectBuilderDeserializer.lazy(Builder::new,
-			MasterRecord::setupMasterRecordDeserializer);
+	public static final JsonpDeserializer<ClusterManagerRecord> _DESERIALIZER = ObjectBuilderDeserializer.lazy(Builder::new,
+			ClusterManagerRecord::setupClusterManagerRecordDeserializer);
 
-	protected static void setupMasterRecordDeserializer(ObjectDeserializer<MasterRecord.Builder> op) {
+	protected static void setupClusterManagerRecordDeserializer(ObjectDeserializer<ClusterManagerRecord.Builder> op) {
 
 		op.add(Builder::id, JsonpDeserializer.stringDeserializer(), "id");
 		op.add(Builder::host, JsonpDeserializer.stringDeserializer(), "host", "h");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cat/nodes/NodesRecord.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cat/nodes/NodesRecord.java
@@ -140,8 +140,12 @@ public class NodesRecord implements JsonpSerializable {
 	@Nullable
 	private final String nodeRole;
 
+	@Deprecated
 	@Nullable
 	private final String master;
+
+	@Nullable
+	private final String clusterManager;
 
 	@Nullable
 	private final String name;
@@ -375,6 +379,7 @@ public class NodesRecord implements JsonpSerializable {
 		this.uptime = builder.uptime;
 		this.nodeRole = builder.nodeRole;
 		this.master = builder.master;
+		this.clusterManager = builder.clusterManager;
 		this.name = builder.name;
 		this.completionSize = builder.completionSize;
 		this.fielddataMemorySize = builder.fielddataMemorySize;
@@ -729,7 +734,7 @@ public class NodesRecord implements JsonpSerializable {
 	}
 
 	/**
-	 * m:master eligible node, d:data node, i:ingest node, -:coordinating node only
+	 * m:cluster-manager eligible node, d:data node, i:ingest node, -:coordinating node only
 	 * <p>
 	 * API name: {@code node.role}
 	 */
@@ -743,9 +748,20 @@ public class NodesRecord implements JsonpSerializable {
 	 * <p>
 	 * API name: {@code master}
 	 */
+	@Deprecated
 	@Nullable
 	public final String master() {
 		return this.master;
+	}
+
+	/**
+	 * *:current cluster-manager
+	 * <p>
+	 * API name: {@code clusterManager}
+	 */
+	@Nullable
+	public final String clusterManager() {
+		return this.clusterManager;
 	}
 
 	/**
@@ -1570,6 +1586,11 @@ public class NodesRecord implements JsonpSerializable {
 			generator.write(this.master);
 
 		}
+		if (this.clusterManager != null) {
+			generator.writeKey("cluster_manager");
+			generator.write(this.clusterManager);
+
+		}
 		if (this.name != null) {
 			generator.writeKey("name");
 			generator.write(this.name);
@@ -1997,8 +2018,12 @@ public class NodesRecord implements JsonpSerializable {
 		@Nullable
 		private String nodeRole;
 
+		@Deprecated
 		@Nullable
 		private String master;
+
+		@Nullable
+		private String clusterManager;
 
 		@Nullable
 		private String name;
@@ -2479,7 +2504,7 @@ public class NodesRecord implements JsonpSerializable {
 		}
 
 		/**
-		 * m:master eligible node, d:data node, i:ingest node, -:coordinating node only
+		 * m:cluster-manager eligible node, d:data node, i:ingest node, -:coordinating node only
 		 * <p>
 		 * API name: {@code node.role}
 		 */
@@ -2493,8 +2518,19 @@ public class NodesRecord implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master}
 		 */
+		@Deprecated
 		public final Builder master(@Nullable String value) {
 			this.master = value;
+			return this;
+		}
+
+		/**
+		 * *:current cluster-manager
+		 * <p>
+		 * API name: {@code clusterManager}
+		 */
+		public final Builder clusterManager(@Nullable String value) {
+			this.clusterManager = value;
 			return this;
 		}
 
@@ -3217,6 +3253,7 @@ public class NodesRecord implements JsonpSerializable {
 		op.add(Builder::uptime, JsonpDeserializer.stringDeserializer(), "uptime", "u");
 		op.add(Builder::nodeRole, JsonpDeserializer.stringDeserializer(), "node.role", "r", "role", "nodeRole");
 		op.add(Builder::master, JsonpDeserializer.stringDeserializer(), "master", "m");
+		op.add(Builder::clusterManager, JsonpDeserializer.stringDeserializer(), "cluster_manager", "m");
 		op.add(Builder::name, JsonpDeserializer.stringDeserializer(), "name", "n");
 		op.add(Builder::completionSize, JsonpDeserializer.stringDeserializer(), "completion.size", "cs",
 				"completionSize");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/DeleteComponentTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/DeleteComponentTemplateRequest.java
@@ -58,8 +58,12 @@ import javax.annotation.Nullable;
  */
 
 public class DeleteComponentTemplateRequest extends RequestBase {
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String name;
 
@@ -71,6 +75,7 @@ public class DeleteComponentTemplateRequest extends RequestBase {
 	private DeleteComponentTemplateRequest(Builder builder) {
 
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
 		this.timeout = builder.timeout;
 
@@ -86,9 +91,20 @@ public class DeleteComponentTemplateRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -117,8 +133,12 @@ public class DeleteComponentTemplateRequest extends RequestBase {
 	 */
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteComponentTemplateRequest> {
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String name;
 
@@ -130,6 +150,7 @@ public class DeleteComponentTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -140,8 +161,28 @@ public class DeleteComponentTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -224,6 +265,9 @@ public class DeleteComponentTemplateRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/ExistsComponentTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/ExistsComponentTemplateRequest.java
@@ -65,8 +65,12 @@ public class ExistsComponentTemplateRequest extends RequestBase {
 	@Nullable
 	private final Boolean local;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<String> name;
 
@@ -76,6 +80,7 @@ public class ExistsComponentTemplateRequest extends RequestBase {
 
 		this.local = builder.local;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.unmodifiableRequired(builder.name, this, "name");
 
 	}
@@ -87,7 +92,7 @@ public class ExistsComponentTemplateRequest extends RequestBase {
 
 	/**
 	 * If true, the request retrieves information from the local node only. Defaults
-	 * to false, which means information is retrieved from the master node.
+	 * to false, which means information is retrieved from the cluster-manager node.
 	 * <p>
 	 * API name: {@code local}
 	 */
@@ -102,9 +107,21 @@ public class ExistsComponentTemplateRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -127,14 +144,18 @@ public class ExistsComponentTemplateRequest extends RequestBase {
 		@Nullable
 		private Boolean local;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private List<String> name;
 
 		/**
 		 * If true, the request retrieves information from the local node only. Defaults
-		 * to false, which means information is retrieved from the master node.
+		 * to false, which means information is retrieved from the cluster-manager node.
 		 * <p>
 		 * API name: {@code local}
 		 */
@@ -149,6 +170,7 @@ public class ExistsComponentTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -160,8 +182,30 @@ public class ExistsComponentTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -241,6 +285,9 @@ public class ExistsComponentTemplateRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.local != null) {
 					params.put("local", String.valueOf(request.local));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/GetClusterSettingsRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/GetClusterSettingsRequest.java
@@ -63,8 +63,12 @@ public class GetClusterSettingsRequest extends RequestBase {
 	@Nullable
 	private final Boolean includeDefaults;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Time timeout;
@@ -76,6 +80,7 @@ public class GetClusterSettingsRequest extends RequestBase {
 		this.flatSettings = builder.flatSettings;
 		this.includeDefaults = builder.includeDefaults;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.timeout = builder.timeout;
 
 	}
@@ -109,9 +114,20 @@ public class GetClusterSettingsRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -137,8 +153,12 @@ public class GetClusterSettingsRequest extends RequestBase {
 		@Nullable
 		private Boolean includeDefaults;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Time timeout;
@@ -168,6 +188,7 @@ public class GetClusterSettingsRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -178,8 +199,28 @@ public class GetClusterSettingsRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -238,6 +279,9 @@ public class GetClusterSettingsRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.flatSettings != null) {
 					params.put("flat_settings", String.valueOf(request.flatSettings));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/GetComponentTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/GetComponentTemplateRequest.java
@@ -63,8 +63,12 @@ public class GetComponentTemplateRequest extends RequestBase {
 	@Nullable
 	private final Boolean local;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final String name;
@@ -76,6 +80,7 @@ public class GetComponentTemplateRequest extends RequestBase {
 		this.flatSettings = builder.flatSettings;
 		this.local = builder.local;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = builder.name;
 
 	}
@@ -108,9 +113,20 @@ public class GetComponentTemplateRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -136,8 +152,12 @@ public class GetComponentTemplateRequest extends RequestBase {
 		@Nullable
 		private Boolean local;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private String name;
@@ -166,6 +186,7 @@ public class GetComponentTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -176,8 +197,28 @@ public class GetComponentTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -247,6 +288,9 @@ public class GetComponentTemplateRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.flatSettings != null) {
 					params.put("flat_settings", String.valueOf(request.flatSettings));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/HealthRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/HealthRequest.java
@@ -75,8 +75,12 @@ public class HealthRequest extends RequestBase {
 	@Nullable
 	private final Boolean local;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Time timeout;
@@ -108,6 +112,7 @@ public class HealthRequest extends RequestBase {
 		this.level = builder.level;
 		this.local = builder.local;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.timeout = builder.timeout;
 		this.waitForActiveShards = builder.waitForActiveShards;
 		this.waitForEvents = builder.waitForEvents;
@@ -156,7 +161,7 @@ public class HealthRequest extends RequestBase {
 
 	/**
 	 * If true, the request retrieves information from the local node only. Defaults
-	 * to false, which means information is retrieved from the master node.
+	 * to false, which means information is retrieved from the cluster-manager node.
 	 * <p>
 	 * API name: {@code local}
 	 */
@@ -171,9 +176,21 @@ public class HealthRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -276,8 +293,12 @@ public class HealthRequest extends RequestBase {
 		@Nullable
 		private Boolean local;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Time timeout;
@@ -367,7 +388,7 @@ public class HealthRequest extends RequestBase {
 
 		/**
 		 * If true, the request retrieves information from the local node only. Defaults
-		 * to false, which means information is retrieved from the master node.
+		 * to false, which means information is retrieved from the cluster-manager node.
 		 * <p>
 		 * API name: {@code local}
 		 */
@@ -382,6 +403,7 @@ public class HealthRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -393,8 +415,30 @@ public class HealthRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -557,6 +601,9 @@ public class HealthRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (ApiTypeHelper.isDefined(request.expandWildcards)) {
 					params.put("expand_wildcards",

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/PendingTasksRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/PendingTasksRequest.java
@@ -61,8 +61,12 @@ public class PendingTasksRequest extends RequestBase {
 	@Nullable
 	private final Boolean local;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	// ---------------------------------------------------------------------------------------------
 
@@ -70,6 +74,7 @@ public class PendingTasksRequest extends RequestBase {
 
 		this.local = builder.local;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 
 	}
 
@@ -78,7 +83,7 @@ public class PendingTasksRequest extends RequestBase {
 	}
 
 	/**
-	 * Return local information, do not retrieve the state from master node
+	 * Return local information, do not retrieve the state from cluster-manager node
 	 * (default: false)
 	 * <p>
 	 * API name: {@code local}
@@ -93,9 +98,20 @@ public class PendingTasksRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	// ---------------------------------------------------------------------------------------------
@@ -108,11 +124,15 @@ public class PendingTasksRequest extends RequestBase {
 		@Nullable
 		private Boolean local;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
 
+		@Nullable
+		private Time clusterManagerTimeout;
+
 		/**
-		 * Return local information, do not retrieve the state from master node
+		 * Return local information, do not retrieve the state from cluster-manager node
 		 * (default: false)
 		 * <p>
 		 * API name: {@code local}
@@ -127,6 +147,7 @@ public class PendingTasksRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -137,8 +158,28 @@ public class PendingTasksRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -178,6 +219,9 @@ public class PendingTasksRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.local != null) {
 					params.put("local", String.valueOf(request.local));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/PutClusterSettingsRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/PutClusterSettingsRequest.java
@@ -68,8 +68,12 @@ public class PutClusterSettingsRequest extends RequestBase implements JsonpSeria
 	@Nullable
 	private final Boolean flatSettings;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final Map<String, JsonData> persistent;
 
@@ -84,6 +88,7 @@ public class PutClusterSettingsRequest extends RequestBase implements JsonpSeria
 
 		this.flatSettings = builder.flatSettings;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.persistent = ApiTypeHelper.unmodifiable(builder.persistent);
 		this.timeout = builder.timeout;
 		this.transient_ = ApiTypeHelper.unmodifiable(builder.transient_);
@@ -109,9 +114,20 @@ public class PutClusterSettingsRequest extends RequestBase implements JsonpSeria
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -184,8 +200,12 @@ public class PutClusterSettingsRequest extends RequestBase implements JsonpSeria
 		@Nullable
 		private Boolean flatSettings;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Map<String, JsonData> persistent;
@@ -223,6 +243,25 @@ public class PutClusterSettingsRequest extends RequestBase implements JsonpSeria
 		 */
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -337,6 +376,9 @@ public class PutClusterSettingsRequest extends RequestBase implements JsonpSeria
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.flatSettings != null) {
 					params.put("flat_settings", String.valueOf(request.flatSettings));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/PutComponentTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/PutComponentTemplateRequest.java
@@ -80,8 +80,12 @@ public class PutComponentTemplateRequest extends RequestBase implements JsonpSer
 	@Nullable
 	private final TypeMapping mappings;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String name;
 
@@ -102,6 +106,7 @@ public class PutComponentTemplateRequest extends RequestBase implements JsonpSer
 		this.create = builder.create;
 		this.mappings = builder.mappings;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
 		this.settings = builder.settings;
 		this.template = ApiTypeHelper.requireNonNull(builder.template, this, "template");
@@ -151,9 +156,20 @@ public class PutComponentTemplateRequest extends RequestBase implements JsonpSer
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -261,8 +277,12 @@ public class PutComponentTemplateRequest extends RequestBase implements JsonpSer
 		@Nullable
 		private TypeMapping mappings;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String name;
 
@@ -354,6 +374,7 @@ public class PutComponentTemplateRequest extends RequestBase implements JsonpSer
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -364,8 +385,28 @@ public class PutComponentTemplateRequest extends RequestBase implements JsonpSer
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -487,6 +528,9 @@ public class PutComponentTemplateRequest extends RequestBase implements JsonpSer
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.create != null) {
 					params.put("create", String.valueOf(request.create));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/RerouteRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/RerouteRequest.java
@@ -76,8 +76,12 @@ public class RerouteRequest extends RequestBase implements JsonpSerializable {
 	@Nullable
 	private final Boolean explain;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<String> metric;
 
@@ -95,6 +99,7 @@ public class RerouteRequest extends RequestBase implements JsonpSerializable {
 		this.dryRun = builder.dryRun;
 		this.explain = builder.explain;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.metric = ApiTypeHelper.unmodifiable(builder.metric);
 		this.retryFailed = builder.retryFailed;
 		this.timeout = builder.timeout;
@@ -142,9 +147,21 @@ public class RerouteRequest extends RequestBase implements JsonpSerializable {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_amanger_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -218,8 +235,12 @@ public class RerouteRequest extends RequestBase implements JsonpSerializable {
 		@Nullable
 		private Boolean explain;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private List<String> metric;
@@ -293,6 +314,7 @@ public class RerouteRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -304,8 +326,30 @@ public class RerouteRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -418,6 +462,9 @@ public class RerouteRequest extends RequestBase implements JsonpSerializable {
 				}
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_mamager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (ApiTypeHelper.isDefined(request.metric)) {
 					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/StateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/StateRequest.java
@@ -77,8 +77,12 @@ public class StateRequest extends RequestBase {
 	@Nullable
 	private final Boolean local;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<String> metric;
 
@@ -99,6 +103,7 @@ public class StateRequest extends RequestBase {
 		this.index = ApiTypeHelper.unmodifiable(builder.index);
 		this.local = builder.local;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.metric = ApiTypeHelper.unmodifiable(builder.metric);
 		this.waitForMetadataVersion = builder.waitForMetadataVersion;
 		this.waitForTimeout = builder.waitForTimeout;
@@ -163,7 +168,7 @@ public class StateRequest extends RequestBase {
 	}
 
 	/**
-	 * Return local information, do not retrieve the state from master node
+	 * Return local information, do not retrieve the state from cluster-manager node
 	 * (default: false)
 	 * <p>
 	 * API name: {@code local}
@@ -178,9 +183,20 @@ public class StateRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -238,8 +254,12 @@ public class StateRequest extends RequestBase {
 		@Nullable
 		private Boolean local;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private List<String> metric;
@@ -336,7 +356,7 @@ public class StateRequest extends RequestBase {
 		}
 
 		/**
-		 * Return local information, do not retrieve the state from master node
+		 * Return local information, do not retrieve the state from cluster-manager node
 		 * (default: false)
 		 * <p>
 		 * API name: {@code local}
@@ -351,6 +371,7 @@ public class StateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -361,8 +382,28 @@ public class StateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -492,6 +533,9 @@ public class StateRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.flatSettings != null) {
 					params.put("flat_settings", String.valueOf(request.flatSettings));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/stats/ClusterNodeCount.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/stats/ClusterNodeCount.java
@@ -60,7 +60,7 @@ public class ClusterNodeCount implements JsonpSerializable {
 
 	private final int ingest;
 
-	private final int master;
+	private final int clusterManager;
 
 	private final int total;
 
@@ -90,7 +90,7 @@ public class ClusterNodeCount implements JsonpSerializable {
 		this.coordinatingOnly = ApiTypeHelper.requireNonNull(builder.coordinatingOnly, this, "coordinatingOnly");
 		this.data = ApiTypeHelper.requireNonNull(builder.data, this, "data");
 		this.ingest = ApiTypeHelper.requireNonNull(builder.ingest, this, "ingest");
-		this.master = ApiTypeHelper.requireNonNull(builder.master, this, "master");
+		this.clusterManager = ApiTypeHelper.requireNonNull(builder.clusterManager, this, "clusterManager");
 		this.total = ApiTypeHelper.requireNonNull(builder.total, this, "total");
 		this.votingOnly = ApiTypeHelper.requireNonNull(builder.votingOnly, this, "votingOnly");
 		this.dataCold = ApiTypeHelper.requireNonNull(builder.dataCold, this, "dataCold");
@@ -131,10 +131,10 @@ public class ClusterNodeCount implements JsonpSerializable {
 	}
 
 	/**
-	 * Required - API name: {@code master}
+	 * Required - API name: {@code clusterManager}
 	 */
-	public final int master() {
-		return this.master;
+	public final int clusterManager() {
+		return this.clusterManager;
 	}
 
 	/**
@@ -228,8 +228,8 @@ public class ClusterNodeCount implements JsonpSerializable {
 		generator.writeKey("ingest");
 		generator.write(this.ingest);
 
-		generator.writeKey("master");
-		generator.write(this.master);
+		generator.writeKey("cluster_manager");
+		generator.write(this.clusterManager);
 
 		generator.writeKey("total");
 		generator.write(this.total);
@@ -278,7 +278,7 @@ public class ClusterNodeCount implements JsonpSerializable {
 
 		private Integer ingest;
 
-		private Integer master;
+		private Integer clusterManager;
 
 		private Integer total;
 
@@ -326,10 +326,10 @@ public class ClusterNodeCount implements JsonpSerializable {
 		}
 
 		/**
-		 * Required - API name: {@code master}
+		 * Required - API name: {@code clusterManager}
 		 */
-		public final Builder master(int value) {
-			this.master = value;
+		public final Builder clusterManager(int value) {
+			this.clusterManager = value;
 			return this;
 		}
 
@@ -439,7 +439,7 @@ public class ClusterNodeCount implements JsonpSerializable {
 		op.add(Builder::coordinatingOnly, JsonpDeserializer.integerDeserializer(), "coordinating_only");
 		op.add(Builder::data, JsonpDeserializer.integerDeserializer(), "data");
 		op.add(Builder::ingest, JsonpDeserializer.integerDeserializer(), "ingest");
-		op.add(Builder::master, JsonpDeserializer.integerDeserializer(), "master");
+		op.add(Builder::clusterManager, JsonpDeserializer.integerDeserializer(), "cluster_manager");
 		op.add(Builder::total, JsonpDeserializer.integerDeserializer(), "total");
 		op.add(Builder::votingOnly, JsonpDeserializer.integerDeserializer(), "voting_only");
 		op.add(Builder::dataCold, JsonpDeserializer.integerDeserializer(), "data_cold");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/DeleteScriptRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/DeleteScriptRequest.java
@@ -60,8 +60,12 @@ import javax.annotation.Nullable;
 public class DeleteScriptRequest extends RequestBase {
 	private final String id;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Time timeout;
@@ -72,6 +76,7 @@ public class DeleteScriptRequest extends RequestBase {
 
 		this.id = ApiTypeHelper.requireNonNull(builder.id, this, "id");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.timeout = builder.timeout;
 
 	}
@@ -100,6 +105,16 @@ public class DeleteScriptRequest extends RequestBase {
 	}
 
 	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
+	}
+
+	/**
 	 * Explicit operation timeout
 	 * <p>
 	 * API name: {@code timeout}
@@ -118,8 +133,12 @@ public class DeleteScriptRequest extends RequestBase {
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteScriptRequest> {
 		private String id;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Time timeout;
@@ -139,6 +158,7 @@ public class DeleteScriptRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -149,8 +169,28 @@ public class DeleteScriptRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -222,6 +262,9 @@ public class DeleteScriptRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/GetScriptRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/GetScriptRequest.java
@@ -60,8 +60,12 @@ import javax.annotation.Nullable;
 public class GetScriptRequest extends RequestBase {
 	private final String id;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	// ---------------------------------------------------------------------------------------------
 
@@ -69,6 +73,7 @@ public class GetScriptRequest extends RequestBase {
 
 		this.id = ApiTypeHelper.requireNonNull(builder.id, this, "id");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 
 	}
 
@@ -90,9 +95,20 @@ public class GetScriptRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	// ---------------------------------------------------------------------------------------------
@@ -104,8 +120,12 @@ public class GetScriptRequest extends RequestBase {
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetScriptRequest> {
 		private String id;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		/**
 		 * Required - Script ID
@@ -122,6 +142,7 @@ public class GetScriptRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -132,8 +153,28 @@ public class GetScriptRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -186,6 +227,9 @@ public class GetScriptRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				return params;
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/PutScriptRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/PutScriptRequest.java
@@ -71,8 +71,12 @@ public class PutScriptRequest extends RequestBase implements JsonpSerializable {
 
 	private final String id;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final StoredScript script;
 
@@ -86,6 +90,7 @@ public class PutScriptRequest extends RequestBase implements JsonpSerializable {
 		this.context = builder.context;
 		this.id = ApiTypeHelper.requireNonNull(builder.id, this, "id");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.script = ApiTypeHelper.requireNonNull(builder.script, this, "script");
 		this.timeout = builder.timeout;
 
@@ -119,9 +124,20 @@ public class PutScriptRequest extends RequestBase implements JsonpSerializable {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -169,8 +185,12 @@ public class PutScriptRequest extends RequestBase implements JsonpSerializable {
 
 		private String id;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private StoredScript script;
 
@@ -202,6 +222,7 @@ public class PutScriptRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -212,8 +233,28 @@ public class PutScriptRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -326,6 +367,9 @@ public class PutScriptRequest extends RequestBase implements JsonpSerializable {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchShardsRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchShardsRequest.java
@@ -142,7 +142,7 @@ public class SearchShardsRequest extends RequestBase {
 	}
 
 	/**
-	 * Return local information, do not retrieve the state from master node
+	 * Return local information, do not retrieve the state from cluster-manager node
 	 * (default: false)
 	 * <p>
 	 * API name: {@code local}
@@ -277,7 +277,7 @@ public class SearchShardsRequest extends RequestBase {
 		}
 
 		/**
-		 * Return local information, do not retrieve the state from master node
+		 * Return local information, do not retrieve the state from cluster-manager node
 		 * (default: false)
 		 * <p>
 		 * API name: {@code local}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/dangling_indices/DeleteDanglingIndexRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/dangling_indices/DeleteDanglingIndexRequest.java
@@ -62,8 +62,12 @@ public class DeleteDanglingIndexRequest extends RequestBase {
 
 	private final String indexUuid;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Time timeout;
@@ -75,6 +79,7 @@ public class DeleteDanglingIndexRequest extends RequestBase {
 		this.acceptDataLoss = ApiTypeHelper.requireNonNull(builder.acceptDataLoss, this, "acceptDataLoss");
 		this.indexUuid = ApiTypeHelper.requireNonNull(builder.indexUuid, this, "indexUuid");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.timeout = builder.timeout;
 
 	}
@@ -112,6 +117,16 @@ public class DeleteDanglingIndexRequest extends RequestBase {
 	}
 
 	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
+	}
+
+	/**
 	 * Explicit operation timeout
 	 * <p>
 	 * API name: {@code timeout}
@@ -132,8 +147,12 @@ public class DeleteDanglingIndexRequest extends RequestBase {
 
 		private String indexUuid;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Time timeout;
@@ -163,6 +182,7 @@ public class DeleteDanglingIndexRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -173,8 +193,28 @@ public class DeleteDanglingIndexRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -247,6 +287,9 @@ public class DeleteDanglingIndexRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				params.put("accept_data_loss", String.valueOf(request.acceptDataLoss));
 				if (request.timeout != null) {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/dangling_indices/ImportDanglingIndexRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/dangling_indices/ImportDanglingIndexRequest.java
@@ -62,8 +62,12 @@ public class ImportDanglingIndexRequest extends RequestBase {
 
 	private final String indexUuid;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Time timeout;
@@ -75,6 +79,7 @@ public class ImportDanglingIndexRequest extends RequestBase {
 		this.acceptDataLoss = ApiTypeHelper.requireNonNull(builder.acceptDataLoss, this, "acceptDataLoss");
 		this.indexUuid = ApiTypeHelper.requireNonNull(builder.indexUuid, this, "indexUuid");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.timeout = builder.timeout;
 
 	}
@@ -106,9 +111,20 @@ public class ImportDanglingIndexRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -132,8 +148,12 @@ public class ImportDanglingIndexRequest extends RequestBase {
 
 		private String indexUuid;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Time timeout;
@@ -163,6 +183,7 @@ public class ImportDanglingIndexRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -173,8 +194,28 @@ public class ImportDanglingIndexRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -247,6 +288,9 @@ public class ImportDanglingIndexRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				params.put("accept_data_loss", String.valueOf(request.acceptDataLoss));
 				if (request.timeout != null) {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/AddBlockRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/AddBlockRequest.java
@@ -74,8 +74,12 @@ public class AddBlockRequest extends RequestBase {
 
 	private final String index;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Time timeout;
@@ -90,6 +94,7 @@ public class AddBlockRequest extends RequestBase {
 		this.ignoreUnavailable = builder.ignoreUnavailable;
 		this.index = ApiTypeHelper.requireNonNull(builder.index, this, "index");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.timeout = builder.timeout;
 
 	}
@@ -154,9 +159,20 @@ public class AddBlockRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -189,8 +205,12 @@ public class AddBlockRequest extends RequestBase {
 
 		private String index;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Time timeout;
@@ -269,6 +289,7 @@ public class AddBlockRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -279,8 +300,28 @@ public class AddBlockRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -356,6 +397,9 @@ public class AddBlockRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (ApiTypeHelper.isDefined(request.expandWildcards)) {
 					params.put("expand_wildcards",

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/CloneIndexRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/CloneIndexRequest.java
@@ -70,8 +70,12 @@ public class CloneIndexRequest extends RequestBase implements JsonpSerializable 
 
 	private final String index;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final Map<String, JsonData> settings;
 
@@ -90,6 +94,7 @@ public class CloneIndexRequest extends RequestBase implements JsonpSerializable 
 		this.aliases = ApiTypeHelper.unmodifiable(builder.aliases);
 		this.index = ApiTypeHelper.requireNonNull(builder.index, this, "index");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.settings = ApiTypeHelper.unmodifiable(builder.settings);
 		this.target = ApiTypeHelper.requireNonNull(builder.target, this, "target");
 		this.timeout = builder.timeout;
@@ -125,6 +130,16 @@ public class CloneIndexRequest extends RequestBase implements JsonpSerializable 
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -212,8 +227,12 @@ public class CloneIndexRequest extends RequestBase implements JsonpSerializable 
 
 		private String index;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Map<String, JsonData> settings;
@@ -270,6 +289,7 @@ public class CloneIndexRequest extends RequestBase implements JsonpSerializable 
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -280,8 +300,28 @@ public class CloneIndexRequest extends RequestBase implements JsonpSerializable 
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -424,6 +464,9 @@ public class CloneIndexRequest extends RequestBase implements JsonpSerializable 
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.waitForActiveShards != null) {
 					params.put("wait_for_active_shards", request.waitForActiveShards._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/CloseIndexRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/CloseIndexRequest.java
@@ -72,8 +72,12 @@ public class CloseIndexRequest extends RequestBase {
 
 	private final List<String> index;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Time timeout;
@@ -90,6 +94,7 @@ public class CloseIndexRequest extends RequestBase {
 		this.ignoreUnavailable = builder.ignoreUnavailable;
 		this.index = ApiTypeHelper.unmodifiableRequired(builder.index, this, "index");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.timeout = builder.timeout;
 		this.waitForActiveShards = builder.waitForActiveShards;
 
@@ -146,9 +151,20 @@ public class CloseIndexRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -192,8 +208,12 @@ public class CloseIndexRequest extends RequestBase {
 
 		private List<String> index;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Time timeout;
@@ -279,6 +299,7 @@ public class CloseIndexRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -289,8 +310,28 @@ public class CloseIndexRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -388,6 +429,9 @@ public class CloseIndexRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (ApiTypeHelper.isDefined(request.expandWildcards)) {
 					params.put("expand_wildcards",

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/CreateIndexRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/CreateIndexRequest.java
@@ -73,8 +73,12 @@ public class CreateIndexRequest extends RequestBase implements JsonpSerializable
 	@Nullable
 	private final TypeMapping mappings;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final IndexSettings settings;
@@ -93,6 +97,7 @@ public class CreateIndexRequest extends RequestBase implements JsonpSerializable
 		this.index = ApiTypeHelper.requireNonNull(builder.index, this, "index");
 		this.mappings = builder.mappings;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.settings = builder.settings;
 		this.timeout = builder.timeout;
 		this.waitForActiveShards = builder.waitForActiveShards;
@@ -139,9 +144,20 @@ public class CreateIndexRequest extends RequestBase implements JsonpSerializable
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -222,8 +238,12 @@ public class CreateIndexRequest extends RequestBase implements JsonpSerializable
 		@Nullable
 		private TypeMapping mappings;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private IndexSettings settings;
@@ -307,6 +327,7 @@ public class CreateIndexRequest extends RequestBase implements JsonpSerializable
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -317,8 +338,28 @@ public class CreateIndexRequest extends RequestBase implements JsonpSerializable
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -440,6 +481,9 @@ public class CreateIndexRequest extends RequestBase implements JsonpSerializable
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.waitForActiveShards != null) {
 					params.put("wait_for_active_shards", request.waitForActiveShards._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/DeleteAliasRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/DeleteAliasRequest.java
@@ -62,8 +62,12 @@ import javax.annotation.Nullable;
 public class DeleteAliasRequest extends RequestBase {
 	private final List<String> index;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<String> name;
 
@@ -76,6 +80,7 @@ public class DeleteAliasRequest extends RequestBase {
 
 		this.index = ApiTypeHelper.unmodifiableRequired(builder.index, this, "index");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.unmodifiableRequired(builder.name, this, "name");
 		this.timeout = builder.timeout;
 
@@ -100,9 +105,20 @@ public class DeleteAliasRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -134,8 +150,12 @@ public class DeleteAliasRequest extends RequestBase {
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteAliasRequest> {
 		private List<String> index;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private List<String> name;
 
@@ -173,6 +193,7 @@ public class DeleteAliasRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -183,8 +204,28 @@ public class DeleteAliasRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -295,6 +336,9 @@ public class DeleteAliasRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/DeleteIndexRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/DeleteIndexRequest.java
@@ -71,8 +71,12 @@ public class DeleteIndexRequest extends RequestBase {
 
 	private final List<String> index;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Time timeout;
@@ -86,6 +90,7 @@ public class DeleteIndexRequest extends RequestBase {
 		this.ignoreUnavailable = builder.ignoreUnavailable;
 		this.index = ApiTypeHelper.unmodifiableRequired(builder.index, this, "index");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.timeout = builder.timeout;
 
 	}
@@ -140,9 +145,20 @@ public class DeleteIndexRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -173,8 +189,12 @@ public class DeleteIndexRequest extends RequestBase {
 
 		private List<String> index;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Time timeout;
@@ -257,6 +277,7 @@ public class DeleteIndexRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -267,8 +288,28 @@ public class DeleteIndexRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -339,6 +380,9 @@ public class DeleteIndexRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (ApiTypeHelper.isDefined(request.expandWildcards)) {
 					params.put("expand_wildcards",

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/DeleteTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/DeleteTemplateRequest.java
@@ -58,8 +58,12 @@ import javax.annotation.Nullable;
  */
 
 public class DeleteTemplateRequest extends RequestBase {
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String name;
 
@@ -71,6 +75,7 @@ public class DeleteTemplateRequest extends RequestBase {
 	private DeleteTemplateRequest(Builder builder) {
 
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
 		this.timeout = builder.timeout;
 
@@ -85,9 +90,20 @@ public class DeleteTemplateRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -116,8 +132,12 @@ public class DeleteTemplateRequest extends RequestBase {
 	 */
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteTemplateRequest> {
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String name;
 
@@ -129,6 +149,7 @@ public class DeleteTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -139,8 +160,28 @@ public class DeleteTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -222,6 +263,9 @@ public class DeleteTemplateRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/DiskUsageRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/DiskUsageRequest.java
@@ -74,8 +74,12 @@ public class DiskUsageRequest extends RequestBase {
 
 	private final String index;
 
+	@Deprecated
 	@Nullable
 	private final TimeUnit masterTimeout;
+
+	@Nullable
+	private final TimeUnit clusterManagerTimeout;
 
 	@Nullable
 	private final Boolean runExpensiveTasks;
@@ -96,6 +100,7 @@ public class DiskUsageRequest extends RequestBase {
 		this.ignoreUnavailable = builder.ignoreUnavailable;
 		this.index = ApiTypeHelper.requireNonNull(builder.index, this, "index");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.runExpensiveTasks = builder.runExpensiveTasks;
 		this.timeout = builder.timeout;
 		this.waitForActiveShards = builder.waitForActiveShards;
@@ -170,9 +175,21 @@ public class DiskUsageRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final TimeUnit masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final TimeUnit clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -230,8 +247,12 @@ public class DiskUsageRequest extends RequestBase {
 
 		private String index;
 
+		@Deprecated
 		@Nullable
 		private TimeUnit masterTimeout;
+
+		@Nullable
+		private TimeUnit clusterManagerTimeout;
 
 		@Nullable
 		private Boolean runExpensiveTasks;
@@ -324,8 +345,20 @@ public class DiskUsageRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable TimeUnit value) {
 			this.masterTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable TimeUnit value) {
+			this.clusterManagerTimeout = value;
 			return this;
 		}
 
@@ -413,6 +446,9 @@ public class DiskUsageRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout.jsonValue());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout.jsonValue());
 				}
 				if (request.flush != null) {
 					params.put("flush", String.valueOf(request.flush));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/ExistsAliasRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/ExistsAliasRequest.java
@@ -137,7 +137,7 @@ public class ExistsAliasRequest extends RequestBase {
 	}
 
 	/**
-	 * Return local information, do not retrieve the state from master node
+	 * Return local information, do not retrieve the state from cluster-manager node
 	 * (default: false)
 	 * <p>
 	 * API name: {@code local}
@@ -254,7 +254,7 @@ public class ExistsAliasRequest extends RequestBase {
 		}
 
 		/**
-		 * Return local information, do not retrieve the state from master node
+		 * Return local information, do not retrieve the state from cluster-manager node
 		 * (default: false)
 		 * <p>
 		 * API name: {@code local}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/ExistsIndexTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/ExistsIndexTemplateRequest.java
@@ -60,8 +60,12 @@ import javax.annotation.Nullable;
  */
 
 public class ExistsIndexTemplateRequest extends RequestBase {
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String name;
 
@@ -70,6 +74,7 @@ public class ExistsIndexTemplateRequest extends RequestBase {
 	private ExistsIndexTemplateRequest(Builder builder) {
 
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
 
 	}
@@ -84,9 +89,21 @@ public class ExistsIndexTemplateRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -106,8 +123,12 @@ public class ExistsIndexTemplateRequest extends RequestBase {
 	 */
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ExistsIndexTemplateRequest> {
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String name;
 
@@ -117,6 +138,7 @@ public class ExistsIndexTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -128,8 +150,30 @@ public class ExistsIndexTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -194,6 +238,9 @@ public class ExistsIndexTemplateRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				return params;
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/ExistsRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/ExistsRequest.java
@@ -160,7 +160,7 @@ public class ExistsRequest extends RequestBase {
 	}
 
 	/**
-	 * Return local information, do not retrieve the state from master node
+	 * Return local information, do not retrieve the state from cluster-manager node
 	 * (default: false)
 	 * <p>
 	 * API name: {@code local}
@@ -289,7 +289,7 @@ public class ExistsRequest extends RequestBase {
 		}
 
 		/**
-		 * Return local information, do not retrieve the state from master node
+		 * Return local information, do not retrieve the state from cluster-manager node
 		 * (default: false)
 		 * <p>
 		 * API name: {@code local}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/ExistsTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/ExistsTemplateRequest.java
@@ -68,8 +68,12 @@ public class ExistsTemplateRequest extends RequestBase {
 	@Nullable
 	private final Boolean local;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<String> name;
 
@@ -80,6 +84,7 @@ public class ExistsTemplateRequest extends RequestBase {
 		this.flatSettings = builder.flatSettings;
 		this.local = builder.local;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.unmodifiableRequired(builder.name, this, "name");
 
 	}
@@ -99,7 +104,7 @@ public class ExistsTemplateRequest extends RequestBase {
 	}
 
 	/**
-	 * Return local information, do not retrieve the state from master node
+	 * Return local information, do not retrieve the state from cluster-manager node
 	 * (default: false)
 	 * <p>
 	 * API name: {@code local}
@@ -114,9 +119,20 @@ public class ExistsTemplateRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -141,8 +157,12 @@ public class ExistsTemplateRequest extends RequestBase {
 		@Nullable
 		private Boolean local;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private List<String> name;
 
@@ -157,7 +177,7 @@ public class ExistsTemplateRequest extends RequestBase {
 		}
 
 		/**
-		 * Return local information, do not retrieve the state from master node
+		 * Return local information, do not retrieve the state from cluster-manager node
 		 * (default: false)
 		 * <p>
 		 * API name: {@code local}
@@ -172,6 +192,7 @@ public class ExistsTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -182,8 +203,28 @@ public class ExistsTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -261,6 +302,9 @@ public class ExistsTemplateRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.flatSettings != null) {
 					params.put("flat_settings", String.valueOf(request.flatSettings));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetAliasRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetAliasRequest.java
@@ -135,7 +135,7 @@ public class GetAliasRequest extends RequestBase {
 	}
 
 	/**
-	 * Return local information, do not retrieve the state from master node
+	 * Return local information, do not retrieve the state from cluster-manager node
 	 * (default: false)
 	 * <p>
 	 * API name: {@code local}
@@ -253,7 +253,7 @@ public class GetAliasRequest extends RequestBase {
 		}
 
 		/**
-		 * Return local information, do not retrieve the state from master node
+		 * Return local information, do not retrieve the state from cluster-manager node
 		 * (default: false)
 		 * <p>
 		 * API name: {@code local}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetFieldMappingRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetFieldMappingRequest.java
@@ -158,7 +158,7 @@ public class GetFieldMappingRequest extends RequestBase {
 	}
 
 	/**
-	 * Return local information, do not retrieve the state from master node
+	 * Return local information, do not retrieve the state from cluster-manager node
 	 * (default: false)
 	 * <p>
 	 * API name: {@code local}
@@ -303,7 +303,7 @@ public class GetFieldMappingRequest extends RequestBase {
 		}
 
 		/**
-		 * Return local information, do not retrieve the state from master node
+		 * Return local information, do not retrieve the state from cluster-manager node
 		 * (default: false)
 		 * <p>
 		 * API name: {@code local}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetIndexRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetIndexRequest.java
@@ -80,8 +80,12 @@ public class GetIndexRequest extends RequestBase {
 	@Nullable
 	private final Boolean local;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	// ---------------------------------------------------------------------------------------------
 
@@ -95,6 +99,7 @@ public class GetIndexRequest extends RequestBase {
 		this.index = ApiTypeHelper.unmodifiableRequired(builder.index, this, "index");
 		this.local = builder.local;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 
 	}
 
@@ -166,7 +171,7 @@ public class GetIndexRequest extends RequestBase {
 
 	/**
 	 * If true, the request retrieves information from the local node only. Defaults
-	 * to false, which means information is retrieved from the master node.
+	 * to false, which means information is retrieved from the cluster-manager node.
 	 * <p>
 	 * API name: {@code local}
 	 */
@@ -181,9 +186,21 @@ public class GetIndexRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	// ---------------------------------------------------------------------------------------------
@@ -213,8 +230,12 @@ public class GetIndexRequest extends RequestBase {
 		@Nullable
 		private Boolean local;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		/**
 		 * Ignore if a wildcard expression resolves to no concrete indices (default:
@@ -313,7 +334,7 @@ public class GetIndexRequest extends RequestBase {
 
 		/**
 		 * If true, the request retrieves information from the local node only. Defaults
-		 * to false, which means information is retrieved from the master node.
+		 * to false, which means information is retrieved from the cluster-manager node.
 		 * <p>
 		 * API name: {@code local}
 		 */
@@ -328,6 +349,7 @@ public class GetIndexRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -339,8 +361,30 @@ public class GetIndexRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -392,6 +436,9 @@ public class GetIndexRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.flatSettings != null) {
 					params.put("flat_settings", String.valueOf(request.flatSettings));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetIndexTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetIndexTemplateRequest.java
@@ -63,8 +63,12 @@ public class GetIndexTemplateRequest extends RequestBase {
 	@Nullable
 	private final Boolean local;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final String name;
@@ -76,6 +80,7 @@ public class GetIndexTemplateRequest extends RequestBase {
 		this.flatSettings = builder.flatSettings;
 		this.local = builder.local;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = builder.name;
 
 	}
@@ -96,7 +101,7 @@ public class GetIndexTemplateRequest extends RequestBase {
 
 	/**
 	 * If true, the request retrieves information from the local node only. Defaults
-	 * to false, which means information is retrieved from the master node.
+	 * to false, which means information is retrieved from the cluster-manager node.
 	 * <p>
 	 * API name: {@code local}
 	 */
@@ -111,9 +116,21 @@ public class GetIndexTemplateRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -140,8 +157,12 @@ public class GetIndexTemplateRequest extends RequestBase {
 		@Nullable
 		private Boolean local;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private String name;
@@ -158,7 +179,7 @@ public class GetIndexTemplateRequest extends RequestBase {
 
 		/**
 		 * If true, the request retrieves information from the local node only. Defaults
-		 * to false, which means information is retrieved from the master node.
+		 * to false, which means information is retrieved from the cluster-manager node.
 		 * <p>
 		 * API name: {@code local}
 		 */
@@ -173,6 +194,7 @@ public class GetIndexTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -184,8 +206,30 @@ public class GetIndexTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -255,6 +299,9 @@ public class GetIndexTemplateRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.flatSettings != null) {
 					params.put("flat_settings", String.valueOf(request.flatSettings));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetIndicesSettingsRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetIndicesSettingsRequest.java
@@ -80,8 +80,12 @@ public class GetIndicesSettingsRequest extends RequestBase {
 	@Nullable
 	private final Boolean local;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<String> name;
 
@@ -97,6 +101,7 @@ public class GetIndicesSettingsRequest extends RequestBase {
 		this.index = ApiTypeHelper.unmodifiable(builder.index);
 		this.local = builder.local;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.unmodifiable(builder.name);
 
 	}
@@ -169,7 +174,7 @@ public class GetIndicesSettingsRequest extends RequestBase {
 	}
 
 	/**
-	 * Return local information, do not retrieve the state from master node
+	 * Return local information, do not retrieve the state from cluster-manager node
 	 * (default: false)
 	 * <p>
 	 * API name: {@code local}
@@ -184,9 +189,20 @@ public class GetIndicesSettingsRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -226,8 +242,12 @@ public class GetIndicesSettingsRequest extends RequestBase {
 		@Nullable
 		private Boolean local;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private List<String> name;
@@ -328,7 +348,7 @@ public class GetIndicesSettingsRequest extends RequestBase {
 		}
 
 		/**
-		 * Return local information, do not retrieve the state from master node
+		 * Return local information, do not retrieve the state from cluster-manager node
 		 * (default: false)
 		 * <p>
 		 * API name: {@code local}
@@ -343,6 +363,7 @@ public class GetIndicesSettingsRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -353,8 +374,28 @@ public class GetIndicesSettingsRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -456,6 +497,9 @@ public class GetIndicesSettingsRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.flatSettings != null) {
 					params.put("flat_settings", String.valueOf(request.flatSettings));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetMappingRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetMappingRequest.java
@@ -74,8 +74,12 @@ public class GetMappingRequest extends RequestBase {
 	@Nullable
 	private final Boolean local;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	// ---------------------------------------------------------------------------------------------
 
@@ -87,6 +91,7 @@ public class GetMappingRequest extends RequestBase {
 		this.index = ApiTypeHelper.unmodifiable(builder.index);
 		this.local = builder.local;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 
 	}
 
@@ -137,7 +142,7 @@ public class GetMappingRequest extends RequestBase {
 	}
 
 	/**
-	 * Return local information, do not retrieve the state from master node
+	 * Return local information, do not retrieve the state from cluster-manager node
 	 * (default: false)
 	 * <p>
 	 * API name: {@code local}
@@ -152,9 +157,20 @@ public class GetMappingRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	// ---------------------------------------------------------------------------------------------
@@ -179,8 +195,12 @@ public class GetMappingRequest extends RequestBase {
 		@Nullable
 		private Boolean local;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		/**
 		 * Whether to ignore if a wildcard indices expression resolves into no concrete
@@ -256,7 +276,7 @@ public class GetMappingRequest extends RequestBase {
 		}
 
 		/**
-		 * Return local information, do not retrieve the state from master node
+		 * Return local information, do not retrieve the state from cluster-manager node
 		 * (default: false)
 		 * <p>
 		 * API name: {@code local}
@@ -271,6 +291,7 @@ public class GetMappingRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -281,8 +302,28 @@ public class GetMappingRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -341,6 +382,9 @@ public class GetMappingRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (ApiTypeHelper.isDefined(request.expandWildcards)) {
 					params.put("expand_wildcards",

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/GetTemplateRequest.java
@@ -66,8 +66,12 @@ public class GetTemplateRequest extends RequestBase {
 	@Nullable
 	private final Boolean local;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<String> name;
 
@@ -78,6 +82,7 @@ public class GetTemplateRequest extends RequestBase {
 		this.flatSettings = builder.flatSettings;
 		this.local = builder.local;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.unmodifiable(builder.name);
 
 	}
@@ -97,7 +102,7 @@ public class GetTemplateRequest extends RequestBase {
 	}
 
 	/**
-	 * Return local information, do not retrieve the state from master node
+	 * Return local information, do not retrieve the state from cluster-manager node
 	 * (default: false)
 	 * <p>
 	 * API name: {@code local}
@@ -112,9 +117,20 @@ public class GetTemplateRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -139,8 +155,12 @@ public class GetTemplateRequest extends RequestBase {
 		@Nullable
 		private Boolean local;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private List<String> name;
@@ -156,7 +176,7 @@ public class GetTemplateRequest extends RequestBase {
 		}
 
 		/**
-		 * Return local information, do not retrieve the state from master node
+		 * Return local information, do not retrieve the state from cluster-manager node
 		 * (default: false)
 		 * <p>
 		 * API name: {@code local}
@@ -171,6 +191,7 @@ public class GetTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -181,8 +202,28 @@ public class GetTemplateRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -265,6 +306,9 @@ public class GetTemplateRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.flatSettings != null) {
 					params.put("flat_settings", String.valueOf(request.flatSettings));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/OpenRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/OpenRequest.java
@@ -72,8 +72,12 @@ public class OpenRequest extends RequestBase {
 
 	private final List<String> index;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Time timeout;
@@ -90,6 +94,7 @@ public class OpenRequest extends RequestBase {
 		this.ignoreUnavailable = builder.ignoreUnavailable;
 		this.index = ApiTypeHelper.unmodifiableRequired(builder.index, this, "index");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.timeout = builder.timeout;
 		this.waitForActiveShards = builder.waitForActiveShards;
 
@@ -146,9 +151,20 @@ public class OpenRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -189,8 +205,12 @@ public class OpenRequest extends RequestBase {
 
 		private List<String> index;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Time timeout;
@@ -276,6 +296,7 @@ public class OpenRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -286,8 +307,28 @@ public class OpenRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -379,6 +420,9 @@ public class OpenRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (ApiTypeHelper.isDefined(request.expandWildcards)) {
 					params.put("expand_wildcards",

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/PutAliasRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/PutAliasRequest.java
@@ -78,8 +78,12 @@ public class PutAliasRequest extends RequestBase implements JsonpSerializable {
 	@Nullable
 	private final Boolean isWriteIndex;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String name;
 
@@ -101,6 +105,7 @@ public class PutAliasRequest extends RequestBase implements JsonpSerializable {
 		this.indexRouting = builder.indexRouting;
 		this.isWriteIndex = builder.isWriteIndex;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
 		this.routing = builder.routing;
 		this.searchRouting = builder.searchRouting;
@@ -152,9 +157,20 @@ public class PutAliasRequest extends RequestBase implements JsonpSerializable {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -249,8 +265,12 @@ public class PutAliasRequest extends RequestBase implements JsonpSerializable {
 		@Nullable
 		private Boolean isWriteIndex;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String name;
 
@@ -327,6 +347,7 @@ public class PutAliasRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -337,8 +358,28 @@ public class PutAliasRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -467,6 +508,9 @@ public class PutAliasRequest extends RequestBase implements JsonpSerializable {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/PutIndicesSettingsRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/PutIndicesSettingsRequest.java
@@ -78,8 +78,12 @@ public class PutIndicesSettingsRequest extends RequestBase implements JsonpSeria
 
 	private final List<String> index;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Boolean preserveExisting;
@@ -99,6 +103,7 @@ public class PutIndicesSettingsRequest extends RequestBase implements JsonpSeria
 		this.ignoreUnavailable = builder.ignoreUnavailable;
 		this.index = ApiTypeHelper.unmodifiable(builder.index);
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.preserveExisting = builder.preserveExisting;
 		this.timeout = builder.timeout;
 		this.settings = ApiTypeHelper.requireNonNull(builder.settings, this, "settings");
@@ -167,9 +172,20 @@ public class PutIndicesSettingsRequest extends RequestBase implements JsonpSeria
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -232,8 +248,12 @@ public class PutIndicesSettingsRequest extends RequestBase implements JsonpSeria
 		@Nullable
 		private List<String> index;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Boolean preserveExisting;
@@ -333,6 +353,7 @@ public class PutIndicesSettingsRequest extends RequestBase implements JsonpSeria
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -343,8 +364,28 @@ public class PutIndicesSettingsRequest extends RequestBase implements JsonpSeria
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -461,6 +502,9 @@ public class PutIndicesSettingsRequest extends RequestBase implements JsonpSeria
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.flatSettings != null) {
 					params.put("flat_settings", String.valueOf(request.flatSettings));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/PutMappingRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/PutMappingRequest.java
@@ -107,8 +107,12 @@ public class PutMappingRequest extends RequestBase implements JsonpSerializable 
 
 	private final List<String> index;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Boolean numericDetection;
@@ -140,6 +144,7 @@ public class PutMappingRequest extends RequestBase implements JsonpSerializable 
 		this.ignoreUnavailable = builder.ignoreUnavailable;
 		this.index = ApiTypeHelper.unmodifiableRequired(builder.index, this, "index");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.numericDetection = builder.numericDetection;
 		this.properties = ApiTypeHelper.unmodifiable(builder.properties);
 		this.runtime = ApiTypeHelper.unmodifiable(builder.runtime);
@@ -282,9 +287,20 @@ public class PutMappingRequest extends RequestBase implements JsonpSerializable 
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -487,8 +503,12 @@ public class PutMappingRequest extends RequestBase implements JsonpSerializable 
 
 		private List<String> index;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Boolean numericDetection;
@@ -745,6 +765,7 @@ public class PutMappingRequest extends RequestBase implements JsonpSerializable 
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -755,8 +776,28 @@ public class PutMappingRequest extends RequestBase implements JsonpSerializable 
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -967,6 +1008,9 @@ public class PutMappingRequest extends RequestBase implements JsonpSerializable 
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (ApiTypeHelper.isDefined(request.expandWildcards)) {
 					params.put("expand_wildcards",

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/PutTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/PutTemplateRequest.java
@@ -80,8 +80,12 @@ public class PutTemplateRequest extends RequestBase implements JsonpSerializable
 	@Nullable
 	private final TypeMapping mappings;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String name;
 
@@ -106,6 +110,7 @@ public class PutTemplateRequest extends RequestBase implements JsonpSerializable
 		this.indexPatterns = ApiTypeHelper.unmodifiable(builder.indexPatterns);
 		this.mappings = builder.mappings;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
 		this.order = builder.order;
 		this.settings = ApiTypeHelper.unmodifiable(builder.settings);
@@ -171,9 +176,21 @@ public class PutTemplateRequest extends RequestBase implements JsonpSerializable
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -310,8 +327,12 @@ public class PutTemplateRequest extends RequestBase implements JsonpSerializable
 		@Nullable
 		private TypeMapping mappings;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String name;
 
@@ -431,6 +452,7 @@ public class PutTemplateRequest extends RequestBase implements JsonpSerializable
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -442,8 +464,30 @@ public class PutTemplateRequest extends RequestBase implements JsonpSerializable
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -590,6 +634,9 @@ public class PutTemplateRequest extends RequestBase implements JsonpSerializable
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.flatSettings != null) {
 					params.put("flat_settings", String.valueOf(request.flatSettings));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/RolloverRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/RolloverRequest.java
@@ -83,8 +83,12 @@ public class RolloverRequest extends RequestBase implements JsonpSerializable {
 	@Nullable
 	private final IndexRolloverMapping mappings;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final String newIndex;
@@ -107,6 +111,7 @@ public class RolloverRequest extends RequestBase implements JsonpSerializable {
 		this.dryRun = builder.dryRun;
 		this.mappings = builder.mappings;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.newIndex = builder.newIndex;
 		this.settings = ApiTypeHelper.unmodifiable(builder.settings);
 		this.timeout = builder.timeout;
@@ -166,9 +171,20 @@ public class RolloverRequest extends RequestBase implements JsonpSerializable {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -276,8 +292,12 @@ public class RolloverRequest extends RequestBase implements JsonpSerializable {
 		@Nullable
 		private IndexRolloverMapping mappings;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private String newIndex;
@@ -376,6 +396,7 @@ public class RolloverRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -386,8 +407,28 @@ public class RolloverRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -540,6 +581,9 @@ public class RolloverRequest extends RequestBase implements JsonpSerializable {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.waitForActiveShards != null) {
 					params.put("wait_for_active_shards", request.waitForActiveShards._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/ShrinkRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/ShrinkRequest.java
@@ -70,8 +70,12 @@ public class ShrinkRequest extends RequestBase implements JsonpSerializable {
 
 	private final String index;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final Map<String, JsonData> settings;
 
@@ -90,6 +94,7 @@ public class ShrinkRequest extends RequestBase implements JsonpSerializable {
 		this.aliases = ApiTypeHelper.unmodifiable(builder.aliases);
 		this.index = ApiTypeHelper.requireNonNull(builder.index, this, "index");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.settings = ApiTypeHelper.unmodifiable(builder.settings);
 		this.target = ApiTypeHelper.requireNonNull(builder.target, this, "target");
 		this.timeout = builder.timeout;
@@ -122,9 +127,20 @@ public class ShrinkRequest extends RequestBase implements JsonpSerializable {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -212,8 +228,12 @@ public class ShrinkRequest extends RequestBase implements JsonpSerializable {
 
 		private String index;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Map<String, JsonData> settings;
@@ -270,6 +290,7 @@ public class ShrinkRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -280,8 +301,28 @@ public class ShrinkRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -424,6 +465,9 @@ public class ShrinkRequest extends RequestBase implements JsonpSerializable {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.waitForActiveShards != null) {
 					params.put("wait_for_active_shards", request.waitForActiveShards._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/SimulateIndexTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/SimulateIndexTemplateRequest.java
@@ -84,8 +84,12 @@ public class SimulateIndexTemplateRequest extends RequestBase implements JsonpSe
 
 	private final List<String> indexPatterns;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String name;
 
@@ -109,6 +113,7 @@ public class SimulateIndexTemplateRequest extends RequestBase implements JsonpSe
 		this.dataStream = builder.dataStream;
 		this.indexPatterns = ApiTypeHelper.unmodifiable(builder.indexPatterns);
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
 		this.priority = builder.priority;
 		this.template = builder.template;
@@ -177,9 +182,21 @@ public class SimulateIndexTemplateRequest extends RequestBase implements JsonpSe
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -310,8 +327,12 @@ public class SimulateIndexTemplateRequest extends RequestBase implements JsonpSe
 		@Nullable
 		private List<String> indexPatterns;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String name;
 
@@ -427,6 +448,7 @@ public class SimulateIndexTemplateRequest extends RequestBase implements JsonpSe
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -438,8 +460,30 @@ public class SimulateIndexTemplateRequest extends RequestBase implements JsonpSe
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -559,6 +603,9 @@ public class SimulateIndexTemplateRequest extends RequestBase implements JsonpSe
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.create != null) {
 					params.put("create", String.valueOf(request.create));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/SimulateTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/SimulateTemplateRequest.java
@@ -67,8 +67,12 @@ public class SimulateTemplateRequest extends RequestBase implements JsonpSeriali
 	@Nullable
 	private final Boolean create;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final String name;
@@ -81,6 +85,7 @@ public class SimulateTemplateRequest extends RequestBase implements JsonpSeriali
 
 		this.create = builder.create;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = builder.name;
 		this.template = ApiTypeHelper.requireNonNull(builder.template, this, "template");
 
@@ -109,9 +114,21 @@ public class SimulateTemplateRequest extends RequestBase implements JsonpSeriali
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -153,8 +170,12 @@ public class SimulateTemplateRequest extends RequestBase implements JsonpSeriali
 		@Nullable
 		private Boolean create;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private String name;
@@ -180,6 +201,7 @@ public class SimulateTemplateRequest extends RequestBase implements JsonpSeriali
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -191,8 +213,30 @@ public class SimulateTemplateRequest extends RequestBase implements JsonpSeriali
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -293,6 +337,9 @@ public class SimulateTemplateRequest extends RequestBase implements JsonpSeriali
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.create != null) {
 					params.put("create", String.valueOf(request.create));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/SplitRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/SplitRequest.java
@@ -71,8 +71,12 @@ public class SplitRequest extends RequestBase implements JsonpSerializable {
 
 	private final String index;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final Map<String, JsonData> settings;
 
@@ -91,6 +95,7 @@ public class SplitRequest extends RequestBase implements JsonpSerializable {
 		this.aliases = ApiTypeHelper.unmodifiable(builder.aliases);
 		this.index = ApiTypeHelper.requireNonNull(builder.index, this, "index");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.settings = ApiTypeHelper.unmodifiable(builder.settings);
 		this.target = ApiTypeHelper.requireNonNull(builder.target, this, "target");
 		this.timeout = builder.timeout;
@@ -123,9 +128,20 @@ public class SplitRequest extends RequestBase implements JsonpSerializable {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -213,8 +229,12 @@ public class SplitRequest extends RequestBase implements JsonpSerializable {
 
 		private String index;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Map<String, JsonData> settings;
@@ -271,6 +291,7 @@ public class SplitRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -281,8 +302,28 @@ public class SplitRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -425,6 +466,9 @@ public class SplitRequest extends RequestBase implements JsonpSerializable {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.waitForActiveShards != null) {
 					params.put("wait_for_active_shards", request.waitForActiveShards._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/UpdateAliasesRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/UpdateAliasesRequest.java
@@ -69,8 +69,12 @@ import javax.annotation.Nullable;
 public class UpdateAliasesRequest extends RequestBase implements JsonpSerializable {
 	private final List<Action> actions;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Time timeout;
@@ -81,6 +85,7 @@ public class UpdateAliasesRequest extends RequestBase implements JsonpSerializab
 
 		this.actions = ApiTypeHelper.unmodifiable(builder.actions);
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.timeout = builder.timeout;
 
 	}
@@ -101,9 +106,20 @@ public class UpdateAliasesRequest extends RequestBase implements JsonpSerializab
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Specify timeout for connection to cluster-manager
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -150,8 +166,12 @@ public class UpdateAliasesRequest extends RequestBase implements JsonpSerializab
 		@Nullable
 		private List<Action> actions;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Time timeout;
@@ -190,6 +210,7 @@ public class UpdateAliasesRequest extends RequestBase implements JsonpSerializab
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -200,8 +221,28 @@ public class UpdateAliasesRequest extends RequestBase implements JsonpSerializab
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Specify timeout for connection to cluster-manager
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -274,6 +315,9 @@ public class UpdateAliasesRequest extends RequestBase implements JsonpSerializab
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/ingest/DeletePipelineRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/ingest/DeletePipelineRequest.java
@@ -60,8 +60,12 @@ import javax.annotation.Nullable;
 public class DeletePipelineRequest extends RequestBase {
 	private final String id;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Time timeout;
@@ -72,6 +76,7 @@ public class DeletePipelineRequest extends RequestBase {
 
 		this.id = ApiTypeHelper.requireNonNull(builder.id, this, "id");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.timeout = builder.timeout;
 
 	}
@@ -94,9 +99,20 @@ public class DeletePipelineRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -118,8 +134,12 @@ public class DeletePipelineRequest extends RequestBase {
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeletePipelineRequest> {
 		private String id;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Time timeout;
@@ -139,6 +159,7 @@ public class DeletePipelineRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -149,8 +170,28 @@ public class DeletePipelineRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -223,6 +264,9 @@ public class DeletePipelineRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/ingest/GetPipelineRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/ingest/GetPipelineRequest.java
@@ -60,8 +60,12 @@ public class GetPipelineRequest extends RequestBase {
 	@Nullable
 	private final String id;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Boolean summary;
@@ -72,6 +76,7 @@ public class GetPipelineRequest extends RequestBase {
 
 		this.id = builder.id;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.summary = builder.summary;
 
 	}
@@ -95,9 +100,20 @@ public class GetPipelineRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -120,8 +136,12 @@ public class GetPipelineRequest extends RequestBase {
 		@Nullable
 		private String id;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Boolean summary;
@@ -141,6 +161,7 @@ public class GetPipelineRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -151,8 +172,28 @@ public class GetPipelineRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -223,6 +264,9 @@ public class GetPipelineRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.summary != null) {
 					params.put("summary", String.valueOf(request.summary));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/ingest/PutPipelineRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/ingest/PutPipelineRequest.java
@@ -73,8 +73,12 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 
 	private final String id;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<Processor> onFailure;
 
@@ -94,6 +98,7 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 		this.description = builder.description;
 		this.id = ApiTypeHelper.requireNonNull(builder.id, this, "id");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.onFailure = ApiTypeHelper.unmodifiable(builder.onFailure);
 		this.processors = ApiTypeHelper.unmodifiable(builder.processors);
 		this.timeout = builder.timeout;
@@ -140,9 +145,21 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -247,8 +264,12 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 
 		private String id;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private List<Processor> onFailure;
@@ -314,6 +335,7 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -325,8 +347,30 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -483,6 +527,9 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/nodes/HotThreadsRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/nodes/HotThreadsRequest.java
@@ -67,8 +67,12 @@ public class HotThreadsRequest extends RequestBase {
 	@Nullable
 	private final Time interval;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<String> nodeId;
 
@@ -91,6 +95,7 @@ public class HotThreadsRequest extends RequestBase {
 		this.ignoreIdleThreads = builder.ignoreIdleThreads;
 		this.interval = builder.interval;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.nodeId = ApiTypeHelper.unmodifiable(builder.nodeId);
 		this.snapshots = builder.snapshots;
 		this.threads = builder.threads;
@@ -130,9 +135,21 @@ public class HotThreadsRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -198,8 +215,12 @@ public class HotThreadsRequest extends RequestBase {
 		@Nullable
 		private Time interval;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private List<String> nodeId;
@@ -252,6 +273,7 @@ public class HotThreadsRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -263,8 +285,30 @@ public class HotThreadsRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -453,6 +497,9 @@ public class HotThreadsRequest extends RequestBase {
 				}
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.threads != null) {
 					params.put("threads", String.valueOf(request.threads));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/nodes/NodesInfoRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/nodes/NodesInfoRequest.java
@@ -63,8 +63,12 @@ public class NodesInfoRequest extends RequestBase {
 	@Nullable
 	private final Boolean flatSettings;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<String> metric;
 
@@ -79,6 +83,7 @@ public class NodesInfoRequest extends RequestBase {
 
 		this.flatSettings = builder.flatSettings;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.metric = ApiTypeHelper.unmodifiable(builder.metric);
 		this.nodeId = ApiTypeHelper.unmodifiable(builder.nodeId);
 		this.timeout = builder.timeout;
@@ -105,9 +110,21 @@ public class NodesInfoRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -150,8 +167,12 @@ public class NodesInfoRequest extends RequestBase {
 		@Nullable
 		private Boolean flatSettings;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private List<String> metric;
@@ -178,6 +199,7 @@ public class NodesInfoRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -189,8 +211,30 @@ public class NodesInfoRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -343,6 +387,9 @@ public class NodesInfoRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.flatSettings != null) {
 					params.put("flat_settings", String.valueOf(request.flatSettings));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/nodes/NodesStatsRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/nodes/NodesStatsRequest.java
@@ -81,8 +81,12 @@ public class NodesStatsRequest extends RequestBase {
 	@Nullable
 	private final Level level;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<String> metric;
 
@@ -106,6 +110,7 @@ public class NodesStatsRequest extends RequestBase {
 		this.indexMetric = ApiTypeHelper.unmodifiable(builder.indexMetric);
 		this.level = builder.level;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.metric = ApiTypeHelper.unmodifiable(builder.metric);
 		this.nodeId = ApiTypeHelper.unmodifiable(builder.nodeId);
 		this.timeout = builder.timeout;
@@ -206,9 +211,21 @@ public class NodesStatsRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -280,8 +297,12 @@ public class NodesStatsRequest extends RequestBase {
 		@Nullable
 		private Level level;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private List<String> metric;
@@ -448,6 +469,7 @@ public class NodesStatsRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -459,8 +481,30 @@ public class NodesStatsRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -669,6 +713,9 @@ public class NodesStatsRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (ApiTypeHelper.isDefined(request.types)) {
 					params.put("types", request.types.stream().map(v -> v).collect(Collectors.joining(",")));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/nodes/info/NodeInfoSettingsCluster.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/nodes/info/NodeInfoSettingsCluster.java
@@ -61,8 +61,12 @@ public class NodeInfoSettingsCluster implements JsonpSerializable {
 
 	private final NodeInfoSettingsClusterElection election;
 
+	@Deprecated
 	@Nullable
 	private final String initialMasterNodes;
+
+	@Nullable
+	private final String initialClusterManagerNodes;
 
 	// ---------------------------------------------------------------------------------------------
 
@@ -72,6 +76,7 @@ public class NodeInfoSettingsCluster implements JsonpSerializable {
 		this.routing = builder.routing;
 		this.election = ApiTypeHelper.requireNonNull(builder.election, this, "election");
 		this.initialMasterNodes = builder.initialMasterNodes;
+		this.initialClusterManagerNodes = builder.initialClusterManagerNodes;
 
 	}
 
@@ -104,9 +109,18 @@ public class NodeInfoSettingsCluster implements JsonpSerializable {
 	/**
 	 * API name: {@code initial_master_nodes}
 	 */
+	@Deprecated
 	@Nullable
 	public final String initialMasterNodes() {
 		return this.initialMasterNodes;
+	}
+
+	/**
+	 * API name: {@code initial_cluster_manager_nodes}
+	 */
+	@Nullable
+	public final String initialClusterManagerNodes() {
+		return this.initialClusterManagerNodes;
 	}
 
 	/**
@@ -137,6 +151,12 @@ public class NodeInfoSettingsCluster implements JsonpSerializable {
 
 		}
 
+		if (this.initialClusterManagerNodes != null) {
+			generator.writeKey("initial_cluster_manager_nodes");
+			generator.write(this.initialClusterManagerNodes);
+
+		}
+
 	}
 
 	// ---------------------------------------------------------------------------------------------
@@ -153,8 +173,12 @@ public class NodeInfoSettingsCluster implements JsonpSerializable {
 
 		private NodeInfoSettingsClusterElection election;
 
+		@Deprecated
 		@Nullable
 		private String initialMasterNodes;
+
+		@Nullable
+		private String initialClusterManagerNodes;
 
 		/**
 		 * Required - API name: {@code name}
@@ -198,8 +222,17 @@ public class NodeInfoSettingsCluster implements JsonpSerializable {
 		/**
 		 * API name: {@code initial_master_nodes}
 		 */
+		@Deprecated
 		public final Builder initialMasterNodes(@Nullable String value) {
 			this.initialMasterNodes = value;
+			return this;
+		}
+
+		/**
+		 * API name: {@code initial_cluster_manager_nodes}
+		 */
+		public final Builder initialClusterManagerNodes(@Nullable String value) {
+			this.initialClusterManagerNodes = value;
 			return this;
 		}
 
@@ -231,6 +264,7 @@ public class NodeInfoSettingsCluster implements JsonpSerializable {
 		op.add(Builder::routing, IndexRouting._DESERIALIZER, "routing");
 		op.add(Builder::election, NodeInfoSettingsClusterElection._DESERIALIZER, "election");
 		op.add(Builder::initialMasterNodes, JsonpDeserializer.stringDeserializer(), "initial_master_nodes");
+		op.add(Builder::initialClusterManagerNodes, JsonpDeserializer.stringDeserializer(), "initial_cluster_manager_nodes");
 
 	}
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/CleanupRepositoryRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/CleanupRepositoryRequest.java
@@ -58,8 +58,12 @@ import javax.annotation.Nullable;
  */
 
 public class CleanupRepositoryRequest extends RequestBase {
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String name;
 
@@ -71,6 +75,7 @@ public class CleanupRepositoryRequest extends RequestBase {
 	private CleanupRepositoryRequest(Builder builder) {
 
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
 		this.timeout = builder.timeout;
 
@@ -85,9 +90,20 @@ public class CleanupRepositoryRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -116,8 +132,12 @@ public class CleanupRepositoryRequest extends RequestBase {
 	 */
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CleanupRepositoryRequest> {
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String name;
 
@@ -129,6 +149,7 @@ public class CleanupRepositoryRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -139,8 +160,28 @@ public class CleanupRepositoryRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -223,6 +264,9 @@ public class CleanupRepositoryRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/CloneSnapshotRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/CloneSnapshotRequest.java
@@ -66,8 +66,12 @@ import javax.annotation.Nullable;
 public class CloneSnapshotRequest extends RequestBase implements JsonpSerializable {
 	private final String indices;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String repository;
 
@@ -84,6 +88,7 @@ public class CloneSnapshotRequest extends RequestBase implements JsonpSerializab
 
 		this.indices = ApiTypeHelper.requireNonNull(builder.indices, this, "indices");
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.repository = ApiTypeHelper.requireNonNull(builder.repository, this, "repository");
 		this.snapshot = ApiTypeHelper.requireNonNull(builder.snapshot, this, "snapshot");
 		this.targetSnapshot = ApiTypeHelper.requireNonNull(builder.targetSnapshot, this, "targetSnapshot");
@@ -110,6 +115,16 @@ public class CloneSnapshotRequest extends RequestBase implements JsonpSerializab
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -172,8 +187,12 @@ public class CloneSnapshotRequest extends RequestBase implements JsonpSerializab
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CloneSnapshotRequest> {
 		private String indices;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String repository;
 
@@ -197,6 +216,7 @@ public class CloneSnapshotRequest extends RequestBase implements JsonpSerializab
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -207,8 +227,28 @@ public class CloneSnapshotRequest extends RequestBase implements JsonpSerializab
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -329,6 +369,9 @@ public class CloneSnapshotRequest extends RequestBase implements JsonpSerializab
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/CreateRepositoryRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/CreateRepositoryRequest.java
@@ -64,8 +64,12 @@ import javax.annotation.Nullable;
  */
 @JsonpDeserializable
 public class CreateRepositoryRequest extends RequestBase implements JsonpSerializable {
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String name;
 
@@ -87,6 +91,7 @@ public class CreateRepositoryRequest extends RequestBase implements JsonpSeriali
 	private CreateRepositoryRequest(Builder builder) {
 
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
 		this.repository = builder.repository;
 		this.settings = ApiTypeHelper.requireNonNull(builder.settings, this, "settings");
@@ -105,9 +110,20 @@ public class CreateRepositoryRequest extends RequestBase implements JsonpSeriali
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -192,8 +208,12 @@ public class CreateRepositoryRequest extends RequestBase implements JsonpSeriali
 	 */
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CreateRepositoryRequest> {
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String name;
 
@@ -215,6 +235,7 @@ public class CreateRepositoryRequest extends RequestBase implements JsonpSeriali
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -225,8 +246,28 @@ public class CreateRepositoryRequest extends RequestBase implements JsonpSeriali
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -373,6 +414,9 @@ public class CreateRepositoryRequest extends RequestBase implements JsonpSeriali
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.verify != null) {
 					params.put("verify", String.valueOf(request.verify));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/CreateSnapshotRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/CreateSnapshotRequest.java
@@ -76,8 +76,12 @@ public class CreateSnapshotRequest extends RequestBase implements JsonpSerializa
 
 	private final List<String> indices;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final Map<String, JsonData> metadata;
 
@@ -100,6 +104,7 @@ public class CreateSnapshotRequest extends RequestBase implements JsonpSerializa
 		this.includeGlobalState = builder.includeGlobalState;
 		this.indices = ApiTypeHelper.unmodifiable(builder.indices);
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.metadata = ApiTypeHelper.unmodifiable(builder.metadata);
 		this.partial = builder.partial;
 		this.repository = ApiTypeHelper.requireNonNull(builder.repository, this, "repository");
@@ -169,9 +174,21 @@ public class CreateSnapshotRequest extends RequestBase implements JsonpSerializa
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -307,8 +324,12 @@ public class CreateSnapshotRequest extends RequestBase implements JsonpSerializa
 		@Nullable
 		private List<String> indices;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Map<String, JsonData> metadata;
@@ -416,6 +437,7 @@ public class CreateSnapshotRequest extends RequestBase implements JsonpSerializa
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -427,8 +449,30 @@ public class CreateSnapshotRequest extends RequestBase implements JsonpSerializa
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -578,6 +622,9 @@ public class CreateSnapshotRequest extends RequestBase implements JsonpSerializa
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.waitForCompletion != null) {
 					params.put("wait_for_completion", String.valueOf(request.waitForCompletion));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/DeleteRepositoryRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/DeleteRepositoryRequest.java
@@ -60,8 +60,12 @@ import javax.annotation.Nullable;
  */
 
 public class DeleteRepositoryRequest extends RequestBase {
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<String> name;
 
@@ -73,6 +77,7 @@ public class DeleteRepositoryRequest extends RequestBase {
 	private DeleteRepositoryRequest(Builder builder) {
 
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.unmodifiableRequired(builder.name, this, "name");
 		this.timeout = builder.timeout;
 
@@ -90,6 +95,16 @@ public class DeleteRepositoryRequest extends RequestBase {
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -119,8 +134,12 @@ public class DeleteRepositoryRequest extends RequestBase {
 	 */
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteRepositoryRequest> {
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private List<String> name;
 
@@ -132,6 +151,7 @@ public class DeleteRepositoryRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -142,8 +162,28 @@ public class DeleteRepositoryRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -241,6 +281,9 @@ public class DeleteRepositoryRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/DeleteSnapshotRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/DeleteSnapshotRequest.java
@@ -58,8 +58,12 @@ import javax.annotation.Nullable;
  */
 
 public class DeleteSnapshotRequest extends RequestBase {
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String repository;
 
@@ -70,6 +74,7 @@ public class DeleteSnapshotRequest extends RequestBase {
 	private DeleteSnapshotRequest(Builder builder) {
 
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.repository = ApiTypeHelper.requireNonNull(builder.repository, this, "repository");
 		this.snapshot = ApiTypeHelper.requireNonNull(builder.snapshot, this, "snapshot");
 
@@ -87,6 +92,16 @@ public class DeleteSnapshotRequest extends RequestBase {
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -114,8 +129,12 @@ public class DeleteSnapshotRequest extends RequestBase {
 	 */
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteSnapshotRequest> {
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String repository;
 
@@ -138,6 +157,25 @@ public class DeleteSnapshotRequest extends RequestBase {
 		 */
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -214,6 +252,9 @@ public class DeleteSnapshotRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				return params;
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/GetRepositoryRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/GetRepositoryRequest.java
@@ -62,8 +62,12 @@ public class GetRepositoryRequest extends RequestBase {
 	@Nullable
 	private final Boolean local;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final List<String> name;
 
@@ -73,6 +77,7 @@ public class GetRepositoryRequest extends RequestBase {
 
 		this.local = builder.local;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.unmodifiable(builder.name);
 
 	}
@@ -82,7 +87,7 @@ public class GetRepositoryRequest extends RequestBase {
 	}
 
 	/**
-	 * Return local information, do not retrieve the state from master node
+	 * Return local information, do not retrieve the state from cluster-manager node
 	 * (default: false)
 	 * <p>
 	 * API name: {@code local}
@@ -97,9 +102,20 @@ public class GetRepositoryRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -121,14 +137,18 @@ public class GetRepositoryRequest extends RequestBase {
 		@Nullable
 		private Boolean local;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private List<String> name;
 
 		/**
-		 * Return local information, do not retrieve the state from master node
+		 * Return local information, do not retrieve the state from cluster-manager node
 		 * (default: false)
 		 * <p>
 		 * API name: {@code local}
@@ -143,6 +163,7 @@ public class GetRepositoryRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -153,8 +174,28 @@ public class GetRepositoryRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -237,6 +278,9 @@ public class GetRepositoryRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.local != null) {
 					params.put("local", String.valueOf(request.local));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/GetSnapshotRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/GetSnapshotRequest.java
@@ -72,8 +72,12 @@ public class GetSnapshotRequest extends RequestBase {
 	@Nullable
 	private final Boolean indexDetails;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String repository;
 
@@ -91,6 +95,7 @@ public class GetSnapshotRequest extends RequestBase {
 		this.includeRepository = builder.includeRepository;
 		this.indexDetails = builder.indexDetails;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.repository = ApiTypeHelper.requireNonNull(builder.repository, this, "repository");
 		this.snapshot = ApiTypeHelper.unmodifiableRequired(builder.snapshot, this, "snapshot");
 		this.verbose = builder.verbose;
@@ -150,9 +155,21 @@ public class GetSnapshotRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Period to wait for a connection to the cluster-manager node. If no response is
+	 * received before the timeout expires, the request fails and returns an error.
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -212,8 +229,12 @@ public class GetSnapshotRequest extends RequestBase {
 		@Nullable
 		private Boolean indexDetails;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String repository;
 
@@ -271,6 +292,7 @@ public class GetSnapshotRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -282,8 +304,30 @@ public class GetSnapshotRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Period to wait for a connection to the cluster-manager node. If no response is
+		 * received before the timeout expires, the request fails and returns an error.
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -402,6 +446,9 @@ public class GetSnapshotRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.includeRepository != null) {
 					params.put("include_repository", String.valueOf(request.includeRepository));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/RestoreRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/RestoreRequest.java
@@ -82,8 +82,12 @@ public class RestoreRequest extends RequestBase implements JsonpSerializable {
 
 	private final List<String> indices;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final Boolean partial;
@@ -112,6 +116,7 @@ public class RestoreRequest extends RequestBase implements JsonpSerializable {
 		this.indexSettings = builder.indexSettings;
 		this.indices = ApiTypeHelper.unmodifiable(builder.indices);
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.partial = builder.partial;
 		this.renamePattern = builder.renamePattern;
 		this.renameReplacement = builder.renameReplacement;
@@ -176,9 +181,20 @@ public class RestoreRequest extends RequestBase implements JsonpSerializable {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -327,8 +343,12 @@ public class RestoreRequest extends RequestBase implements JsonpSerializable {
 		@Nullable
 		private List<String> indices;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private Boolean partial;
@@ -431,6 +451,7 @@ public class RestoreRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -441,8 +462,28 @@ public class RestoreRequest extends RequestBase implements JsonpSerializable {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -578,6 +619,9 @@ public class RestoreRequest extends RequestBase implements JsonpSerializable {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.waitForCompletion != null) {
 					params.put("wait_for_completion", String.valueOf(request.waitForCompletion));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/SnapshotStatusRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/SnapshotStatusRequest.java
@@ -63,8 +63,12 @@ public class SnapshotStatusRequest extends RequestBase {
 	@Nullable
 	private final Boolean ignoreUnavailable;
 
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	@Nullable
 	private final String repository;
@@ -77,6 +81,7 @@ public class SnapshotStatusRequest extends RequestBase {
 
 		this.ignoreUnavailable = builder.ignoreUnavailable;
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.repository = builder.repository;
 		this.snapshot = ApiTypeHelper.unmodifiable(builder.snapshot);
 
@@ -102,9 +107,20 @@ public class SnapshotStatusRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -136,8 +152,12 @@ public class SnapshotStatusRequest extends RequestBase {
 		@Nullable
 		private Boolean ignoreUnavailable;
 
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		@Nullable
 		private String repository;
@@ -161,6 +181,7 @@ public class SnapshotStatusRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -171,8 +192,28 @@ public class SnapshotStatusRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -281,6 +322,9 @@ public class SnapshotStatusRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.ignoreUnavailable != null) {
 					params.put("ignore_unavailable", String.valueOf(request.ignoreUnavailable));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/VerifyRepositoryRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/snapshot/VerifyRepositoryRequest.java
@@ -57,8 +57,12 @@ import javax.annotation.Nullable;
  */
 
 public class VerifyRepositoryRequest extends RequestBase {
+	@Deprecated
 	@Nullable
 	private final Time masterTimeout;
+
+	@Nullable
+	private final Time clusterManagerTimeout;
 
 	private final String name;
 
@@ -70,6 +74,7 @@ public class VerifyRepositoryRequest extends RequestBase {
 	private VerifyRepositoryRequest(Builder builder) {
 
 		this.masterTimeout = builder.masterTimeout;
+		this.clusterManagerTimeout = builder.clusterManagerTimeout;
 		this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
 		this.timeout = builder.timeout;
 
@@ -84,9 +89,20 @@ public class VerifyRepositoryRequest extends RequestBase {
 	 * <p>
 	 * API name: {@code master_timeout}
 	 */
+	@Deprecated
 	@Nullable
 	public final Time masterTimeout() {
 		return this.masterTimeout;
+	}
+
+	/**
+	 * Explicit operation timeout for connection to cluster-manager node
+	 * <p>
+	 * API name: {@code cluster_manager_timeout}
+	 */
+	@Nullable
+	public final Time clusterManagerTimeout() {
+		return this.clusterManagerTimeout;
 	}
 
 	/**
@@ -115,8 +131,12 @@ public class VerifyRepositoryRequest extends RequestBase {
 	 */
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<VerifyRepositoryRequest> {
+		@Deprecated
 		@Nullable
 		private Time masterTimeout;
+
+		@Nullable
+		private Time clusterManagerTimeout;
 
 		private String name;
 
@@ -128,6 +148,7 @@ public class VerifyRepositoryRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(@Nullable Time value) {
 			this.masterTimeout = value;
 			return this;
@@ -138,8 +159,28 @@ public class VerifyRepositoryRequest extends RequestBase {
 		 * <p>
 		 * API name: {@code master_timeout}
 		 */
+		@Deprecated
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(@Nullable Time value) {
+			this.clusterManagerTimeout = value;
+			return this;
+		}
+
+		/**
+		 * Explicit operation timeout for connection to cluster-manager node
+		 * <p>
+		 * API name: {@code cluster_manager_timeout}
+		 */
+		public final Builder clusterManagerTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+			return this.clusterManagerTimeout(fn.apply(new Time.Builder()).build());
 		}
 
 		/**
@@ -222,6 +263,9 @@ public class VerifyRepositoryRequest extends RequestBase {
 				Map<String, String> params = new HashMap<>();
 				if (request.masterTimeout != null) {
 					params.put("master_timeout", request.masterTimeout._toJsonString());
+				}
+				if (request.clusterManagerTimeout != null) {
+					params.put("cluster_manager_timeout", request.clusterManagerTimeout._toJsonString());
 				}
 				if (request.timeout != null) {
 					params.put("timeout", request.timeout._toJsonString());

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/RequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/RequestTest.java
@@ -199,6 +199,9 @@ public class RequestTest extends OpenSearchRestHighLevelClientTestCase {
 
         InfoResponse info = highLevelClient().info();
         String version = info.version().number();
+        if (version.contains("SNAPSHOT")) {
+                version = version.split("-")[0];
+        }
         assertEquals(1, nodes.valueBody().size());
         if (Version.fromString(version).onOrAfter(Version.fromString("2.0.0"))) {
                 assertEquals("*", nodes.valueBody().get(0).clusterManager());

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/RequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/RequestTest.java
@@ -34,6 +34,7 @@ package org.opensearch.client.opensearch.integTest;
 
 
 import org.junit.Test;
+import org.opensearch.Version;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Refresh;
@@ -44,6 +45,7 @@ import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.ClearScrollResponse;
 import org.opensearch.client.opensearch.core.GetResponse;
 import org.opensearch.client.opensearch.core.IndexResponse;
+import org.opensearch.client.opensearch.core.InfoResponse;
 import org.opensearch.client.opensearch.core.MsearchResponse;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.bulk.OperationType;
@@ -195,10 +197,15 @@ public class RequestTest extends OpenSearchRestHighLevelClientTestCase {
         NodesResponse nodes = highLevelClient().cat().nodes(_0 -> _0);
         System.out.println(ModelTestCase.toJson(nodes, highLevelClient()._transport().jsonpMapper()));
 
+        InfoResponse info = highLevelClient().info();
+        String version = info.version().number();
         assertEquals(1, nodes.valueBody().size());
-        // TODO: Removing this assert for now since the endpoint _cat/nodes now returns cluster_manager. 
-        // This will be done along with changes for inclusive naming.
-        // assertEquals("*", nodes.valueBody().get(0).master());
+        if (Version.fromString(version).onOrAfter(Version.fromString("2.0.0"))) {
+                assertEquals("*", nodes.valueBody().get(0).clusterManager());
+        } else {
+                assertEquals("*", nodes.valueBody().get(0).master());
+        }
+        
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Deprecating master nomenclature for inclusive naming which includes the following changes:

- `master` -> `cluster-manager` in comments
- `master` -> `clusterManager` in methods and variables
- `master` -> `cluster_manager` in API parameters

### Issues Resolved
#166 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
