### PR TITLE
Update Jackson Databind to 2.13.4.2 (addressing CVE-2022-42003)

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -133,7 +133,7 @@ dependencies {
 
     val opensearchVersion = "2.3.0"
     val jacksonVersion = "2.13.4"
-    val jacksonDatabindVersion = "2.13.4"
+    val jacksonDatabindVersion = "2.13.4.2"
 
     // Apache 2.0
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)


### PR DESCRIPTION
### Description
Update Jackson Databind to 2.13.4.2 (addressing CVE-2022-42003) (see please https://github.com/FasterXML/jackson-databind/pull/3621)

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
