### PR TITLE
Fix: correct env variables for the SNAPSHOT repo username/password.

### DIFF
--- a/jenkins/publish-snapshot.jenkinsfile
+++ b/jenkins/publish-snapshot.jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         stage('Publish to Sonatype Snapshots Repo') {
             steps {
                 git url: 'https://github.com/opensearch-project/opensearch-java.git', branch: 'main'
-                withCredentials([usernamePassword(credentialsId: 'jenkins-sonatype-creds', usernameVariable: 'ORG_GRADLE_PROJECT_snapshotsUsername', passwordVariable: 'ORG_GRADLE_PROJECT_snapshotsPassword')]) {
+                withCredentials([usernamePassword(credentialsId: 'jenkins-sonatype-creds', usernameVariable: 'ORG_GRADLE_PROJECT_snapshotRepoUsername', passwordVariable: 'ORG_GRADLE_PROJECT_snapshotRepoPassword')]) {
                     sh './gradlew --no-daemon publishPublishMavenPublicationToSnapshotRepoRepository'
                 }
             }


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I had renamed the repo name, but failed to correctly rename the expect username/password env variables.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
