### PR TITLE
[Backport] [2.x] Update Jackson to 2.14.0 (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `grgit-gradle` from 4.0.1 to 5.0.0
+- Update Jackson to 2.14.0 ([#259](https://github.com/opensearch-project/opensearch-java/pull/259))
 
 ### Changed
 - Update literature around changelog contributions in CONTRIBUTING.md ([#242](https://github.com/opensearch-project/opensearch-java/pull/242))

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -138,8 +138,8 @@ val integrationTest = task<Test>("integrationTest") {
 dependencies {
 
     val opensearchVersion = "2.3.0"
-    val jacksonVersion = "2.13.4"
-    val jacksonDatabindVersion = "2.13.4.2"
+    val jacksonVersion = "2.14.0"
+    val jacksonDatabindVersion = "2.14.0"
 
     // Apache 2.0
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/258 to `2.x`