### PR TITLE
refactor: deprecate totalDataSetSize and totalDataSetSizeInBytes in S…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update maintainers, admins and documentation ([#248](https://github.com/opensearch-project/opensearch-java/pull/248))
 
 ### Deprecated
+- Deprecate the totalDataSetSize and totalDataSetSizeInBytes fields in the StoreStats ([#498](https://github.com/opensearch-project/opensearch-java/pull/498))
+
 
 ### Removed
 - Remove support for unsupported dynamic_templates in bulk ([#276](https://github.com/opensearch-project/opensearch-java/pull/276))

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/StoreStats.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/StoreStats.java
@@ -64,9 +64,11 @@ public class StoreStats implements JsonpSerializable {
 
 	private final long reservedInBytes;
 
+	@Deprecated
 	@Nullable
 	private final String totalDataSetSize;
 
+	@Deprecated
 	@Nullable
 	private final Long totalDataSetSizeInBytes;
 
@@ -118,16 +120,22 @@ public class StoreStats implements JsonpSerializable {
 	}
 
 	/**
+	 * @deprecated
+	 * Not returned by server
 	 * API name: {@code total_data_set_size}
 	 */
+	@Deprecated
 	@Nullable
 	public final String totalDataSetSize() {
 		return this.totalDataSetSize;
 	}
 
 	/**
+	 * @deprecated
+	 * Not returned by server
 	 * API name: {@code total_data_set_size_in_bytes}
 	 */
+	@Deprecated
 	@Nullable
 	public final Long totalDataSetSizeInBytes() {
 		return this.totalDataSetSizeInBytes;
@@ -190,9 +198,11 @@ public class StoreStats implements JsonpSerializable {
 
 		private Long reservedInBytes;
 
+		@Deprecated
 		@Nullable
 		private String totalDataSetSize;
 
+		@Deprecated
 		@Nullable
 		private Long totalDataSetSizeInBytes;
 
@@ -229,16 +239,22 @@ public class StoreStats implements JsonpSerializable {
 		}
 
 		/**
+		 * @deprecated
+		 * Not returned by server
 		 * API name: {@code total_data_set_size}
 		 */
+		@Deprecated
 		public final Builder totalDataSetSize(@Nullable String value) {
 			this.totalDataSetSize = value;
 			return this;
 		}
 
 		/**
+		 * @deprecated
+		 * Not returned by server
 		 * API name: {@code total_data_set_size_in_bytes}
 		 */
+		@Deprecated
 		public final Builder totalDataSetSizeInBytes(@Nullable Long value) {
 			this.totalDataSetSizeInBytes = value;
 			return this;


### PR DESCRIPTION
…toreStats

### Description
Deprecate totalDataSetSize and totalDataSetSizeInBytes in StoreStats

### Issues Resolved
https://github.com/opensearch-project/opensearch-java/issues/497

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
