### PR TITLE
Migrate client transports to Apache HttpClient / Core 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add support to parse sub-aggregations from filter/nested aggregations ([#234](https://github.com/opensearch-project/opensearch-java/pull/234))
 - Add timeout and throttle to the jenkins workflows ([#231](https://github.com/opensearch-project/opensearch-java/pull/231)) 
 - Updating maintainers, admins and documentation ([#248](https://github.com/opensearch-project/opensearch-java/pull/248))
+- Migrate client transports to Apache HttpClient / Core 5.x ([#246](https://github.com/opensearch-project/opensearch-java/pull/246))
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-systemProp.version = 2.1.1
+systemProp.version = 3.0.0-SNAPSHOT

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -137,7 +137,7 @@ val integrationTest = task<Test>("integrationTest") {
 
 dependencies {
 
-    val opensearchVersion = "2.3.0"
+    val opensearchVersion = "3.0.0-SNAPSHOT"
     val jacksonVersion = "2.13.4"
     val jacksonDatabindVersion = "2.13.4.2"
 
@@ -172,7 +172,8 @@ dependencies {
     testImplementation("software.amazon.awssdk","aws-crt-client","[2.15,3.0)")
     testImplementation("software.amazon.awssdk","apache-client","[2.15,3.0)")
     testImplementation("software.amazon.awssdk","sts","[2.15,3.0)")
-
+    testImplementation("org.apache.logging.log4j", "log4j-api","[2.17.1,3.0)")
+    testImplementation("org.apache.logging.log4j", "log4j-core","[2.17.1,3.0)")
     // EPL-2.0 OR BSD-3-Clause
     // https://eclipse-ee4j.github.io/yasson/
     implementation("org.eclipse", "yasson", "2.0.2")

--- a/java-client/src/main/java/org/opensearch/client/transport/endpoints/SimpleEndpoint.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/endpoints/SimpleEndpoint.java
@@ -33,9 +33,9 @@
 package org.opensearch.client.transport.endpoints;
 
 import org.opensearch.client.opensearch._types.ErrorResponse;
+import org.apache.hc.core5.net.URLEncodedUtils;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.transport.JsonEndpoint;
-import org.apache.http.client.utils.URLEncodedUtils;
 
 import java.util.Collections;
 import java.util.Map;

--- a/java-client/src/main/java/org/opensearch/client/transport/rest_client/RestClientTransport.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/rest_client/RestClientTransport.java
@@ -48,11 +48,12 @@ import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.MissingRequiredPropertyException;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
-import org.apache.http.HttpEntity;
-import org.apache.http.entity.BufferedHttpEntity;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.entity.ContentType;
-import org.apache.http.util.EntityUtils;
+
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.BufferedHttpEntity;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Cancellable;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;

--- a/java-client/src/test/java/org/opensearch/client/documentation/ConnectingTest.java
+++ b/java-client/src/test/java/org/opensearch/client/documentation/ConnectingTest.java
@@ -38,8 +38,8 @@ import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.rest_client.RestClientTransport;
-import org.apache.http.HttpHost;
 import org.opensearch.client.RestClient;
+import org.apache.hc.core5.http.HttpHost;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/java-client/src/test/java/org/opensearch/client/documentation/MigrateHlrcTest.java
+++ b/java-client/src/test/java/org/opensearch/client/documentation/MigrateHlrcTest.java
@@ -36,9 +36,9 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.rest_client.RestClientTransport;
-import org.apache.http.HttpHost;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
+import org.apache.hc.core5.http.HttpHost;
 import org.junit.Test;
 
 public class MigrateHlrcTest {

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/PingAndInfoIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/PingAndInfoIT.java
@@ -8,7 +8,7 @@
 
 package org.opensearch.client.opensearch.integTest;
 
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.opensearch.client.Request;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.core.InfoResponse;

--- a/java-client/src/test/java/org/opensearch/client/opensearch/model/EndpointTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/model/EndpointTest.java
@@ -51,10 +51,10 @@ public class EndpointTest extends Assert {
         assertEquals("/a/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
 
         req = RefreshRequest.of(b -> b.index("a", "b"));
-        assertEquals("/a,b/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
+        assertEquals("/a%2Cb/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
 
         req = RefreshRequest.of(b -> b.index("a", "b", "c"));
-        assertEquals("/a,b,c/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
+        assertEquals("/a%2Cb%2Cc/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
     }
 
     @Test
@@ -65,7 +65,7 @@ public class EndpointTest extends Assert {
         assertEquals("/a%2Fb/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
 
         req = RefreshRequest.of(b -> b.index("a/b", "c/d"));
-        assertEquals("/a%2Fb,c%2Fd/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
+        assertEquals("/a%2Fb%2Cc%2Fd/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
 
     }
 

--- a/java-client/src/test/java/org/opensearch/client/transport/RequestOptionsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/transport/RequestOptionsTest.java
@@ -36,11 +36,11 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.transport.rest_client.RestClientTransport;
 import com.sun.net.httpserver.HttpServer;
-import org.apache.http.HttpHost;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URLEncodedUtils;
 import org.opensearch.client.ResponseException;
 import org.opensearch.client.RestClient;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.net.URLEncodedUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -96,7 +96,7 @@ public class RequestOptionsTest extends Assert {
 
         httpServer.start();
         InetSocketAddress address = httpServer.getAddress();
-        restClient = RestClient.builder(new HttpHost(address.getHostString(), address.getPort(), "http"))
+        restClient = RestClient.builder(new HttpHost("http", address.getHostString(), address.getPort()))
             .build();
     }
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Migrate client transports to Apache HttpClient / Core 5.x

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-java/issues/245

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has comments added
  - [ ] New functionality is added to `docs` folder
- [X] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](https://github.com/opensearch-project/opensearch-java/blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-java/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).