### PR TITLE
Set version as env variable for release

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,8 @@ jobs:
           java-version: 11
       - name: Build with Gradle
         run: |
+          export VERSION=`cat gradle.properties | grep "systemProp.version" | tr -d " " | cut -d '=' -f2`
+          echo Building the version: $VERSION
           ./gradlew --no-daemon publishPublishMavenPublicationToLocalRepoRepository && tar -C build -cvf artifacts.tar.gz repository
       - name: Draft a release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
The [current logic](https://github.com/opensearch-project/opensearch-java/blob/main/build.gradle.kts#L37) needs someone to set the `VERSION` in order to build a non-snapshot version. This is a hot fix for the same. @VachaShah will take care of refactoring the logic for both main and subsequent branches. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
