### PR TITLE
Upgrading gradle plugin dependency-license-report to 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `io.github.classgraph:classgraph` from 4.8.157 to 4.8.158
+- Bumps `com.github.jk1.dependency-license-report` from 1.19 to 2.2
 
 ### Changed
 - Migrate client transports to Apache HttpClient / Core 5.x ([#246](https://github.com/opensearch-project/opensearch-java/pull/246))

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -51,7 +51,7 @@ plugins {
     `java-library`
     checkstyle
     `maven-publish`
-    id("com.github.jk1.dependency-license-report") version "1.19"
+    id("com.github.jk1.dependency-license-report") version "2.2"
 }
 apply(plugin = "opensearch.repositories")
 


### PR DESCRIPTION
### Description
2.2 version of Gradle plugin dependency-license-report is now available. The upgrade previously to the 2.x line of the plugin was not successful given the issues in 2.0 and 2.1 versions of the plugin.

### Issues Resolved
Closes #219

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
