### PR TITLE
Set up cron testing for integration tests against unreleased OpenSearch

### DIFF
--- a/.github/test-failure-issue-template.md
+++ b/.github/test-failure-issue-template.md
@@ -1,0 +1,5 @@
+---
+title: Integration tests against the server failing
+labels: bug, test-failure
+---
+Integration tests against the server have failed. Please look into it to determine and fix the cause of failure.

--- a/.github/workflows/test-integration-unreleased.yml
+++ b/.github/workflows/test-integration-unreleased.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - "main"
+  schedule:
+    - cron: '0 8 * * *'
 
 jobs:
   test:
@@ -21,6 +23,14 @@ jobs:
           - { opensearch_ref: 'main', java: 11 }
           - { opensearch_ref: 'main', java: 17 }
     steps:
+    - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
       - name: Set up JDK ${{ matrix.entry.java }}
         uses: actions/setup-java@v3
         with:
@@ -82,3 +92,12 @@ jobs:
           name: test-reports
           path: opensearch-java/java-client/build/reports/
           retention-days: 7
+
+      - name: Create issue about failure
+        if: failure() && github.event_name == 'schedule'
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}
+        with:
+          filename: .github/test-failure-issue-template.md
+          update_existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Document HTTP/2 support ([#330](https://github.com/opensearch-project/opensearch-java/pull/330))
 - Added Point-In-Time APIs ([#461](https://github.com/opensearch-project/opensearch-java/pull/461))
+- Set up cron schedule and failure monitoring for integration tests against unreleased OpenSearch ([#]())
 
 ### Dependencies
 


### PR DESCRIPTION
### Description
Setting up cron testing for integration tests against unreleased OpenSearch. If the tests fail from this cron, an issue gets created in the repo to look into the issue. If an issue already exists, the workflow will update the existing issue instead of creating a new one. 

### Issues Resolved
Part of #469 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
