### PR TITLE
[Backport 2.x] Upgrading gradle plugin dependency-license-report to 2.2 (#483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added Point-In-Time APIs ([#461](https://github.com/opensearch-project/opensearch-java/pull/461))
 
 ### Dependencies
+- Bumps `com.github.jk1.dependency-license-report` from 1.19 to 2.2
 
 ### Changed
 - Improve time taken by Github actions by using cache ([#439](https://github.com/opensearch-project/opensearch-java/pull/439))

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -48,7 +48,7 @@ plugins {
     `java-library`
     checkstyle
     `maven-publish`
-    id("com.github.jk1.dependency-license-report") version "1.19"
+    id("com.github.jk1.dependency-license-report") version "2.2"
 }
 
 checkstyle {


### PR DESCRIPTION
* Upgrading gradle plugin dependency-license-report to 2.x line



* Add Changelog



---------

### Description
Backport #483 to 2.x

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
