### PR TITLE
Remove unused Log4j 2 dependency

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -130,7 +130,6 @@ dependencies {
     // Apache 2.0
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)
     testImplementation("org.opensearch.test", "framework", opensearchVersion)
-    implementation("org.apache.logging.log4j", "log4j-core", "2.17.2")
 
     // Apache 2.0
     // https://search.maven.org/artifact/com.google.code.findbugs/jsr305


### PR DESCRIPTION
Signed-off-by: Dermot Hardy <dermot.hardy@microfocus.com>

### Description
- Removes an unused dependency
- Removes a dependency on a logging framework

### Issues Resolved
A library intended for reuse from different projects should only depend on a logging facade like `slf4j-api` or `log4j-api`.  It should not depend on an actual logging framework.  This is somewhat academic anyway since so far as I can see the dependency is not used at all.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).