### PR TITLE
fix: handle String error deserialization for ErrorCause object (#301)…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Do not double-wrap OpenSearchException on error ([#323](https://github.com/opensearch-project/opensearch-java/pull/323))
 - Fix AwsSdk2TransportOptions.responseCompression ([#322](https://github.com/opensearch-project/opensearch-java/pull/322))
 - Fix missing Highlight and SourceConfig in the MultisearchBody ([#442](https://github.com/opensearch-project/opensearch-java/pull/442))
+- Fix parsing /_alias error response for not existing alias ([#476](https://github.com/opensearch-project/opensearch-java/pull/476))
+
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/ErrorResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/ErrorResponse.java
@@ -42,10 +42,12 @@ import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.JsonpSerializable;
 import org.opensearch.client.json.ObjectBuilderDeserializer;
 import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.json.UnionDeserializer;
 import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.ObjectBuilder;
 import org.opensearch.client.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
+
 import java.util.function.Function;
 
 // typedef: _types.ErrorResponseBase
@@ -57,6 +59,11 @@ import java.util.function.Function;
  */
 @JsonpDeserializable
 public class ErrorResponse implements JsonpSerializable {
+
+	private enum Kind {
+		OBJECT,
+		STRING
+	}
 	private final ErrorCause error;
 
 	private final int status;
@@ -164,9 +171,22 @@ public class ErrorResponse implements JsonpSerializable {
 
 	protected static void setupErrorResponseDeserializer(ObjectDeserializer<ErrorResponse.Builder> op) {
 
-		op.add(Builder::error, ErrorCause._DESERIALIZER, "error");
+		op.add(Builder::error, buildErrorCauseDeserializers(), "error");
 		op.add(Builder::status, JsonpDeserializer.integerDeserializer(), "status");
 
+	}
+
+	protected static JsonpDeserializer<ErrorCause> buildErrorCauseDeserializers() {
+		return new UnionDeserializer.Builder<>(ErrorResponse::getErrorCause, false)
+				.addMember(Kind.OBJECT, ErrorCause._DESERIALIZER)
+				.addMember(Kind.STRING, JsonpDeserializer.stringDeserializer())
+				.build();
+	}
+
+	private static ErrorCause getErrorCause(Kind kind, Object errorCause) {
+		return Kind.STRING.equals(kind) ?
+				ErrorCause.of(builder -> builder.type("string_error").reason((String) errorCause)) :
+				(ErrorCause) errorCause;
 	}
 
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractIndicesClientIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractIndicesClientIT.java
@@ -15,6 +15,8 @@ import org.opensearch.client.opensearch.indices.CreateIndexResponse;
 import org.opensearch.client.opensearch.indices.DataStream;
 import org.opensearch.client.opensearch.indices.DataStreamsStatsResponse;
 import org.opensearch.client.opensearch.indices.DeleteDataStreamResponse;
+import org.opensearch.client.opensearch.indices.GetAliasRequest;
+import org.opensearch.client.opensearch.indices.GetAliasResponse;
 import org.opensearch.client.opensearch.indices.GetDataStreamResponse;
 import org.opensearch.client.opensearch.indices.GetIndexRequest;
 import org.opensearch.client.opensearch.indices.GetIndexResponse;
@@ -186,6 +188,21 @@ public abstract class AbstractIndicesClientIT extends OpenSearchJavaClientTestCa
         } catch (OpenSearchException ex) {
             assertNotNull(ex);
             assertEquals(ex.status(), 404);
+        }
+    }
+
+    public void testGetNotExistingIndexAlias() throws Exception {
+        String notExistingIndexAlias = "alias_not_exists";
+        GetAliasRequest aliasRequest = new GetAliasRequest.Builder().name(notExistingIndexAlias).build();
+        try {
+            GetAliasResponse response = javaClient().indices().getAlias(aliasRequest);
+            fail();
+        } catch (OpenSearchException ex) {
+            assertNotNull(ex);
+            assertEquals(ex.status(), 404);
+            assertEquals(ex.getMessage(),
+                    "Request failed: [string_error] " +
+                            "alias [alias_not_exists] missing");
         }
     }
 }


### PR DESCRIPTION
… (#476)

* fix: handle String error deserialization for ErrorCause object (#301)



* update CHANGELOG.md



---------

### Description
Backport https://github.com/opensearch-project/opensearch-java/pull/476 to 2.x

@reta Some time ago, the backport was done automatically, right?

### Issues Resolved
https://github.com/opensearch-project/opensearch-java/issues/301

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
