### PR TITLE
Sort field in Hit deserializer should handle null events

### DIFF
--- a/java-client/src/main/java/org/opensearch/client/json/JsonpDeserializer.java
+++ b/java-client/src/main/java/org/opensearch/client/json/JsonpDeserializer.java
@@ -204,6 +204,10 @@ public interface JsonpDeserializer<V> {
         return new JsonpDeserializerBase.IntOrNullDeserializer(defaultValue);
     }
 
+    static JsonpDeserializer<String> stringOrNullDeserializer() {
+        return new JsonpDeserializerBase.StringOrNullDeserializer();
+    }
+
     static JsonpDeserializer<Number> numberDeserializer() {
         return JsonpDeserializerBase.NUMBER;
     }

--- a/java-client/src/main/java/org/opensearch/client/json/JsonpDeserializerBase.java
+++ b/java-client/src/main/java/org/opensearch/client/json/JsonpDeserializerBase.java
@@ -238,6 +238,30 @@ public abstract class JsonpDeserializerBase<V> implements JsonpDeserializer<V> {
         }
     }
 
+    static final class StringOrNullDeserializer extends JsonpDeserializerBase<String> {
+        static final EnumSet<Event> nativeEvents = EnumSet.of(Event.VALUE_STRING, Event.VALUE_NULL);
+        static final EnumSet<Event> acceptedEvents = EnumSet.of(Event.KEY_NAME, Event.VALUE_STRING,
+            Event.VALUE_NUMBER, Event.VALUE_FALSE, Event.VALUE_TRUE, Event.VALUE_NULL);
+
+        StringOrNullDeserializer() {
+            super(acceptedEvents, nativeEvents);
+        }
+
+        @Override
+        public String deserialize(JsonParser parser, JsonpMapper mapper, Event event) {
+            if (event == Event.VALUE_NULL) {
+                return null;
+            }
+            if (event == Event.VALUE_TRUE) {
+                return "true";
+            }
+            if (event == Event.VALUE_FALSE) {
+                return "false";
+            }
+            return parser.getString();
+        }
+    }
+
     static final JsonpDeserializer<Double> DOUBLE_OR_NAN =
         new JsonpDeserializerBase<Double>(
             EnumSet.of(Event.VALUE_NUMBER, Event.VALUE_STRING, Event.VALUE_NULL),

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/search/Hit.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/search/Hit.java
@@ -775,7 +775,7 @@ public class Hit<TDocument> implements JsonpSerializable {
 		op.add(Builder::seqNo, JsonpDeserializer.longDeserializer(), "_seq_no");
 		op.add(Builder::primaryTerm, JsonpDeserializer.longDeserializer(), "_primary_term");
 		op.add(Builder::version, JsonpDeserializer.longDeserializer(), "_version");
-		op.add(Builder::sort, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "sort");
+		op.add(Builder::sort, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringOrNullDeserializer()), "sort");
 
 	}
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/model/BuiltinTypesTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/model/BuiltinTypesTest.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.client.opensearch.model;
 
+import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
@@ -42,7 +43,11 @@ import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.indices.IndexSettings;
 import org.junit.Test;
 
+import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.List;
+
+import jakarta.json.stream.JsonParser;
 
 public class BuiltinTypesTest extends ModelTestCase {
 
@@ -228,5 +233,22 @@ public class BuiltinTypesTest extends ModelTestCase {
         assertEquals(0, stats.minLength());
         assertEquals(0, stats.maxLength());
         assertEquals(0.0, stats.entropy(), 0.01);
+    }
+
+    @Test
+    public void testNullableStringInArray() {
+        // stringOrNullDeserializer allows to handle null events in string arrays
+        String json = "[\"lettuce\", null, \"tomato\"]";
+        JsonParser jsonParser = mapper.jsonProvider().createParser(new StringReader(json));
+        JsonpDeserializer<String> stringDeserializer = JsonpDeserializer.stringOrNullDeserializer();
+
+        List<String> result = JsonpDeserializer.arrayDeserializer(stringDeserializer).deserialize(jsonParser, mapper);
+
+        List<String> expected = new ArrayList<>();
+        expected.add("lettuce");
+        expected.add(null);
+        expected.add("tomato");
+
+        assertEquals(result, expected);
     }
 }


### PR DESCRIPTION
Signed-off-by: Rene Cordier <rcordier@linagora.com>

### Description

Adds a new `StringOrNullDeserializer` to allow to handle the null events with strings (like with Int or Double), which then allows us to use this for the sort field in Hit deserializer, thus getting the null event case being handled in the array deserializer.

Would like to add I built it locally and tested on my project and it seems to solve the issue for sorts on my end.

Let me know if this is good for you guys :)

### Issues Resolved

Attempt to solve #158

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
