### PR TITLE
Refactor two-client usage.

### DIFF
--- a/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2Transport.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2Transport.java
@@ -84,7 +84,7 @@ public class AwsSdk2Transport implements OpenSearchTransport {
      * Note that asynchronous OpenSearch requests sent through this transport will be dispatched
      * *synchronously* on the calling thread.
      *
-     * @param httpClient HTTP client to use for OpenSearch requests.
+     * @param asyncHttpClient Asynchronous HTTP client to use for OpenSearch requests.
      * @param host The fully qualified domain name to connect to.
      * @param signingRegion The AWS region for which requests will be signed. This should typically match the region in `host`.
      * @param options Options that apply to all requests. Can be null. Create with
@@ -92,41 +92,38 @@ public class AwsSdk2Transport implements OpenSearchTransport {
      *                compression options, etc.
      */
     public AwsSdk2Transport(
-            @CheckForNull SdkAsyncHttpClient httpClient,
+            @CheckForNull SdkAsyncHttpClient asyncHttpClient,
             @Nonnull String host,
             @Nonnull Region signingRegion,
             @CheckForNull AwsSdk2TransportOptions options) {
-        this(httpClient, host, "es", signingRegion, options);
+        this(asyncHttpClient, host, "es", signingRegion, options);
     }
 
     /**
      * Create an {@link OpenSearchTransport} with a synchronous AWS HTTP client.
+     *
+     * @param syncHttpClient Synchronous HTTP client to use for OpenSearch requests.
+     * @param host The fully qualified domain name to connect to.
+     * @param signingRegion The AWS region for which requests will be signed. This should typically match the region in `host`.
+     * @param options Options that apply to all requests. Can be null. Create with
+     *                {@link AwsSdk2TransportOptions#builder()} and use these to specify non-default credentials,
+     *                compression options, etc.
+     */
+    public AwsSdk2Transport(
+            @CheckForNull SdkHttpClient syncHttpClient,
+            @Nonnull String host,
+            @Nonnull Region signingRegion,
+            @CheckForNull AwsSdk2TransportOptions options) {
+        this(syncHttpClient, host, "es", signingRegion, options);
+    }
+
+    /**
+     * Create an {@link OpenSearchTransport} with an asynchronous AWS HTTP client.
      * <p>
      * Note that asynchronous OpenSearch requests sent through this transport will be dispatched
      * *synchronously* on the calling thread.
      *
-     * @param httpClient HTTP client to use for OpenSearch requests.
-     * @param host The fully qualified domain name to connect to.
-     * @param signingRegion The AWS region for which requests will be signed. This should typically match the region in `host`.
-     * @param options Options that apply to all requests. Can be null. Create with
-     *                {@link AwsSdk2TransportOptions#builder()} and use these to specify non-default credentials,
-     *                compression options, etc.
-     */
-    public AwsSdk2Transport(
-            @CheckForNull SdkHttpClient httpClient,
-            @Nonnull String host,
-            @Nonnull Region signingRegion,
-            @CheckForNull AwsSdk2TransportOptions options) {
-        this(httpClient, host, "es", signingRegion, options);
-    }
-
-    /**
-     * Create an {@link OpenSearchTransport} with an asynchronous AWS HTTP clients.
-     * <p>
-     * The synchronous client will be used for synchronous OpenSearch requests, and the asynchronous client
-     * will be used for asynchronous HTTP requests.
-     *
-     * @param httpClient HTTP client to use for OpenSearch requests.
+     * @param asyncHttpClient Asynchronous HTTP client to use for OpenSearch requests.
      * @param host The fully qualified domain name to connect to.
      * @param signingRegion The AWS region for which requests will be signed. This should typically match the region in `host`.
      * @param signingServiceName The AWS signing service name, one of `es` (Amazon OpenSearch) or `aoss` (Amazon OpenSearch Serverless).
@@ -135,21 +132,18 @@ public class AwsSdk2Transport implements OpenSearchTransport {
      *                compression options, etc.
      */
     public AwsSdk2Transport(
-            @CheckForNull SdkAsyncHttpClient httpClient,
+            @CheckForNull SdkAsyncHttpClient asyncHttpClient,
             @Nonnull String host,
             @Nonnull String signingServiceName,
             @Nonnull Region signingRegion,
             @CheckForNull AwsSdk2TransportOptions options) {
-        this((SdkAutoCloseable) httpClient, host, signingServiceName, signingRegion, options);
+        this((SdkAutoCloseable) asyncHttpClient, host, signingServiceName, signingRegion, options);
     }
 
     /**
-     * Create an {@link OpenSearchTransport} with a synchronous AWS HTTP clients.
-     * <p>
-     * The synchronous client will be used for synchronous OpenSearch requests, and the asynchronous client
-     * will be used for asynchronous HTTP requests.
+     * Create an {@link OpenSearchTransport} with a synchronous AWS HTTP client.
      *
-     * @param httpClient HTTP client to use for OpenSearch requests.
+     * @param syncHttpClient Synchronous HTTP client to use for OpenSearch requests.
      * @param host The fully qualified domain name to connect to.
      * @param signingRegion The AWS region for which requests will be signed. This should typically match the region in `host`.
      * @param signingServiceName The AWS signing service name, one of `es` (Amazon OpenSearch) or `aoss` (Amazon OpenSearch Serverless).
@@ -158,12 +152,12 @@ public class AwsSdk2Transport implements OpenSearchTransport {
      *                compression options, etc.
      */
     public AwsSdk2Transport(
-            @CheckForNull SdkHttpClient httpClient,
+            @CheckForNull SdkHttpClient syncHttpClient,
             @Nonnull String host,
             @Nonnull String signingServiceName,
             @Nonnull Region signingRegion,
             @CheckForNull AwsSdk2TransportOptions options) {
-        this((SdkAutoCloseable) httpClient, host, signingServiceName, signingRegion, options);
+        this((SdkAutoCloseable) syncHttpClient, host, signingServiceName, signingRegion, options);
     }
 
     private AwsSdk2Transport(

--- a/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2Transport.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2Transport.java
@@ -79,6 +79,27 @@ public class AwsSdk2Transport implements OpenSearchTransport {
     private final AwsSdk2TransportOptions transportOptions;
 
     /**
+     * Create an {@link OpenSearchTransport} with an asynchronous AWS HTTP client.
+     * <p>
+     * Note that asynchronous OpenSearch requests sent through this transport will be dispatched
+     * *synchronously* on the calling thread.
+     *
+     * @param httpClient HTTP client to use for OpenSearch requests.
+     * @param host The fully qualified domain name to connect to.
+     * @param signingRegion The AWS region for which requests will be signed. This should typically match the region in `host`.
+     * @param options Options that apply to all requests. Can be null. Create with
+     *                {@link AwsSdk2TransportOptions#builder()} and use these to specify non-default credentials,
+     *                compression options, etc.
+     */
+    public AwsSdk2Transport(
+            @CheckForNull SdkAsyncHttpClient httpClient,
+            @Nonnull String host,
+            @Nonnull Region signingRegion,
+            @CheckForNull AwsSdk2TransportOptions options) {
+        this(httpClient, host, "es", signingRegion, options);
+    }
+
+    /**
      * Create an {@link OpenSearchTransport} with a synchronous AWS HTTP client.
      * <p>
      * Note that asynchronous OpenSearch requests sent through this transport will be dispatched
@@ -92,7 +113,7 @@ public class AwsSdk2Transport implements OpenSearchTransport {
      *                compression options, etc.
      */
     public AwsSdk2Transport(
-            @Nonnull SdkAutoCloseable httpClient,
+            @CheckForNull SdkHttpClient httpClient,
             @Nonnull String host,
             @Nonnull Region signingRegion,
             @CheckForNull AwsSdk2TransportOptions options) {
@@ -100,7 +121,7 @@ public class AwsSdk2Transport implements OpenSearchTransport {
     }
 
     /**
-     * Create an {@link OpenSearchTransport} with both synchronous and asynchronous AWS HTTP clients.
+     * Create an {@link OpenSearchTransport} with an asynchronous AWS HTTP clients.
      * <p>
      * The synchronous client will be used for synchronous OpenSearch requests, and the asynchronous client
      * will be used for asynchronous HTTP requests.
@@ -114,6 +135,38 @@ public class AwsSdk2Transport implements OpenSearchTransport {
      *                compression options, etc.
      */
     public AwsSdk2Transport(
+            @CheckForNull SdkAsyncHttpClient httpClient,
+            @Nonnull String host,
+            @Nonnull String signingServiceName,
+            @Nonnull Region signingRegion,
+            @CheckForNull AwsSdk2TransportOptions options) {
+        this((SdkAutoCloseable) httpClient, host, signingServiceName, signingRegion, options);
+    }
+
+    /**
+     * Create an {@link OpenSearchTransport} with a synchronous AWS HTTP clients.
+     * <p>
+     * The synchronous client will be used for synchronous OpenSearch requests, and the asynchronous client
+     * will be used for asynchronous HTTP requests.
+     *
+     * @param httpClient HTTP client to use for OpenSearch requests.
+     * @param host The fully qualified domain name to connect to.
+     * @param signingRegion The AWS region for which requests will be signed. This should typically match the region in `host`.
+     * @param signingServiceName The AWS signing service name, one of `es` (Amazon OpenSearch) or `aoss` (Amazon OpenSearch Serverless).
+     * @param options Options that apply to all requests. Can be null. Create with
+     *                {@link AwsSdk2TransportOptions#builder()} and use these to specify non-default credentials,
+     *                compression options, etc.
+     */
+    public AwsSdk2Transport(
+            @CheckForNull SdkHttpClient httpClient,
+            @Nonnull String host,
+            @Nonnull String signingServiceName,
+            @Nonnull Region signingRegion,
+            @CheckForNull AwsSdk2TransportOptions options) {
+        this((SdkAutoCloseable) httpClient, host, signingServiceName, signingRegion, options);
+    }
+
+    private AwsSdk2Transport(
             @CheckForNull SdkAutoCloseable httpClient,
             @Nonnull String host,
             @Nonnull String signingServiceName,

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/aws/AwsSdk2TransportTestCase.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/aws/AwsSdk2TransportTestCase.java
@@ -171,6 +171,7 @@ public abstract class AwsSdk2TransportTestCase {
         if (httpClient != null) {
             try {
                 httpClient.close();
+                httpClient = null;
             } catch (Throwable e) {
                 // Not our problem
             }
@@ -178,6 +179,7 @@ public abstract class AwsSdk2TransportTestCase {
         if (asyncHttpClient != null) {
             try {
                 asyncHttpClient.close();
+                asyncHttpClient = null;
             } catch (Throwable e) {
                 // Not our problem
             }
@@ -204,7 +206,6 @@ public abstract class AwsSdk2TransportTestCase {
             IndexState indexInfo = client.get(b -> b.index(TEST_INDEX)).get(TEST_INDEX);
             if (indexInfo != null) {
                 indexExists = true;
-
             }
         } catch (
                 OpenSearchException e) {

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/aws/AwsSdk2TransportTestCase.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/aws/AwsSdk2TransportTestCase.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.client.opensearch.integTest.aws;
 
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -41,7 +40,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-
 
 public abstract class AwsSdk2TransportTestCase {
     public static final String TEST_INDEX = "opensearch-java-integtest";
@@ -85,16 +83,14 @@ public abstract class AwsSdk2TransportTestCase {
                     getTestClusterHost(),
                     getTestClusterServiceName(),
                     getTestClusterRegion(),
-                    getTransportOptions().build()
-            );
+                    getTransportOptions().build());
         } else {
             transport = new AwsSdk2Transport(
                     getHttpClient(),
                     getTestClusterHost(),
                     getTestClusterServiceName(),
                     getTestClusterRegion(),
-                    getTransportOptions().build()
-            );
+                    getTransportOptions().build());
         }
         return new OpenSearchClient(transport);
     }
@@ -111,16 +107,14 @@ public abstract class AwsSdk2TransportTestCase {
                     getTestClusterHost(),
                     getTestClusterServiceName(),
                     getTestClusterRegion(),
-                    getTransportOptions().build()
-            );
+                    getTransportOptions().build());
         } else {
             transport = new AwsSdk2Transport(
                     getHttpClient(),
                     getTestClusterHost(),
                     getTestClusterServiceName(),
                     getTestClusterRegion(),
-                    getTransportOptions().build()
-            );
+                    getTransportOptions().build());
         }
         return new OpenSearchAsyncClient(transport);
     }
@@ -137,16 +131,14 @@ public abstract class AwsSdk2TransportTestCase {
                     getTestClusterHost(),
                     getTestClusterServiceName(),
                     getTestClusterRegion(),
-                    getTransportOptions().build()
-            );
+                    getTransportOptions().build());
         } else {
             transport = new AwsSdk2Transport(
                     getHttpClient(),
                     getTestClusterHost(),
                     getTestClusterServiceName(),
                     getTestClusterRegion(),
-                    getTransportOptions().build()
-            );
+                    getTransportOptions().build());
         }
         return new OpenSearchIndicesClient(transport);
     }
