### PR TITLE
Fix issue with completion suggester being parsed as term suggester.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update Gradle to 7.6 ([#309](https://github.com/opensearch-project/opensearch-java/pull/309))
 - Prevent SPI calls at runtime ([#293](https://github.com/opensearch-project/opensearch-java/pull/293))
 - Add support for OpenSearch Serverless ([#339](https://github.com/opensearch-project/opensearch-java/pull/339))
+- Fix issue where completion suggestions were failing, due to being parsed as term suggestions([#107](https://github.com/opensearch-project/opensearch-java/issues/107))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update Gradle to 7.6 ([#309](https://github.com/opensearch-project/opensearch-java/pull/309))
 - Prevent SPI calls at runtime ([#293](https://github.com/opensearch-project/opensearch-java/pull/293))
 - Add support for OpenSearch Serverless ([#339](https://github.com/opensearch-project/opensearch-java/pull/339))
-- Fix issue where completion suggestions were failing, due to being parsed as term suggestions([#107](https://github.com/opensearch-project/opensearch-java/issues/107))
+- Fix issue where completion suggestions were failing, due to being parsed as term suggestions ([#107](https://github.com/opensearch-project/opensearch-java/issues/107))
 
 ### Deprecated
 

--- a/java-client/src/main/java/org/opensearch/client/json/UnionDeserializer.java
+++ b/java-client/src/main/java/org/opensearch/client/json/UnionDeserializer.java
@@ -48,6 +48,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class UnionDeserializer<Union, Kind, Member> implements JsonpDeserializer<Union> {
 
@@ -169,14 +171,15 @@ public class UnionDeserializer<Union, Kind, Member> implements JsonpDeserializer
             JsonpDeserializer<?> unwrapped = DelegatingDeserializer.unwrap(deserializer);
             if (unwrapped instanceof ObjectDeserializer) {
                 ObjectDeserializer<?> od = (ObjectDeserializer<?>) unwrapped;
-                Set<String> allFields = od.fieldNames();
-                Set<String> fields = new HashSet<>(allFields); // copy to update
-                for (UnionDeserializer.SingleMemberHandler<Union, Kind, Member> member: objectMembers) {
-                    // Remove respective fields on both sides to keep specific ones
-                    fields.removeAll(member.fields);
-                    member.fields.removeAll(allFields);
-                }
-                UnionDeserializer.SingleMemberHandler<Union, Kind, Member> member = new SingleMemberHandler<>(tag, deserializer, fields);
+//                Set<String> allFields = od.fieldNames();
+//                Set<String> fields = new HashSet<>(allFields); // copy to update
+//                for (UnionDeserializer.SingleMemberHandler<Union, Kind, Member> member: objectMembers) {
+//                    // Remove respective fields on both sides to keep specific ones
+//                    fields.removeAll(member.fields);
+//                    member.fields.removeAll(allFields);
+//                }
+                UnionDeserializer.SingleMemberHandler<Union, Kind, Member> member =
+                        new SingleMemberHandler<>(tag, deserializer, new HashSet<>(od.fieldNames()));
                 objectMembers.add(member);
                 if (od.shortcutProperty() != null) {
                     // also add it as a string
@@ -194,6 +197,16 @@ public class UnionDeserializer<Union, Kind, Member> implements JsonpDeserializer
 
         @Override
         public JsonpDeserializer<Union> build() {
+            Map<String, Long> fieldFrequencies = objectMembers.stream().flatMap(m -> m.fields.stream())
+                    .collect( Collectors.groupingBy(Function.identity(), Collectors.counting()));
+            Set<String> duplicateFields = fieldFrequencies.entrySet().stream()
+                    .filter(entry -> entry.getValue() > 1)
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toSet());
+            for (UnionDeserializer.SingleMemberHandler<Union, Kind, Member> member: objectMembers) {
+                member.fields.removeAll(duplicateFields);
+            }
+
             // Check that no object member had all its fields removed
             for (UnionDeserializer.SingleMemberHandler<Union, Kind, Member> member: objectMembers) {
                 if (member.fields.isEmpty()) {

--- a/java-client/src/main/java/org/opensearch/client/json/UnionDeserializer.java
+++ b/java-client/src/main/java/org/opensearch/client/json/UnionDeserializer.java
@@ -171,13 +171,6 @@ public class UnionDeserializer<Union, Kind, Member> implements JsonpDeserializer
             JsonpDeserializer<?> unwrapped = DelegatingDeserializer.unwrap(deserializer);
             if (unwrapped instanceof ObjectDeserializer) {
                 ObjectDeserializer<?> od = (ObjectDeserializer<?>) unwrapped;
-//                Set<String> allFields = od.fieldNames();
-//                Set<String> fields = new HashSet<>(allFields); // copy to update
-//                for (UnionDeserializer.SingleMemberHandler<Union, Kind, Member> member: objectMembers) {
-//                    // Remove respective fields on both sides to keep specific ones
-//                    fields.removeAll(member.fields);
-//                    member.fields.removeAll(allFields);
-//                }
                 UnionDeserializer.SingleMemberHandler<Union, Kind, Member> member =
                         new SingleMemberHandler<>(tag, deserializer, new HashSet<>(od.fieldNames()));
                 objectMembers.add(member);


### PR DESCRIPTION
This commit fixes the issue where a completion suggester search request was being parsed as a term suggester and failing due to "Missing required property 'TermSuggestOption.score'"

### Description
Fixes failure of completion suggester due to being improperly parsed as a term suggester. 

This solution was originally proposed by @apatrida, but due to the age of the original bug report and a pressing need for a fix, I created the PR as well as a corresponding integration test.

### Issues Resolved
https://github.com/opensearch-project/opensearch-java/issues/107

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
