### PR TITLE
Fix maven release path

### DIFF
--- a/jenkins/stage-maven-release.jenkinsfile
+++ b/jenkins/stage-maven-release.jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
 
                 // stage artifacts for release with Sonatype
                 withCredentials([usernamePassword(credentialsId: 'jenkins-sonatype-creds', usernameVariable: 'SONATYPE_USERNAME', passwordVariable: 'SONATYPE_PASSWORD')]) {
-                    sh('$WORKSPACE/publish/stage-maven-release.sh $ARTIFACT_PATH')
+                    sh('$WORKSPACE/publish/stage-maven-release.sh $WORKSPACE/build/repository/')
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Fix maven release path. Requirement of the script https://github.com/opensearch-project/opensearch-build/blob/main/publish/stage-maven-release.sh#L31-L33

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
