### PR TITLE
Always allow publishing to local repo.

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -253,10 +253,9 @@ publishing {
                 name = "snapshotRepo"
                 credentials(PasswordCredentials::class)
             }
-        } else {
-            maven("${rootProject.buildDir}/repository") {
-                name = "localRepo"
-            }
+        }
+        maven("${rootProject.buildDir}/repository") {
+            name = "localRepo"
         }
     }
     publications {


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Publishing to a local repo, aka `./gradlew publishPublishMavenPublicationToLocalRepoRepository` should work regardless of whether the version is `-SNAPSHOT` or not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
