### PR TITLE
Fixing version for the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add timeout and throttle to the jenkins workflows ([#231](https://github.com/opensearch-project/opensearch-java/pull/231)) 
 - Updating maintainers, admins and documentation ([#248](https://github.com/opensearch-project/opensearch-java/pull/248))
 - Migrate client transports to Apache HttpClient / Core 5.x ([#246](https://github.com/opensearch-project/opensearch-java/pull/246))
+- Fixing version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-systemProp.version = 3.0.0-SNAPSHOT
+systemProp.version = 3.0.0

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -41,6 +41,9 @@ buildscript {
         mavenCentral()
         maven(url = "https://plugins.gradle.org/m2/")
     }
+    dependencies {
+        "classpath"(group = "org.opensearch.gradle", name = "build-tools", version = "3.0.0-SNAPSHOT")
+    }
 }
 
 plugins {
@@ -50,6 +53,7 @@ plugins {
     `maven-publish`
     id("com.github.jk1.dependency-license-report") version "1.19"
 }
+apply(plugin = "opensearch.repositories")
 
 checkstyle {
     toolVersion = "10.0"


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Realized that the version would not include `SNAPSHOT`, publishing to sonatype adds this suffix. Refer [publish snapshots](https://github.com/opensearch-project/opensearch-java/blob/main/jenkins/publish-snapshot.jenkinsfile) workflow.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
