### PR TITLE
Upgrading compatibility to opensearch 2.5

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -17,6 +17,8 @@ jobs:
           - { opensearch_version: 2.1.0, java: 11 }
           - { opensearch_version: 2.2.1, java: 11 }
           - { opensearch_version: 2.3.0, java: 11 }
+          - { opensearch_version: 2.4.0, java: 11 }
+          - { opensearch_version: 2.5.0, java: 11 }
     steps:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -17,7 +17,7 @@ jobs:
           - { opensearch_version: 2.1.0, java: 11 }
           - { opensearch_version: 2.2.1, java: 11 }
           - { opensearch_version: 2.3.0, java: 11 }
-          - { opensearch_version: 2.4.0, java: 11 }
+          - { opensearch_version: 2.4.1, java: 11 }
           - { opensearch_version: 2.5.0, java: 11 }
     steps:
       - name: Set up JDK ${{ matrix.java }}

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,10 +6,10 @@
 The below matrix shows the compatibility of the [`opensearch-java-client`](https://search.maven.org/artifact/org.opensearch.client/opensearch-java) with versions of [`OpenSearch`](https://opensearch.org/downloads.html#opensearch).
 
 | Client Version | OpenSearch Version |
-| --- | --- |
-| 1.0.0 | 1.0.0-1.3.3 |
-| 2.0.0 | 1.3.3-2.0.1 |
-| 2.1.0 | 1.3.3-2.3.0 |
+| --- |--------------------|
+| 1.0.0 | 1.0.0-1.3.3        |
+| 2.0.0 | 1.3.3-2.0.1        |
+| 2.1.0 | 1.3.3-2.5.0        |
 
 ## Upgrading
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,10 +6,11 @@
 The below matrix shows the compatibility of the [`opensearch-java-client`](https://search.maven.org/artifact/org.opensearch.client/opensearch-java) with versions of [`OpenSearch`](https://opensearch.org/downloads.html#opensearch).
 
 | Client Version | OpenSearch Version |
-| --- |--------------------|
-| 1.0.0 | 1.0.0-1.3.3        |
-| 2.0.0 | 1.3.3-2.0.1        |
-| 2.1.0 | 1.3.3-2.5.0        |
+|----------------|--------------------|
+| 1.0.0          | 1.0.0-1.3.3        |
+| 2.0.0          | 1.3.3-2.0.1        |
+| 2.1.0          | 1.3.3-2.3.0        |
+| 2.2.0          | 1.3.3-2.5.0        |
 
 ## Upgrading
 


### PR DESCRIPTION
### Description
Client version compatibility matrix required updating to the later versions of OpenSearch
Upgrading the tests to 2.4, 2.5 and updating the COMPATIBILITY.doc

### Issues Resolved
resolves #285 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
