### PR TITLE
[Backport] [1.x] Update Jackson to 2.14.0 (#258)

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,7 +31,7 @@
  */
 
 dependencies {
-    implementation("org.ajoberstar.grgit:grgit-gradle:4.0.1")
+    implementation("org.ajoberstar.grgit:grgit-gradle:4.1.1")
 }
 
 repositories {

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -160,7 +160,7 @@ dependencies {
     testImplementation("io.github.classgraph:classgraph:4.8.116")
 
     // Eclipse 1.0
-    testImplementation("junit", "junit" , "4.12") {
+    testImplementation("junit", "junit" , "4.13.1") {
         exclude(group = "org.hamcrest")
     }
 }

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -123,7 +123,7 @@ val integrationTest = task<Test>("integrationTest") {
 dependencies {
 
     val opensearchVersion = "1.2.4"
-    val jacksonVersion = "2.12.6"
+    val jacksonVersion = "2.14.0"
 
     // Apache 2.0
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/258 to `1.x`