### PR TITLE
Only add SPDX license to new files.

### DIFF
--- a/config/checkstyle/checkstyle_suppressions.xml
+++ b/config/checkstyle/checkstyle_suppressions.xml
@@ -41,5 +41,4 @@
     <suppress files="client[/\\]src[/\\]main[/\\]java[/\\]org[/\\]opensearch[/\\]client[/\\]opensearch[^.]*\.java" checks="UnusedImports" />
     <suppress files="client[/\\]src[/\\]main[/\\]java[/\\]org[/\\]opensearch[/\\]client[/\\]opensearch[/\\]OpenSearch[^.]*\.java" checks="LineLength" />
     <suppress files="client[/\\]src[/\\]main[/\\]java[/\\]org[/\\]opensearch[/\\]client[/\\]opensearch[/\\]OpenSearch[^.]*\.java" checks="UnusedImports" />
-    <suppress files="client[/\\]src[/\\]test[/\\]java[/\\]org[/\\]opensearch[/\\]client[/\\]opensearch[/\\]integTest[^.]*\.java" checks="Header" />
 </suppressions>

--- a/config/checkstyle/header.java.txt
+++ b/config/checkstyle/header.java.txt
@@ -5,27 +5,3 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-
-/*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */


### PR DESCRIPTION
Signed-off-by: Daniel (dB.) Doubrovkine <dblock@amazon.com>

### Description

In https://github.com/opensearch-project/opensearch-java/pull/177 we have contributors creating files that carry the SPDX license header, a copyright notice from Elastic and a modifications line. Only SPDX is required for new code. This PR removes it from checkstyle. We have to continue making sure we don't merge anything that _removes_ any existing copyright notices when reviewing pull requests.

~I'm still confirming that this is ok.~ I've confirmed this is ok and PRed https://github.com/opensearch-project/.github/pull/76 to update guidance on what we'd like ideally. Note that it includes copyright in every header, which I am not doing as part of this PR, it's a nice to have.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
