### PR TITLE
Publish snapshot to maven.

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -248,8 +248,15 @@ tasks.withType<Jar> {
 
 publishing {
     repositories{
-        maven {
-            url = uri("${rootProject.buildDir}/repository")
+        if (version.toString().endsWith("SNAPSHOT")) {
+            maven("https://aws.oss.sonatype.org/content/repositories/snapshots/") {
+                name = "snapshots"
+                credentials(PasswordCredentials::class)
+            }
+        } else {
+            maven {
+                uri("${rootProject.buildDir}/repository")
+            }
         }
     }
     publications {

--- a/jenkins/publish-snapshot.jenkinsfile
+++ b/jenkins/publish-snapshot.jenkinsfile
@@ -1,0 +1,25 @@
+pipeline {
+    agent {
+        docker {
+            label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
+            image 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2'
+            args '-e JAVA_HOME=/opt/java/openjdk-11'
+            alwaysPull true
+        }
+    }
+    stages {
+        stage('Publish to Maven Staging') {
+            steps {
+                git url: 'https://github.com/opensearch-project/opensearch-java.git', branch: 'main'
+                withCredentials([usernamePassword(credentialsId: 'Sonatype', usernameVariable: 'ORG_GRADLE_PROJECT_snapshotsUsername', passwordVariable: 'ORG_GRADLE_PROJECT_snapshotsPassword')]) {
+                    sh './gradlew --no-daemon publishPublishMavenPublicationToSnapshotsRepository'
+                }
+            }
+            post() {
+                always {
+                    cleanWs disableDeferredWipeout: true, deleteDirs: true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Adds a Jenkinsfile to publish snapshot to aws.oss.sonatype.org. See http://jenki-jenki-fpgmrv2ryxko-1366042710.us-east-1.elb.amazonaws.com/job/dblock-opensearch-java-publish-to-maven-staging/3/console for a successful run and https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/client/opensearch-java/2.1.0-SNAPSHOT/ for a published snapshot.

1. Question: is aws.oss.sonatype.org the right target? Or should it be OSSHR?
1. Next step is to either add a GHA workflow that would auto-trigger this job in production Jenkins or set that up to be triggered on every commit to main. @gaiksaya wdyt is best?

### Issues Resolved

Part of #57.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
