### PR TITLE
[Backport] [2.x] Bumps Jackson from 2.14.1 to 2.14.2 (#357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bumps `grgit-gradle` from 4.0.1 to 5.0.0
 - Update Jackson to 2.14.0 ([#259](https://github.com/opensearch-project/opensearch-java/pull/259))
+- Bumps `Jackson` from 2.14.1 to 2.14.2 ([#357](https://github.com/opensearch-project/opensearch-java/pull/357))
 
 ### Changed
 - Update literature around changelog contributions in CONTRIBUTING.md ([#242](https://github.com/opensearch-project/opensearch-java/pull/242))

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -140,8 +140,8 @@ val integrationTest = task<Test>("integrationTest") {
 dependencies {
 
     val opensearchVersion = "2.4.1"
-    val jacksonVersion = "2.14.1"
-    val jacksonDatabindVersion = "2.14.1"
+    val jacksonVersion = "2.14.2"
+    val jacksonDatabindVersion = "2.14.2"
 
     // Apache 2.0
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/357 to `2.x`