### PR TITLE
Remove redundant SHA stage.

### DIFF
--- a/jenkins/stage-maven-release/JenkinsFile
+++ b/jenkins/stage-maven-release/JenkinsFile
@@ -87,29 +87,6 @@ pipeline {
                     }
             }
         }
-        stage('Generate checksums') {
-            steps {
-                 dir("$OUTPUT_DIR/org"){
-                    // copy only required artifacts to other folder so that not everything from .m2 gets staged
-                    sh('cp -r /usr/share/opensearch/.m2/repository/org/opensearch $OUTPUT_DIR/org/')
-                    sh('bash -O extglob -c "rm -rf $OUTPUT_DIR/org/opensearch/!(client)"')
-                    sh '''
-                    for file in $(find \$OUTPUT_DIR/org/opensearch/client/opensearch-java/ -type f)
-                        do
-                        if [ \${file##*.} != "asc" ]
-                        then
-                            echo "Creating checksum for \$file"
-                            (md5sum \$file | cut -d \' \' -f 1) > \$file.md5
-                            (sha1sum \$file | cut -d \' \' -f 1) > \$file.sha1
-                            (sha256sum \$file | cut -d \' \' -f 1) > \$file.sha256
-                            (sha512sum \$file | cut -d \' \' -f 1) > \$file.sha512
-                        fi
-                        done
-                    '''
-                    }
-                    sh('ls -l \$OUTPUT_DIR/org/opensearch/client/opensearch-java/\${VERSION}')
-                }
-        }
         stage('Stage maven artifacts') {
             tools {
               maven "maven-3.8.2"


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I believe this is redundant since https://github.com/opensearch-project/opensearch-java/commit/f10608a1ec0b2cad5af2d3a99c475452cfffbf37 which has 

```
tasks.withType<Jar> {
    doLast {
        ant.withGroovyBuilder {
            "checksum"("algorithm" to "md5", "file" to archivePath)
            "checksum"("algorithm" to "sha1", "file" to archivePath)
            "checksum"("algorithm" to "sha-256", "file" to archivePath, "fileext" to ".sha256")
            "checksum"("algorithm" to "sha-512", "file" to archivePath, "fileext" to ".sha512")
        }
    }
}
```

If I run `./gradlew publishtoMavenLocal` I do get:

```
$ ls -la java-client/build/libs/
total 41080
drwxr-xr-x  17 dblock  staff       544 Jul 20 13:08 .
drwxr-xr-x  11 dblock  staff       352 Jul 28 09:21 ..
-rw-r--r--   1 dblock  staff  11544128 Jul 28 09:21 java-client-2.1.0-SNAPSHOT-javadoc.jar
-rw-r--r--   1 dblock  staff        33 Jul 28 09:21 java-client-2.1.0-SNAPSHOT-javadoc.jar.md5
-rw-r--r--   1 dblock  staff        41 Jul 28 09:21 java-client-2.1.0-SNAPSHOT-javadoc.jar.sha1
-rw-r--r--   1 dblock  staff        65 Jul 28 09:21 java-client-2.1.0-SNAPSHOT-javadoc.jar.sha256
-rw-r--r--   1 dblock  staff       129 Jul 28 09:21 java-client-2.1.0-SNAPSHOT-javadoc.jar.sha512
-rw-r--r--   1 dblock  staff   2941651 Jul 28 09:21 java-client-2.1.0-SNAPSHOT-sources.jar
-rw-r--r--   1 dblock  staff        33 Jul 28 09:21 java-client-2.1.0-SNAPSHOT-sources.jar.md5
-rw-r--r--   1 dblock  staff        41 Jul 28 09:21 java-client-2.1.0-SNAPSHOT-sources.jar.sha1
-rw-r--r--   1 dblock  staff        65 Jul 28 09:21 java-client-2.1.0-SNAPSHOT-sources.jar.sha256
-rw-r--r--   1 dblock  staff       129 Jul 28 09:21 java-client-2.1.0-SNAPSHOT-sources.jar.sha512
-rw-r--r--   1 dblock  staff   4964277 Jul 28 09:20 java-client-2.1.0-SNAPSHOT.jar
-rw-r--r--   1 dblock  staff        33 Jul 28 09:20 java-client-2.1.0-SNAPSHOT.jar.md5
-rw-r--r--   1 dblock  staff        41 Jul 28 09:20 java-client-2.1.0-SNAPSHOT.jar.sha1
-rw-r--r--   1 dblock  staff        65 Jul 28 09:20 java-client-2.1.0-SNAPSHOT.jar.sha256
-rw-r--r--   1 dblock  staff       129 Jul 28 09:20 java-client-2.1.0-SNAPSHOT.jar.sha512
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
