### PR TITLE
Upgrading to OpenSearch 2.3.0

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -9,21 +9,14 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          - { opensearch_version: 1.0.0, java: 11 }
           - { opensearch_version: 1.0.1, java: 11 }
           - { opensearch_version: 1.1.0, java: 11 }
-          - { opensearch_version: 1.2.0, java: 11 }
-          - { opensearch_version: 1.2.1, java: 11 }
-          - { opensearch_version: 1.2.2, java: 11 }
-          - { opensearch_version: 1.2.3, java: 11 }
           - { opensearch_version: 1.2.4, java: 11 }
-          - { opensearch_version: 1.3.0, java: 11 }
-          - { opensearch_version: 1.3.1, java: 11 }
-          - { opensearch_version: 1.3.2, java: 11 }
-          - { opensearch_version: 1.3.3, java: 11 }
-          - { opensearch_version: 2.0.0, java: 11 }
+          - { opensearch_version: 1.3.5, java: 11 }
           - { opensearch_version: 2.0.1, java: 11 }
           - { opensearch_version: 2.1.0, java: 11 }
+          - { opensearch_version: 2.2.1, java: 11 }
+          - { opensearch_version: 2.3.0, java: 11 }
     steps:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -9,7 +9,7 @@ The below matrix shows the compatibility of the [`opensearch-java-client`](https
 | --- | --- |
 | 1.0.0 | 1.0.0-1.3.3 |
 | 2.0.0 | 1.3.3-2.0.1 |
-| 2.1.0 | 1.3.3-2.1.0 |
+| 2.1.0 | 1.3.3-2.3.0 |
 
 ## Upgrading
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -131,7 +131,7 @@ val integrationTest = task<Test>("integrationTest") {
 
 dependencies {
 
-    val opensearchVersion = "2.1.0"
+    val opensearchVersion = "2.3.0"
     val jacksonVersion = "2.13.3"
     val jacksonDatabindVersion = "2.13.3"
 


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Upgrading to latest OpenSearch version in dependencies. This also fixes #216 since `framework 2.3.0` brings in `snakeyaml 1.31` which is a patched version.

```
+--- org.opensearch.test:framework:2.3.0
|    +--- org.opensearch:opensearch:2.3.0
|    |    +--- org.opensearch:opensearch-core:2.3.0
|    |    +--- org.opensearch:opensearch-secure-sm:2.3.0
|    |    +--- org.opensearch:opensearch-x-content:2.3.0
|    |    |    +--- org.opensearch:opensearch-core:2.3.0
|    |    |    +--- org.yaml:snakeyaml:1.31
|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.3
|    |    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.3
|    |    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.3
|    |    |    \--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.3
```

### Issues Resolved
Resolves #216 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
