### PR TITLE
Document how to ignore cert check when running server using docker with self-signed cert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Migrate client transports to Apache HttpClient / Core 5.x ([#246](https://github.com/opensearch-project/opensearch-java/pull/246))
 - Document how to use Java 8 Time (JSR 310) objects ([#251](https://github.com/opensearch-project/opensearch-java/pull/251))
 - Fixing version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
+- Document how to ignore cert check when running docker container with self-signed cert ([#308](https://github.com/opensearch-project/opensearch-java/pull/308))
 
 ### Deprecated
 


### PR DESCRIPTION
### Description

- Add instruction for ignoring cert check on client side because docker container uses self signed cert by default.
- Add instruction for creating index with mapping

### Issues Resolved

Fixes #236 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
