### PR TITLE
[Backport 2.x] Adding x-amz-content-sha256 header for signed requests (#339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add timeout and throttle to the jenkins workflows ([#231](https://github.com/opensearch-project/opensearch-java/pull/231)) 
 - Update maintainers, admins and documentation ([#248](https://github.com/opensearch-project/opensearch-java/pull/248))
 - Update Gradle to 7.6 ([#311](https://github.com/opensearch-project/opensearch-java/pull/311))
+- Add support for OpenSearch Serverless ([#339](https://github.com/opensearch-project/opensearch-java/pull/339))
 
 ### Deprecated
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -67,10 +67,10 @@ Run integration tests after starting OpenSearch cluster:
 
 #### AWS Transport Integration Tests
 
-To run integration tests for the AWS transport client, ensure working AWS credentials and specify your OpenSearch domain and region as follows:
+To run integration tests for the AWS transport client, ensure working AWS credentials in `/.aws/credentials` and specify your OpenSearch domain and region as follows:
 
 ```
-./gradlew integrationTest --tests "*AwsSdk2*" -Dtests.awsSdk2support.domainHost=search-...us-west-2.es.amazonaws.com -Dtests.awsSdk2support.domainRegion=us-west-2
+./gradlew integrationTest --tests "*AwsSdk2*" -Dtests.awsSdk2support.domainHost=search-...us-west-2.es.amazonaws.com -Dtests.awsSdk2support.domainRegion=us-west-2 -Dtests.awsSdk2support.serviceName=es
 ```
 
 For OpenSearch Serverless, change the signing service name.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -166,7 +166,7 @@ DeleteIndexResponse deleteIndexResponse = client.indices().delete(deleteIndexReq
 
 ## Amazon Managed OpenSearch
 
-Use `AwsSdk2Transport` to make requests to Amazon Managed OpenSearch.
+Use `AwsSdk2Transport` to make requests to Amazon Managed OpenSearch and OpenSearch Serverless.
 
 ```java
 SdkHttpClient httpClient = ApacheHttpClient.builder().build();
@@ -175,7 +175,7 @@ OpenSearchClient client = new OpenSearchClient(
     new AwsSdk2Transport(
         httpClient,
         "search-...us-west-2.es.amazonaws.com", // OpenSearch endpoint, without https://
-        "es" // signing service name
+        "es" // signing service name, use "aoss" for OpenSearch Serverless
         Region.US_WEST_2, // signing service region
         AwsSdk2TransportOptions.builder().build()
     )

--- a/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2Transport.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2Transport.java
@@ -363,6 +363,9 @@ public class AwsSdk2Transport implements OpenSearchTransport {
             }
             req.putHeader("Content-Length", String.valueOf(body.getContentLength()));
             req.contentStreamProvider(body::getInputStream);
+            // To add the "X-Amz-Content-Sha256" header, it needs to set as required.
+            // It is a required header for Amazon OpenSearch Serverless.
+            req.putHeader("x-amz-content-sha256", "required");
         }
 
         boolean responseCompression = Optional.ofNullable(options)


### PR DESCRIPTION
* Adding X-Amz-Content-Sha256 header for signed requests

Signed-off-by: Vacha Shah <vachshah@amazon.com>

* Adding CHANGELOG entry

Signed-off-by: Vacha Shah <vachshah@amazon.com>

* Adding documentation comment

Signed-off-by: Vacha Shah <vachshah@amazon.com>

* Adding tests

Signed-off-by: Vacha Shah <vachshah@amazon.com>

* Addressing comments

Signed-off-by: Vacha Shah <vachshah@amazon.com>

* Addressing comments

Signed-off-by: Vacha Shah <vachshah@amazon.com>

* Removing refresh policy for integ tests for Sigv4

Signed-off-by: Vacha Shah <vachshah@amazon.com>

* Updating the developer guide

Signed-off-by: Vacha Shah <vachshah@amazon.com>

Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Backport #339 to 2.x.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
