### PR TITLE
Bumps Jackson from 2.14.1 to 2.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `classgraph` from 4.8.149 to 4.8.154
+- Bumps `Jackson` from 2.14.1 to 2.14.2 ([#357](https://github.com/opensearch-project/opensearch-java/pull/357))
 
 ### Dependencies
 - Bumps `grgit-gradle` from 4.0.1 to 5.0.0

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -144,8 +144,8 @@ val integrationTest = task<Test>("integrationTest") {
 dependencies {
 
     val opensearchVersion = "3.0.0-SNAPSHOT"
-    val jacksonVersion = "2.14.1"
-    val jacksonDatabindVersion = "2.14.1"
+    val jacksonVersion = "2.14.2"
+    val jacksonDatabindVersion = "2.14.2"
 
     // Apache 2.0
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Bumps Jackson from 2.14.1 to 2.14.2

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
