### PR TITLE
Upgrade backport workflow.

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   backport:
+    if: ${{ contains(github.event.label.name, 'backport') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -22,7 +23,7 @@ jobs:
           installation_id: 22958780
 
       - name: Backport
-        uses: VachaShah/backport@v1.1.4
+        uses: VachaShah/backport@v2.1.0
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
-          branch_name: backport/backport-${{ github.event.number }}
+          head_template: backport/backport-<%= number %>-to-<%= base %>


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I copied the workflow from OpenSearch to attempt to fix DCO problems we see in https://github.com/opensearch-project/opensearch-java/pull/332. I don't know if it's right and whether it will work 😅 @VachaShah ? Particularly I don't know whether `if: ${{ contains(github.event.label.name, 'backport') }}` is needed, where that event comes from.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
