### PR TITLE
Fix checkstyle badge by executing checkstyle workflow on push to main.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,6 @@
 name: Build
 
-on:
-  push:
-    branches:
-      - "*"
-  pull_request:
-    branches:
-      - "*"
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -1,6 +1,7 @@
-name: Code style and license headers
+name: Checkstyle
 
-on: [pull_request]
+on: [push, pull_request]
+
 jobs:
   checkstyle:
     runs-on: ubuntu-latest

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,11 +1,6 @@
 name: Link Checker
-on:
-  push:
-    branches:
-      - "*"
-  pull_request:
-    branches:
-      - "*"
+
+on: [push, pull_request]
 
 jobs:
   linkchecker:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,12 +1,6 @@
 name: Integration with Released OpenSearch
 
-on:
-  push:
-    branches:
-      - "*"
-  pull_request:
-    branches:
-      - "*"
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,12 +1,6 @@
 name: Unit
 
-on:
-  push:
-    branches:
-      - "*"
-  pull_request:
-    branches:
-      - "*"
+on: [push, pull_request]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Code style and license headers](https://github.com/opensearch-project/opensearch-java/actions/workflows/checkstyle.yml/badge.svg?branch=main)](https://github.com/opensearch-project/opensearch-java/actions/workflows/checkstyle.yml)
+[![Checkstyle](https://github.com/opensearch-project/opensearch-java/actions/workflows/checkstyle.yml/badge.svg?branch=main)](https://github.com/opensearch-project/opensearch-java/actions/workflows/checkstyle.yml)
 [![Build](https://github.com/opensearch-project/opensearch-java/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/opensearch-project/opensearch-java/actions/workflows/build.yml)
 [![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/clients/)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

The badge in the README says `branch=main`, but the workflow only runs on PRs. No reason not to run it on all pushes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
