### PR TITLE
Upgrade dependabot PR action.

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -1,5 +1,12 @@
 name: Dependabot PR actions
-on: pull_request
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
 
 jobs:
   dependabot:
@@ -23,7 +30,7 @@ jobs:
           token: ${{ steps.github_app_token.outputs.token }}
 
       - name: Update the changelog
-        uses: dangoslen/dependabot-changelog-helper@v1
+        uses: dangoslen/dependabot-changelog-helper@v2
         with:
           version: 'Unreleased'
 

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -29,10 +29,14 @@ jobs:
         with:
           token: ${{ steps.github_app_token.outputs.token }}
 
+      - id: version
+        run: |
+          echo "::set-output name=version::$(cat gradle.properties | grep systemProp.version | cut -d' ' -f3 | cut -d\. -f1,2)"
+
       - name: Update the changelog
         uses: dangoslen/dependabot-changelog-helper@v2
         with:
-          version: 'Unreleased'
+          version: "Unreleased ${{ steps.version.outputs.version }}"
 
       - name: Commit the changes
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
### Description

In https://github.com/opensearch-project/opensearch-java/pull/458 we failed to update CHANGELOG because the version in it didn't match. Get the version dynamically from .properties.

Here is an output from the version task to ensure the grep/cut combination works: https://github.com/dblock/opensearch-java/actions/runs/4789190392/jobs/8516753346

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
