### PR TITLE
Downgrade client to build with Java 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,16 +7,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 8, 11 ]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
 
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build with Gradle
         run: ./gradlew clean build -x test

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -60,8 +60,8 @@ checkstyle {
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_11
-    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_1_8
 
     withJavadocJar()
     withSourcesJar()

--- a/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2Transport.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2Transport.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
@@ -294,9 +295,13 @@ public class AwsSdk2Transport implements OpenSearchTransport {
         Map<String, String> params = endpoint.queryParameters(request);
         if (params != null && !params.isEmpty()) {
             char sep = '?';
-            for (var ent : params.entrySet()) {
+            for (Map.Entry<String, String> ent : params.entrySet()) {
                 url.append(sep).append(ent.getKey()).append('=');
-                url.append(URLEncoder.encode(ent.getValue(), StandardCharsets.UTF_8));
+                try {
+                    url.append(URLEncoder.encode(ent.getValue(), StandardCharsets.UTF_8.name()));
+                } catch (UnsupportedEncodingException e) {
+                    throw new AssertionError("UTF-8 is unknown");
+                }
                 sep = '&';
             }
         }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/aws/AwsSdk2SearchIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/aws/AwsSdk2SearchIT.java
@@ -18,6 +18,7 @@ import org.opensearch.client.opensearch.core.IndexResponse;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest.Builder;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -139,7 +140,7 @@ public class AwsSdk2SearchIT extends AwsSdk2TransportTestCase {
         resetTestIndex(false);
         // attempt to create the same index a second time
         OpenSearchIndicesClient client = getIndexesClient(false, null, null);
-        var req = new CreateIndexRequest.Builder().index(TEST_INDEX);
+        Builder req = new CreateIndexRequest.Builder().index(TEST_INDEX);
         Exception exception = Assert.assertThrows(OpenSearchException.class, () -> {
             client.create(req.build());
         });

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/aws/AwsSdk2TransportTestCase.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/aws/AwsSdk2TransportTestCase.java
@@ -26,6 +26,7 @@ import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.opensearch.indices.IndexState;
 import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest.Builder;
 import org.opensearch.client.transport.TransportOptions;
 import org.opensearch.client.transport.aws.AwsSdk2Transport;
 import org.opensearch.client.transport.aws.AwsSdk2TransportOptions;
@@ -207,13 +208,13 @@ public abstract class AwsSdk2TransportTestCase {
         if (indexExists) {
             client.delete(b -> b.index(List.of(TEST_INDEX)));
         }
-        var req = new CreateIndexRequest.Builder()
+        Builder req = new CreateIndexRequest.Builder()
                 .index(TEST_INDEX);
         client.create(req.build());
     }
 
     protected SearchResponse<SimplePojo> query(OpenSearchClient client, String title, String text) throws Exception {
-        var query = Query.of(qb -> {
+        Query query = Query.of(qb -> {
             if (title != null) {
                 qb.match(mb -> mb.field("title").query(vb -> vb.stringValue(title)));
             }
@@ -237,7 +238,7 @@ public abstract class AwsSdk2TransportTestCase {
 
     protected CompletableFuture<SearchResponse<SimplePojo>> query(
             OpenSearchAsyncClient client, String title, String text) {
-        var query = Query.of(qb -> {
+        Query query = Query.of(qb -> {
             if (title != null) {
                 qb.match(mb -> mb.field("title").query(vb -> vb.stringValue(title)));
             }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/httpclient5/HttpClient5TransportSupport.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/httpclient5/HttpClient5TransportSupport.java
@@ -51,7 +51,7 @@ interface HttpClient5TransportSupport extends OpenSearchTransportSupport {
         return builder.setStrictDeprecationMode(true).build();
     }
 
-    private void configure(ApacheHttpClient5TransportBuilder builder, Settings settings, HttpHost[] hosts) throws IOException {
+    default void configure(ApacheHttpClient5TransportBuilder builder, Settings settings, HttpHost[] hosts) throws IOException {
         if (isHttps()) {
             try {
                 final SSLContext sslcontext = SSLContextBuilder


### PR DESCRIPTION
### Description
Coming from #156, this downgrades the target to Java 8. This has to go in after #326.

### Issues Resolved
Closes #156 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
