### PR TITLE
Fix: ResponseCompression option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Make ChildrenAggregate as a SingleBucketAggregate ([#306](https://github.com/opensearch-project/opensearch-java/pull/306))
 - Fix /_nodes/stats, /_nodes/info throwing serialization error ([#315](https://github.com/opensearch-project/opensearch-java/pull/315))
+- Fix AwsSdk2TransportOptions.responseCompression ([#322](https://github.com/opensearch-project/opensearch-java/pull/322))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2TransportOptions.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2TransportOptions.java
@@ -173,6 +173,7 @@ public interface AwsSdk2TransportOptions extends TransportOptions {
             super(builder);
             credentials = builder.credentials;
             requestCompressionSize = builder.requestCompressionSize;
+            responseCompression = builder.responseCompression;
             mapper = builder.mapper;
         }
 

--- a/java-client/src/test/java/org/opensearch/client/transport/aws/AwsSdk2TransportOptionsTestCase.java
+++ b/java-client/src/test/java/org/opensearch/client/transport/aws/AwsSdk2TransportOptionsTestCase.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.transport.aws;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AwsSdk2TransportOptionsTestCase extends Assert {
+    @Test
+    public void testBuilderResponseCompression() throws Exception {
+        AwsSdk2TransportOptions options = AwsSdk2TransportOptions.builder()
+            .setResponseCompression(true)
+            .setRequestCompressionSize(10)
+            .build();
+        assertEquals(10, options.requestCompressionSize().intValue());
+        assertTrue(options.responseCompression());
+    }
+}


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Noticed that I couldn't disable `Accept: gzip` despite being advertised. Option not being copied from the builder.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
