### PR TITLE
Set javadoc encoding to utf-8 (#50)

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -74,6 +74,12 @@ tasks.withType<ProcessResources> {
     )
 }
 
+tasks.withType<Javadoc>().configureEach{
+    options {
+        encoding = "UTF-8"
+    }
+}
+
 tasks.withType<Jar> {
     doFirst {
         if (rootProject.extra.has("gitHashFull")) {


### PR DESCRIPTION
Signed-off-by: Meetesh Kumawat <kmeetesh@gmail.com>

### Description

Set javadoc encoding to utf-8.

### Issues Resolved

Closes [#50]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