@@ -207,8 +199,7 @@ public abstract class AwsSdk2TransportTestCase {
             if (indexInfo != null) {
                 indexExists = true;
             }
-        } catch (
-                OpenSearchException e) {
+        } catch (OpenSearchException e) {
             if (e.status() != 404) {
                 throw e;
             }
@@ -238,17 +229,14 @@ public abstract class AwsSdk2TransportTestCase {
                 .ignoreThrottled(false)
                 .sort(
                         new SortOptions.Builder().score(o -> o.order(SortOrder.Desc)).build(),
-                        new SortOptions.Builder().doc(o -> o.order(SortOrder.Desc)).build()
-                )
+                        new SortOptions.Builder().doc(o -> o.order(SortOrder.Desc)).build())
                 .query(query);
-
 
         return client.search(req.build(), SimplePojo.class);
     }
 
     protected CompletableFuture<SearchResponse<SimplePojo>> query(
-            OpenSearchAsyncClient client, String title, String text
-    ) {
+            OpenSearchAsyncClient client, String title, String text) {
         var query = Query.of(qb -> {
             if (title != null) {
                 qb.match(mb -> mb.field("title").query(vb -> vb.stringValue(title)));
@@ -265,8 +253,7 @@ public abstract class AwsSdk2TransportTestCase {
                 .ignoreThrottled(false)
                 .sort(
                         new SortOptions.Builder().score(o -> o.order(SortOrder.Desc)).build(),
-                        new SortOptions.Builder().doc(o -> o.order(SortOrder.Desc)).build()
-                )
+                        new SortOptions.Builder().doc(o -> o.order(SortOrder.Desc)).build())
                 .query(query);
 
         try {


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I really dislike that this code uses two different clients like it does. Is this better? Should I go further and add a class that wraps either of `SdkAutoCloseable` and implements the `execute` method so we don't have to check the type other than when creating the wrapper?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
