### PR TITLE
Add automatic triggers to jenkins workflow

### DIFF
--- a/jenkins/publish-snapshot.jenkinsfile
+++ b/jenkins/publish-snapshot.jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
             printContributedVariables: false,
             printPostContent: false,
             regexpFilterText: '$ref',
-            regexpFilterExpression: 'refs/heads/main'
+            regexpFilterExpression: '^(refs/heads/main)$'
         )
     }
     stages {

--- a/jenkins/publish-snapshot.jenkinsfile
+++ b/jenkins/publish-snapshot.jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         stage('Publish to Sonatype Snapshots Repo') {
             steps {
                 git url: 'https://github.com/opensearch-project/opensearch-java.git', branch: 'main'
-                withCredentials([usernamePassword(credentialsId: 'jenkins-sonatype-creds', usernameVariable: 'ORG_GRADLE_PROJECT_snapshotsUsername', passwordVariable: 'ORG_GRADLE_PROJECT_snapshotsPassword')]) {
+                withCredentials([usernamePassword(credentialsId: 'jenkins-sonatype-creds', usernameVariable: 'snapshotRepoUsername', passwordVariable: 'snapshotRepoPassword')]) {
                     sh './gradlew --no-daemon publishPublishMavenPublicationToSnapshotRepoRepository'
                 }
             }

--- a/jenkins/publish-snapshot.jenkinsfile
+++ b/jenkins/publish-snapshot.jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         stage('Publish to Sonatype Snapshots Repo') {
             steps {
                 git url: 'https://github.com/opensearch-project/opensearch-java.git', branch: 'main'
-                withCredentials([usernamePassword(credentialsId: 'jenkins-sonatype-creds', usernameVariable: 'snapshotRepoUsername', passwordVariable: 'snapshotRepoPassword')]) {
+                withCredentials([usernamePassword(credentialsId: 'jenkins-sonatype-creds', usernameVariable: 'ORG_GRADLE_PROJECT_snapshotsUsername', passwordVariable: 'ORG_GRADLE_PROJECT_snapshotsPassword')]) {
                     sh './gradlew --no-daemon publishPublishMavenPublicationToSnapshotRepoRepository'
                 }
             }

--- a/jenkins/publish-snapshot.jenkinsfile
+++ b/jenkins/publish-snapshot.jenkinsfile
@@ -7,6 +7,19 @@ pipeline {
             alwaysPull true
         }
     }
+    triggers {
+        GenericTrigger(
+            genericVariables: [
+                [key: 'ref', value: '$.ref'],
+            ],
+            tokenCredentialId: 'jenkins-opensearch-java-generic-webhook-token',
+            causeString: 'A commit was pushed on opensearch-project/opensearch-java repository main branch causing this workflow to run',
+            printContributedVariables: false,
+            printPostContent: false,
+            regexpFilterText: '$ref',
+            regexpFilterExpression: 'refs/heads/main'
+        )
+    }
     stages {
         stage('Publish to Sonatype Snapshots Repo') {
             steps {

--- a/jenkins/stage-maven-release.jenkinsfile
+++ b/jenkins/stage-maven-release.jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
         GenericTrigger(
             genericVariables: [
                 [key: 'ref', value: '$.ref'],
-                [key: 'version', value: '$.ref', regexpFilter: 'refs/tags/v' ],
+                [key: 'VERSION', value: '$.ref', regexpFilter: 'refs/tags/v' ],
             ],
             tokenCredentialId: 'jenkins-opensearch-java-generic-webhook-token',
             causeString: 'A tag was cut on opensearch-project/opensearch-java repository causing this workflow to run',
@@ -27,7 +27,7 @@ pipeline {
         )
     }
     environment {
-        ARTIFACT_PATH = "$WORKSPACE/build/repository/org/opensearch/client/opensearch-java/$version"
+        ARTIFACT_PATH = "$WORKSPACE/build/repository/org/opensearch/client/opensearch-java/$VERSION"
     }
     stages {
         stage('Publish to Maven Local') {

--- a/jenkins/stage-maven-release.jenkinsfile
+++ b/jenkins/stage-maven-release.jenkinsfile
@@ -12,38 +12,33 @@ pipeline {
             alwaysPull true
         }
     }
+    triggers {
+        GenericTrigger(
+            genericVariables: [
+                [key: 'ref', value: '$.ref'],
+                [key: 'version', value: '$.ref', regexpFilter: 'refs/tags/v' ],
+            ],
+            tokenCredentialId: 'jenkins-opensearch-java-generic-webhook-token',
+            causeString: 'A tag was cut on opensearch-project/opensearch-java repository causing this workflow to run',
+            printContributedVariables: false,
+            printPostContent: false,
+            regexpFilterText: '$ref',
+            regexpFilterExpression: '^refs/tags/.*'
+        )
+    }
     environment {
-        VERSION = "${params.VERSION}"
-        ARTIFACT_PATH = "$WORKSPACE/build/repository/org/opensearch/client/opensearch-java/${VERSION}"
+        ARTIFACT_PATH = "$WORKSPACE/build/repository/org/opensearch/client/opensearch-java/$version"
     }
     stages {
-        stage('parameters') {
-            steps {
-                script {
-                    properties([
-                        parameters([
-                            string(
-                                name: 'REF',
-                                trim: true
-                            ),
-                            string(
-                                name: 'VERSION',
-                                trim: true
-                            )
-                        ])
-                    ])
-                    if (params.REF.isEmpty() || params.VERSION.isEmpty()) {
-                        currentBuild.result = 'ABORTED'
-                        error('Missing REF and/or VERSION.')
-                    }
-                }
-            }
-        }
         stage('Publish to Maven Local') {
             steps {
+                echo "ref : $ref"
+                echo "version: $version"
                 // checkout the commit
-                git url: 'https://github.com/opensearch-project/opensearch-java.git', branch: 'main'
-                sh('git checkout ${REF}')
+                checkout([
+                    $class: 'GitSCM', userRemoteConfigs: [[url: 'https://github.com/opensearch-project/opensearch-java.git']],
+                    branches: [[name: "$ref"]]
+                    ])
 
                 // publish maven artifacts
                 sh('./gradlew --no-daemon publishPublishMavenPublicationToLocalRepoRepository')

--- a/jenkins/stage-maven-release.jenkinsfile
+++ b/jenkins/stage-maven-release.jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
                 checkout([
                     $class: 'GitSCM', userRemoteConfigs: [[url: 'https://github.com/opensearch-project/opensearch-java.git']],
                     branches: [[name: "$ref"]]
-                    ])
+                        ])
 
                 // publish maven artifacts
                 sh('./gradlew --no-daemon publishPublishMavenPublicationToLocalRepoRepository')

--- a/jenkins/stage-maven-release.jenkinsfile
+++ b/jenkins/stage-maven-release.jenkinsfile
@@ -32,8 +32,6 @@ pipeline {
     stages {
         stage('Publish to Maven Local') {
             steps {
-                echo "ref : $ref"
-                echo "version: $version"
                 // checkout the commit
                 checkout([
                     $class: 'GitSCM', userRemoteConfigs: [[url: 'https://github.com/opensearch-project/opensearch-java.git']],


### PR DESCRIPTION
### Description
1. The [maven release workflow ](https://github.com/opensearch-project/opensearch-java/blob/main/jenkins/stage-maven-release.jenkinsfile)runs only when a **tag** is pushed to this repository 
2. The [maven snapshot release workflow](https://github.com/opensearch-project/opensearch-java/blob/main/jenkins/publish-snapshot.jenkinsfile) runs when a commit is pushed to **main branch** only or if the workflow is run manually.

To-Do:
Before this PR is merged:
1. Add webhook for public jenkins with token

After:
Create jobs for snapshot release and fix the jenkinsFile path for maven release

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
