### PR TITLE
httpclient builder: tls strategy customization

### DIFF
--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5TransportBuilder.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5TransportBuilder.java
@@ -79,6 +79,7 @@ public class ApacheHttpClient5TransportBuilder {
     private Optional<Boolean> chunkedEnabled;
     private JsonpMapper mapper;
     private TransportOptions options;
+    private TlsStrategy tlsStrategy;
 
     /**
      * Creates a new builder instance and sets the hosts that the client will send requests to.
@@ -264,6 +265,16 @@ public class ApacheHttpClient5TransportBuilder {
     }
 
     /**
+     * Optional custom tls strategy to replace the default
+     *
+     * @param tlsStrategy custom tlsStrategy
+     */
+    public ApacheHttpClient5TransportBuilder setTlsStrategy(TlsStrategy tlsStrategy) {
+        this.tlsStrategy = tlsStrategy;
+        return this;
+    }
+
+    /**
      * Creates a new {@link RestClient} based on the provided configuration.
      */
     public ApacheHttpClient5Transport build() {
@@ -338,7 +349,7 @@ public class ApacheHttpClient5TransportBuilder {
         }
 
         try {
-            final TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
+            final TlsStrategy tlsStrategy = this.tlsStrategy != null ? this.tlsStrategy : ClientTlsStrategyBuilder.create()
                 .setSslContext(SSLContext.getDefault())
                 // See https://issues.apache.org/jira/browse/HTTPCLIENT-2219
                 .setTlsDetailsFactory(new Factory<SSLEngine, TlsDetails>() {


### PR DESCRIPTION
Signed-off-by: Jan Berge Sommerdahl <jan@jotta.no>

### Description
Allows custom tls strategies to be used with ApacheHttpClient5TransportBuilder

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
