### PR TITLE
fix: add missing translog sync interval option to index settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 ### Deprecated
+- Deprecate translogDurability and translogFlushThresholdSize in IndexSettings in favor of a separate translog object ([#518](https://github.com/opensearch-project/opensearch-java/pull/518))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Add support for knn_vector field type ([#529](https://github.com/opensearch-project/opensearch-java/pull/524))
+- Add translog option object and missing translog sync interval option in index settings ([#518](https://github.com/opensearch-project/opensearch-java/pull/518))
 
 ### Dependencies
 - Bumps `jackson` from 2.14.2 to 2.15.2 ((#537)[https://github.com/opensearch-project/opensearch-java/pull/537])

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexSettings.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexSettings.java
@@ -199,10 +199,16 @@ public class IndexSettings implements JsonpSerializable {
 	private final Integer maxSlicesPerScroll;
 
 	@Nullable
+	private final Translog translog;
+
+	@Nullable
 	private final String translogDurability;
 
 	@Nullable
 	private final String translogFlushThresholdSize;
+
+	@Nullable
+	private final Time translogSyncInterval;
 
 	@Nullable
 	private final Boolean queryStringLenient;
@@ -280,8 +286,10 @@ public class IndexSettings implements JsonpSerializable {
 		this.verifiedBeforeClose = builder.verifiedBeforeClose;
 		this.format = builder.format;
 		this.maxSlicesPerScroll = builder.maxSlicesPerScroll;
+		this.translog = builder.translog;
 		this.translogDurability = builder.translogDurability;
 		this.translogFlushThresholdSize = builder.translogFlushThresholdSize;
+		this.translogSyncInterval = builder.translogSyncInterval;
 		this.queryStringLenient = builder.queryStringLenient;
 		this.priority = builder.priority;
 		this.topMetricsMaxSize = builder.topMetricsMaxSize;
@@ -681,6 +689,14 @@ public class IndexSettings implements JsonpSerializable {
 	}
 
 	/**
+	 * API name: {@code translog}
+	 */
+	@Nullable
+	public final Translog translog() {
+		return this.translog;
+	}
+
+	/**
 	 * API name: {@code translog.durability}
 	 */
 	@Nullable
@@ -694,6 +710,14 @@ public class IndexSettings implements JsonpSerializable {
 	@Nullable
 	public final String translogFlushThresholdSize() {
 		return this.translogFlushThresholdSize;
+	}
+
+	/**
+	 * API name: {@code translog.sync_interval}
+	 */
+	@Nullable
+	public final Time translogSyncInterval() {
+		return this.translogSyncInterval;
 	}
 
 	/**
@@ -1016,6 +1040,11 @@ public class IndexSettings implements JsonpSerializable {
 			generator.write(this.maxSlicesPerScroll);
 
 		}
+		if (this.translog != null) {
+			generator.writeKey("translog");
+			this.translog.serialize(generator, mapper);
+
+		}
 		if (this.translogDurability != null) {
 			generator.writeKey("translog.durability");
 			generator.write(this.translogDurability);
@@ -1024,6 +1053,11 @@ public class IndexSettings implements JsonpSerializable {
 		if (this.translogFlushThresholdSize != null) {
 			generator.writeKey("translog.flush_threshold_size");
 			generator.write(this.translogFlushThresholdSize);
+
+		}
+		if (this.translogSyncInterval != null) {
+			generator.writeKey("translog.sync_interval");
+			this.translogSyncInterval.serialize(generator, mapper);
 
 		}
 		if (this.queryStringLenient != null) {
@@ -1221,10 +1255,16 @@ public class IndexSettings implements JsonpSerializable {
 		private Integer maxSlicesPerScroll;
 
 		@Nullable
+		private Translog translog;
+
+		@Nullable
 		private String translogDurability;
 
 		@Nullable
 		private String translogFlushThresholdSize;
+
+		@Nullable
+		private Time translogSyncInterval;
 
 		@Nullable
 		private Boolean queryStringLenient;
@@ -1717,6 +1757,14 @@ public class IndexSettings implements JsonpSerializable {
 		}
 
 		/**
+		 * API name: {@code translog}
+		 */
+		public final Builder translog(@Nullable Translog value) {
+			this.translog = value;
+			return this;
+		}
+
+		/**
 		 * API name: {@code translog.durability}
 		 */
 		public final Builder translogDurability(@Nullable String value) {
@@ -1729,6 +1777,14 @@ public class IndexSettings implements JsonpSerializable {
 		 */
 		public final Builder translogFlushThresholdSize(@Nullable String value) {
 			this.translogFlushThresholdSize = value;
+			return this;
+		}
+
+		/**
+		 * API name: {@code translog.sync_interval}
+		 */
+		public final Builder translogSyncInterval(@Nullable Time value) {
+			this.translogSyncInterval = value;
 			return this;
 		}
 
@@ -1920,10 +1976,13 @@ public class IndexSettings implements JsonpSerializable {
 		op.add(Builder::format, JsonpDeserializer.stringDeserializer(), "format", "index.format");
 		op.add(Builder::maxSlicesPerScroll, JsonpDeserializer.integerDeserializer(), "max_slices_per_scroll",
 				"index.max_slices_per_scroll");
+		op.add(Builder::translog, Translog._DESERIALIZER, "translog", "index.translog");
 		op.add(Builder::translogDurability, JsonpDeserializer.stringDeserializer(), "translog.durability",
 				"index.translog.durability");
 		op.add(Builder::translogFlushThresholdSize, JsonpDeserializer.stringDeserializer(),
 				"translog.flush_threshold_size", "index.translog.flush_threshold_size");
+		op.add(Builder::translogSyncInterval, Time._DESERIALIZER,
+				"translog.sync_interval", "index.translog.sync_interval");
 		op.add(Builder::queryStringLenient, JsonpDeserializer.booleanDeserializer(), "query_string.lenient",
 				"index.query_string.lenient");
 		op.add(Builder::priority, JsonpDeserializer.stringDeserializer(), "priority", "index.priority");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexSettings.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexSettings.java
@@ -36,20 +36,21 @@
 
 package org.opensearch.client.opensearch.indices;
 
-import org.opensearch.client.opensearch._types.Time;
+import jakarta.json.stream.JsonGenerator;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.JsonpSerializable;
 import org.opensearch.client.json.ObjectBuilderDeserializer;
 import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.ObjectBuilder;
 import org.opensearch.client.util.ObjectBuilderBase;
-import jakarta.json.stream.JsonGenerator;
+
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 
 // typedef: indices._types.IndexSettings
 
@@ -202,15 +203,6 @@ public class IndexSettings implements JsonpSerializable {
 	private final Translog translog;
 
 	@Nullable
-	private final String translogDurability;
-
-	@Nullable
-	private final String translogFlushThresholdSize;
-
-	@Nullable
-	private final Time translogSyncInterval;
-
-	@Nullable
 	private final Boolean queryStringLenient;
 
 	@Nullable
@@ -287,9 +279,6 @@ public class IndexSettings implements JsonpSerializable {
 		this.format = builder.format;
 		this.maxSlicesPerScroll = builder.maxSlicesPerScroll;
 		this.translog = builder.translog;
-		this.translogDurability = builder.translogDurability;
-		this.translogFlushThresholdSize = builder.translogFlushThresholdSize;
-		this.translogSyncInterval = builder.translogSyncInterval;
 		this.queryStringLenient = builder.queryStringLenient;
 		this.priority = builder.priority;
 		this.topMetricsMaxSize = builder.topMetricsMaxSize;
@@ -698,26 +687,22 @@ public class IndexSettings implements JsonpSerializable {
 
 	/**
 	 * API name: {@code translog.durability}
+	 * @deprecated use {@link #translog()} instead
 	 */
+	@Deprecated
 	@Nullable
 	public final String translogDurability() {
-		return this.translogDurability;
+		return this.translog != null ? this.translog.durability() : null;
 	}
 
 	/**
 	 * API name: {@code translog.flush_threshold_size}
+	 * @deprecated use {@link #translog()} instead
 	 */
+	@Deprecated
 	@Nullable
 	public final String translogFlushThresholdSize() {
-		return this.translogFlushThresholdSize;
-	}
-
-	/**
-	 * API name: {@code translog.sync_interval}
-	 */
-	@Nullable
-	public final Time translogSyncInterval() {
-		return this.translogSyncInterval;
+		return this.translog != null ? this.translog.flushThresholdSize() : null;
 	}
 
 	/**
@@ -1045,21 +1030,6 @@ public class IndexSettings implements JsonpSerializable {
 			this.translog.serialize(generator, mapper);
 
 		}
-		if (this.translogDurability != null) {
-			generator.writeKey("translog.durability");
-			generator.write(this.translogDurability);
-
-		}
-		if (this.translogFlushThresholdSize != null) {
-			generator.writeKey("translog.flush_threshold_size");
-			generator.write(this.translogFlushThresholdSize);
-
-		}
-		if (this.translogSyncInterval != null) {
-			generator.writeKey("translog.sync_interval");
-			this.translogSyncInterval.serialize(generator, mapper);
-
-		}
 		if (this.queryStringLenient != null) {
 			generator.writeKey("query_string.lenient");
 			generator.write(this.queryStringLenient);
@@ -1256,15 +1226,6 @@ public class IndexSettings implements JsonpSerializable {
 
 		@Nullable
 		private Translog translog;
-
-		@Nullable
-		private String translogDurability;
-
-		@Nullable
-		private String translogFlushThresholdSize;
-
-		@Nullable
-		private Time translogSyncInterval;
 
 		@Nullable
 		private Boolean queryStringLenient;
@@ -1766,25 +1727,33 @@ public class IndexSettings implements JsonpSerializable {
 
 		/**
 		 * API name: {@code translog.durability}
+		 * @deprecated use {@link #translog()} instead
 		 */
+		@Deprecated
 		public final Builder translogDurability(@Nullable String value) {
-			this.translogDurability = value;
+			if (translog == null) {
+				translog = Translog.of(b -> b.durability(value));
+			} else {
+				translog = Translog.of(b -> b.durability(value)
+						.flushThresholdSize(translog.flushThresholdSize())
+						.syncInterval(translog.syncInterval()));
+			}
 			return this;
 		}
 
 		/**
 		 * API name: {@code translog.flush_threshold_size}
+		 * @deprecated use {@link #translog()} instead
 		 */
+		@Deprecated
 		public final Builder translogFlushThresholdSize(@Nullable String value) {
-			this.translogFlushThresholdSize = value;
-			return this;
-		}
-
-		/**
-		 * API name: {@code translog.sync_interval}
-		 */
-		public final Builder translogSyncInterval(@Nullable Time value) {
-			this.translogSyncInterval = value;
+			if (translog == null) {
+				translog = Translog.of(b -> b.flushThresholdSize(value));
+			} else {
+				translog = Translog.of(b -> b.flushThresholdSize(value)
+						.durability(translog.durability())
+						.syncInterval(translog.syncInterval()));
+			}
 			return this;
 		}
 
@@ -1981,8 +1950,6 @@ public class IndexSettings implements JsonpSerializable {
 				"index.translog.durability");
 		op.add(Builder::translogFlushThresholdSize, JsonpDeserializer.stringDeserializer(),
 				"translog.flush_threshold_size", "index.translog.flush_threshold_size");
-		op.add(Builder::translogSyncInterval, Time._DESERIALIZER,
-				"translog.sync_interval", "index.translog.sync_interval");
 		op.add(Builder::queryStringLenient, JsonpDeserializer.booleanDeserializer(), "query_string.lenient",
 				"index.query_string.lenient");
 		op.add(Builder::priority, JsonpDeserializer.stringDeserializer(), "priority", "index.priority");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/Translog.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/Translog.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch.indices;
+
+import jakarta.json.stream.JsonGenerator;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.opensearch._types.Time;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+import javax.annotation.Nullable;
+import java.util.function.Function;
+
+
+@JsonpDeserializable
+public class Translog implements JsonpSerializable {
+
+    @Nullable
+    private final String durability;
+
+    @Nullable
+    private final String flushThresholdSize;
+
+    @Nullable
+    private final Time syncInterval;
+
+    private Translog(Builder builder) {
+
+        this.durability = builder.durability;
+        this.flushThresholdSize = builder.flushThresholdSize;
+        this.syncInterval = builder.syncInterval;
+
+    }
+
+    public static Translog of(Function<Builder, ObjectBuilder<Translog>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * API name: {@code durability}
+     */
+    @Nullable
+    public final String durability() {
+        return this.durability;
+    }
+
+    /**
+     * API name: {@code flush_threshold_size}
+     */
+    @Nullable
+    public final String flushThresholdSize() {
+        return this.flushThresholdSize;
+    }
+
+    /**
+     * API name: {@code sync_interval}
+     */
+    @Nullable
+    public final Time syncInterval() {
+        return this.syncInterval;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        if (this.durability != null) {
+            generator.writeKey("durability");
+            generator.write(this.durability);
+
+        }
+        if (this.flushThresholdSize != null) {
+            generator.writeKey("flush_threshold_size");
+            generator.write(this.flushThresholdSize);
+
+        }
+        if (this.syncInterval != null) {
+            generator.writeKey("sync_interval");
+            this.syncInterval.serialize(generator, mapper);
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link Translog}.
+     */
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Translog> {
+
+        @Nullable
+        private String durability;
+
+        @Nullable
+        private String flushThresholdSize;
+
+        @Nullable
+        private Time syncInterval;
+
+        /**
+         * API name: {@code durability}
+         */
+        public final Translog.Builder durability(@Nullable String value) {
+            this.durability = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code flush_threshold_size}
+         */
+        public final Translog.Builder flushThresholdSize(@Nullable String value) {
+            this.flushThresholdSize = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code sync_interval}
+         */
+        public final Translog.Builder syncInterval(@Nullable Time value) {
+            this.syncInterval = value;
+            return this;
+        }
+
+        /**
+         * Builds a {@link Translog}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public Translog build() {
+            _checkSingleUse();
+
+            return new Translog(this);
+        }
+    }
+
+    /**
+     * Json deserializer for {@link Translog}
+     */
+    public static final JsonpDeserializer<Translog> _DESERIALIZER = ObjectBuilderDeserializer.lazy(Builder::new,
+            Translog::setupTranslogDeserializer);
+
+    protected static void setupTranslogDeserializer(ObjectDeserializer<Translog.Builder> op) {
+
+        op.add(Translog.Builder::durability, JsonpDeserializer.stringDeserializer(), "durability");
+        op.add(Translog.Builder::flushThresholdSize, JsonpDeserializer.stringDeserializer(), "flush_threshold_size");
+        op.add(Translog.Builder::syncInterval, Time._DESERIALIZER, "sync_interval");
+
+    }
+
+}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/experiments/ParsingTests.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/experiments/ParsingTests.java
@@ -33,13 +33,15 @@
 package org.opensearch.client.opensearch.experiments;
 
 import jakarta.json.spi.JsonProvider;
-import jakarta.json.stream.JsonGenerator;
-import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpSerializable;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch.experiments.api.FooRequest;
+import org.opensearch.client.opensearch.indices.IndexSettings;
 import org.opensearch.client.opensearch.indices.IndexSettingsMapping;
 
 import java.io.ByteArrayInputStream;
@@ -53,8 +55,6 @@ public class ParsingTests extends Assert {
 
     try {
 
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
       FooRequest foo = FooRequest.builder()
               .name("z")
               .value(1)
@@ -64,19 +64,10 @@ public class ParsingTests extends Assert {
               )
               .build();
 
-      JsonProvider provider = JsonProvider.provider();
-      JsonGenerator generator = provider.createGenerator(baos);
-      foo.serialize(generator, new JsonbJsonpMapper());
-
-      generator.close();
-      String str = baos.toString();
-
+      String str = serialize(foo);
       assertEquals("{\"name\":\"z\",\"value\":1,\"indices\":[\"a\",\"b\",\"c\"],\"bar\":{\"name\":\"Raise the bar\"}}", str);
 
-      JsonParser parser = provider.createParser(new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8)));
-
-      FooRequest foo2 = FooRequest.parser().deserialize(parser, new JsonbJsonpMapper());
-
+      FooRequest foo2 = deserialize(str, FooRequest.parser());
       assertEquals(foo.name(), foo2.name());
       assertEquals(foo.value(), foo2.value());
       assertNull(foo2.size());
@@ -88,11 +79,31 @@ public class ParsingTests extends Assert {
   }
 
   @Test
-  public void testIndexSettingsMappingParsing() {
+  public void testIndexSettingsSyncIntervalTimeParsing() {
 
     try {
 
-      var baos = new ByteArrayOutputStream();
+      var indexSettings = IndexSettings.of(_1 -> _1.translogSyncInterval(Time.of(_2 -> _2.time("10s"))));
+
+      var str = serialize(indexSettings);
+      assertEquals("{\"translog.sync_interval\":\"10s\"}", str);
+
+      IndexSettings deserialized = deserialize(str, IndexSettings._DESERIALIZER);
+      assertEquals(indexSettings.translogSyncInterval().time(), deserialized.translogSyncInterval().time());
+
+      var responseStr = "{\"translog\":{\"sync_interval\":\"10s\"}}";
+      IndexSettings responseDeserialized = deserialize(responseStr, IndexSettings._DESERIALIZER);
+      assertEquals(indexSettings.translogSyncInterval().time(), responseDeserialized.translog().syncInterval().time());
+
+    } catch (JsonParsingException je) {
+      throw new JsonParsingException(je.getMessage() + " at " + je.getLocation(), je, je.getLocation());
+    }
+  }
+
+  @Test
+  public void testIndexSettingsMappingParsing() {
+
+    try {
 
       var mapping = IndexSettingsMapping.of(b -> b
               .totalFields(d -> d.limit(1L))
@@ -101,20 +112,11 @@ public class ParsingTests extends Assert {
               .nestedObjects(d -> d.limit(4L))
               .fieldNameLength(d -> d.limit(5L)));
 
-      var provider = JsonProvider.provider();
-      var generator = provider.createGenerator(baos);
-      mapping.serialize(generator, new JsonbJsonpMapper());
-
-      generator.close();
-      var str = baos.toString();
-
+      var str = serialize(mapping);
       assertEquals("{\"total_fields\":{\"limit\":1},\"depth\":{\"limit\":2},\"nested_fields\":{\"limit\":3}," +
                    "\"nested_objects\":{\"limit\":4},\"field_name_length\":{\"limit\":5}}", str);
 
-      var parser = provider.createParser(new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8)));
-
-      var deserialized = IndexSettingsMapping._DESERIALIZER.deserialize(parser, new JsonbJsonpMapper());
-
+      var deserialized = deserialize(str, IndexSettingsMapping._DESERIALIZER);
       assertEquals(mapping.totalFields().limit(), deserialized.totalFields().limit());
       assertEquals(mapping.depth().limit(), deserialized.depth().limit());
       assertEquals(mapping.nestedFields().limit(), deserialized.nestedFields().limit());
@@ -123,5 +125,23 @@ public class ParsingTests extends Assert {
     } catch (JsonParsingException je) {
       throw new JsonParsingException(je.getMessage() + " at " + je.getLocation(), je, je.getLocation());
     }
+  }
+
+  private <T extends JsonpSerializable> T deserialize(String serializedValue, JsonpDeserializer<T> deserializer) {
+    var provider = JsonProvider.provider();
+    var parser = provider.createParser(new ByteArrayInputStream(serializedValue.getBytes(StandardCharsets.UTF_8)));
+
+    return deserializer.deserialize(parser, new JsonbJsonpMapper());
+  }
+
+  private String serialize(JsonpSerializable object) {
+    var baos = new ByteArrayOutputStream();
+    var provider = JsonProvider.provider();
+
+    var generator = provider.createGenerator(baos);
+    object.serialize(generator, new JsonbJsonpMapper());
+    generator.close();
+
+    return baos.toString();
   }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/experiments/ParsingTests.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/experiments/ParsingTests.java
@@ -32,27 +32,15 @@
 
 package org.opensearch.client.opensearch.experiments;
 
-import jakarta.json.spi.JsonProvider;
-import org.junit.Assert;
 import org.junit.Test;
-import org.opensearch.client.json.JsonpDeserializer;
-import org.opensearch.client.json.JsonpSerializable;
-import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch.experiments.api.FooRequest;
 import org.opensearch.client.opensearch.indices.IndexSettings;
 import org.opensearch.client.opensearch.indices.IndexSettingsMapping;
 import org.opensearch.client.opensearch.indices.Translog;
+import org.opensearch.client.opensearch.model.ModelTestCase;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
-
-public class ParsingTests extends Assert {
+public class ParsingTests extends ModelTestCase {
 
   @Test
   public void testFoo() {
@@ -66,10 +54,10 @@ public class ParsingTests extends Assert {
             )
             .build();
 
-    String str = serialize(foo);
+    String str = toJson(foo);
     assertEquals("{\"name\":\"z\",\"value\":1,\"indices\":[\"a\",\"b\",\"c\"],\"bar\":{\"name\":\"Raise the bar\"}}", str);
 
-    FooRequest foo2 = deserialize(str, FooRequest.parser());
+    FooRequest foo2 = fromJson(str, FooRequest.parser());
     assertEquals(foo.name(), foo2.name());
     assertEquals(foo.value(), foo2.value());
     assertNull(foo2.size());
@@ -85,18 +73,18 @@ public class ParsingTests extends Assert {
             .durability("async")
             .flushThresholdSize("256mb"))));
 
-    var str = serialize(indexSettings);
+    var str = toJson(indexSettings);
     assertEquals("{\"translog\":{\"durability\":\"async\",\"flush_threshold_size\":\"256mb\"," +
             "\"sync_interval\":\"10s\"}}", str);
 
-    IndexSettings deserialized = deserialize(str, IndexSettings._DESERIALIZER);
+    IndexSettings deserialized = fromJson(str, IndexSettings._DESERIALIZER);
     assertEquals(indexSettings.translog().syncInterval().time(), deserialized.translog().syncInterval().time());
     assertEquals(indexSettings.translog().durability(), deserialized.translog().durability());
     assertEquals(indexSettings.translog().flushThresholdSize(), deserialized.translog().flushThresholdSize());
 
     var deprecatedForm = "{\"translog\":{\"sync_interval\":\"10s\"},\"translog.durability\":\"async\",\"translog" +
             ".flush_threshold_size\":\"256mb\"}";
-    IndexSettings deprecatedDeserialized = deserialize(deprecatedForm, IndexSettings._DESERIALIZER);
+    IndexSettings deprecatedDeserialized = fromJson(deprecatedForm, IndexSettings._DESERIALIZER);
     assertEquals(indexSettings.translog().syncInterval().time(), deprecatedDeserialized.translog().syncInterval().time());
     assertEquals(indexSettings.translog().durability(), deprecatedDeserialized.translog().durability());
     assertEquals(indexSettings.translog().flushThresholdSize(), deprecatedDeserialized.translog().flushThresholdSize());
@@ -112,11 +100,11 @@ public class ParsingTests extends Assert {
             .nestedObjects(d -> d.limit(4L))
             .fieldNameLength(d -> d.limit(5L)));
 
-    var str = serialize(mapping);
+    var str = toJson(mapping);
     assertEquals("{\"total_fields\":{\"limit\":1},\"depth\":{\"limit\":2},\"nested_fields\":{\"limit\":3}," +
                  "\"nested_objects\":{\"limit\":4},\"field_name_length\":{\"limit\":5}}", str);
 
-    var deserialized = deserialize(str, IndexSettingsMapping._DESERIALIZER);
+    var deserialized = fromJson(str, IndexSettingsMapping._DESERIALIZER);
     assertEquals(mapping.totalFields().limit(), deserialized.totalFields().limit());
     assertEquals(mapping.depth().limit(), deserialized.depth().limit());
     assertEquals(mapping.nestedFields().limit(), deserialized.nestedFields().limit());
@@ -124,21 +112,4 @@ public class ParsingTests extends Assert {
     assertEquals(mapping.fieldNameLength().limit(), deserialized.fieldNameLength().limit());
   }
 
-  private <T extends JsonpSerializable> T deserialize(String serializedValue, JsonpDeserializer<T> deserializer) {
-    var provider = JsonProvider.provider();
-    var parser = provider.createParser(new ByteArrayInputStream(serializedValue.getBytes(StandardCharsets.UTF_8)));
-
-    return deserializer.deserialize(parser, new JsonbJsonpMapper());
-  }
-
-  private String serialize(JsonpSerializable object) {
-    var baos = new ByteArrayOutputStream();
-    var provider = JsonProvider.provider();
-
-    var generator = provider.createGenerator(baos);
-    object.serialize(generator, new JsonbJsonpMapper());
-    generator.close();
-
-    return baos.toString();
-  }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/experiments/ParsingTests.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/experiments/ParsingTests.java
@@ -33,7 +33,6 @@
 package org.opensearch.client.opensearch.experiments;
 
 import jakarta.json.spi.JsonProvider;
-import jakarta.json.stream.JsonParsingException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -43,6 +42,11 @@ import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch.experiments.api.FooRequest;
 import org.opensearch.client.opensearch.indices.IndexSettings;
 import org.opensearch.client.opensearch.indices.IndexSettingsMapping;
+import org.opensearch.client.opensearch.indices.Translog;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -51,80 +55,73 @@ import java.nio.charset.StandardCharsets;
 public class ParsingTests extends Assert {
 
   @Test
-  public void testFoo() throws Exception {
+  public void testFoo() {
 
-    try {
+    FooRequest foo = FooRequest.builder()
+            .name("z")
+            .value(1)
+            .indices("a", "b", "c")
+            .bar(b -> b
+                    .name("Raise the bar")
+            )
+            .build();
 
-      FooRequest foo = FooRequest.builder()
-              .name("z")
-              .value(1)
-              .indices("a", "b", "c")
-              .bar(b -> b
-                      .name("Raise the bar")
-              )
-              .build();
+    String str = serialize(foo);
+    assertEquals("{\"name\":\"z\",\"value\":1,\"indices\":[\"a\",\"b\",\"c\"],\"bar\":{\"name\":\"Raise the bar\"}}", str);
 
-      String str = serialize(foo);
-      assertEquals("{\"name\":\"z\",\"value\":1,\"indices\":[\"a\",\"b\",\"c\"],\"bar\":{\"name\":\"Raise the bar\"}}", str);
-
-      FooRequest foo2 = deserialize(str, FooRequest.parser());
-      assertEquals(foo.name(), foo2.name());
-      assertEquals(foo.value(), foo2.value());
-      assertNull(foo2.size());
-      assertEquals(foo.indices(), foo2.indices());
-      assertEquals("Raise the bar", foo.bar().name());
-    } catch (JsonParsingException je) {
-      throw new JsonParsingException(je.getMessage() + " at " + je.getLocation(), je, je.getLocation());
-    }
+    FooRequest foo2 = deserialize(str, FooRequest.parser());
+    assertEquals(foo.name(), foo2.name());
+    assertEquals(foo.value(), foo2.value());
+    assertNull(foo2.size());
+    assertEquals(foo.indices(), foo2.indices());
+    assertEquals("Raise the bar", foo.bar().name());
   }
 
   @Test
-  public void testIndexSettingsSyncIntervalTimeParsing() {
+  public void testIndexSettingsTranslogOptionsParsing() {
 
-    try {
+    var indexSettings = IndexSettings.of(_1 -> _1.translog(Translog.of(tr -> tr
+            .syncInterval(Time.of(t -> t.time("10s")))
+            .durability("async")
+            .flushThresholdSize("256mb"))));
 
-      var indexSettings = IndexSettings.of(_1 -> _1.translogSyncInterval(Time.of(_2 -> _2.time("10s"))));
+    var str = serialize(indexSettings);
+    assertEquals("{\"translog\":{\"durability\":\"async\",\"flush_threshold_size\":\"256mb\"," +
+            "\"sync_interval\":\"10s\"}}", str);
 
-      var str = serialize(indexSettings);
-      assertEquals("{\"translog.sync_interval\":\"10s\"}", str);
+    IndexSettings deserialized = deserialize(str, IndexSettings._DESERIALIZER);
+    assertEquals(indexSettings.translog().syncInterval().time(), deserialized.translog().syncInterval().time());
+    assertEquals(indexSettings.translog().durability(), deserialized.translog().durability());
+    assertEquals(indexSettings.translog().flushThresholdSize(), deserialized.translog().flushThresholdSize());
 
-      IndexSettings deserialized = deserialize(str, IndexSettings._DESERIALIZER);
-      assertEquals(indexSettings.translogSyncInterval().time(), deserialized.translogSyncInterval().time());
-
-      var responseStr = "{\"translog\":{\"sync_interval\":\"10s\"}}";
-      IndexSettings responseDeserialized = deserialize(responseStr, IndexSettings._DESERIALIZER);
-      assertEquals(indexSettings.translogSyncInterval().time(), responseDeserialized.translog().syncInterval().time());
-
-    } catch (JsonParsingException je) {
-      throw new JsonParsingException(je.getMessage() + " at " + je.getLocation(), je, je.getLocation());
-    }
+    var deprecatedForm = "{\"translog\":{\"sync_interval\":\"10s\"},\"translog.durability\":\"async\",\"translog" +
+            ".flush_threshold_size\":\"256mb\"}";
+    IndexSettings deprecatedDeserialized = deserialize(deprecatedForm, IndexSettings._DESERIALIZER);
+    assertEquals(indexSettings.translog().syncInterval().time(), deprecatedDeserialized.translog().syncInterval().time());
+    assertEquals(indexSettings.translog().durability(), deprecatedDeserialized.translog().durability());
+    assertEquals(indexSettings.translog().flushThresholdSize(), deprecatedDeserialized.translog().flushThresholdSize());
   }
 
   @Test
   public void testIndexSettingsMappingParsing() {
 
-    try {
+    var mapping = IndexSettingsMapping.of(b -> b
+            .totalFields(d -> d.limit(1L))
+            .depth(d -> d.limit(2L))
+            .nestedFields(d -> d.limit(3L))
+            .nestedObjects(d -> d.limit(4L))
+            .fieldNameLength(d -> d.limit(5L)));
 
-      var mapping = IndexSettingsMapping.of(b -> b
-              .totalFields(d -> d.limit(1L))
-              .depth(d -> d.limit(2L))
-              .nestedFields(d -> d.limit(3L))
-              .nestedObjects(d -> d.limit(4L))
-              .fieldNameLength(d -> d.limit(5L)));
+    var str = serialize(mapping);
+    assertEquals("{\"total_fields\":{\"limit\":1},\"depth\":{\"limit\":2},\"nested_fields\":{\"limit\":3}," +
+                 "\"nested_objects\":{\"limit\":4},\"field_name_length\":{\"limit\":5}}", str);
 
-      var str = serialize(mapping);
-      assertEquals("{\"total_fields\":{\"limit\":1},\"depth\":{\"limit\":2},\"nested_fields\":{\"limit\":3}," +
-                   "\"nested_objects\":{\"limit\":4},\"field_name_length\":{\"limit\":5}}", str);
-
-      var deserialized = deserialize(str, IndexSettingsMapping._DESERIALIZER);
-      assertEquals(mapping.totalFields().limit(), deserialized.totalFields().limit());
-      assertEquals(mapping.depth().limit(), deserialized.depth().limit());
-      assertEquals(mapping.nestedFields().limit(), deserialized.nestedFields().limit());
-      assertEquals(mapping.nestedObjects().limit(), deserialized.nestedObjects().limit());
-      assertEquals(mapping.fieldNameLength().limit(), deserialized.fieldNameLength().limit());
-    } catch (JsonParsingException je) {
-      throw new JsonParsingException(je.getMessage() + " at " + je.getLocation(), je, je.getLocation());
-    }
+    var deserialized = deserialize(str, IndexSettingsMapping._DESERIALIZER);
+    assertEquals(mapping.totalFields().limit(), deserialized.totalFields().limit());
+    assertEquals(mapping.depth().limit(), deserialized.depth().limit());
+    assertEquals(mapping.nestedFields().limit(), deserialized.nestedFields().limit());
+    assertEquals(mapping.nestedObjects().limit(), deserialized.nestedObjects().limit());
+    assertEquals(mapping.fieldNameLength().limit(), deserialized.fieldNameLength().limit());
   }
 
   private <T extends JsonpSerializable> T deserialize(String serializedValue, JsonpDeserializer<T> deserializer) {

--- a/java-client/src/test/java/org/opensearch/client/opensearch/experiments/containers/SomeUnionTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/experiments/containers/SomeUnionTest.java
@@ -32,16 +32,9 @@
 
 package org.opensearch.client.opensearch.experiments.containers;
 
-import org.opensearch.client.opensearch.model.ModelTestCase;
-import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
-import jakarta.json.spi.JsonProvider;
-import jakarta.json.stream.JsonGenerator;
-import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
 import org.junit.Test;
-
-import java.io.ByteArrayOutputStream;
-import java.io.StringReader;
+import org.opensearch.client.opensearch.model.ModelTestCase;
 
 public class SomeUnionTest extends ModelTestCase {
 
@@ -67,16 +60,11 @@ public class SomeUnionTest extends ModelTestCase {
     @Test
     public void testSerialization() {
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        JsonProvider provider = JsonProvider.provider();
-        JsonGenerator generator = provider.createGenerator(baos);
+        String str = toJson(su);
 
-        su.serialize(generator, new JsonbJsonpMapper());
-        generator.close();
+        System.out.println(str);
 
-        System.out.println(baos.toString());
-
-        assertEquals(json, baos.toString());
+        assertEquals(json, str);
 
     }
 
@@ -84,11 +72,8 @@ public class SomeUnionTest extends ModelTestCase {
     public void testMissingVariantDeserialization() {
         String json = "{}";
 
-        JsonProvider provider = JsonProvider.provider();
-        JsonParser parser = provider.createParser(new StringReader(json));
-
         JsonParsingException e = assertThrows(JsonParsingException.class, () -> {
-            SomeUnion c = SomeUnion._DESERIALIZER.deserialize(parser, new JsonbJsonpMapper());
+            fromJson(json, SomeUnion._DESERIALIZER);
         });
 
         assertEquals("Property 'type' not found", e.getMessage());

--- a/java-client/src/test/java/org/opensearch/client/opensearch/experiments/inheritance/InheritanceTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/experiments/inheritance/InheritanceTest.java
@@ -32,25 +32,15 @@
 
 package org.opensearch.client.opensearch.experiments.inheritance;
 
+import org.junit.Test;
 import org.opensearch.client.opensearch.experiments.inheritance.child.ChildClass;
 import org.opensearch.client.opensearch.experiments.inheritance.final_.FinalClass;
-import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
-import jakarta.json.spi.JsonProvider;
-import jakarta.json.stream.JsonGenerator;
-import jakarta.json.stream.JsonParser;
-import org.junit.Assert;
-import org.junit.Test;
+import org.opensearch.client.opensearch.model.ModelTestCase;
 
-import java.io.ByteArrayOutputStream;
-import java.io.StringReader;
-
-public class InheritanceTest extends Assert {
+public class InheritanceTest extends ModelTestCase {
 
     @Test
     public void testSerialization() {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        JsonProvider provider = JsonProvider.provider();
 
         FinalClass fc = new FinalClass.Builder()
             // Start fields from the top of the hierarchy to test setter return values
@@ -59,15 +49,9 @@ public class InheritanceTest extends Assert {
             .finalField("finalValue")
             .build();
 
-        JsonGenerator generator = provider.createGenerator(baos);
-        fc.serialize(generator, new JsonbJsonpMapper());
-
-        generator.close();
-        String str = baos.toString();
+        String str = toJson(fc);
 
         assertEquals("{\"baseField\":\"baseValue\",\"childField\":\"childValue\",\"finalField\":\"finalValue\"}", str);
-
-        baos.reset();
 
         ChildClass cc = new ChildClass.Builder()
             // Start fields from the top of the hierarchy to test setter return values
@@ -75,33 +59,26 @@ public class InheritanceTest extends Assert {
             .childField("childValue")
             .build();
 
-        generator = provider.createGenerator(baos);
-        cc.serialize(generator, new JsonbJsonpMapper());
-
-        generator.close();
-        str = baos.toString();
+        str = toJson(cc);
 
         assertEquals("{\"baseField\":\"baseValue\",\"childField\":\"childValue\"}", str);
     }
 
     @Test
     public void testDeserialization() {
-        JsonProvider provider = JsonProvider.provider();
 
-        JsonParser parser = provider.createParser(new StringReader(
-            "{\"baseField\":\"baseValue\",\"childField\":\"childValue\",\"finalField\":\"finalValue\"}"));
+        String json = "{\"baseField\":\"baseValue\",\"childField\":\"childValue\",\"finalField\":\"finalValue\"}";
 
-        FinalClass fc = FinalClass.JSONP_PARSER.deserialize(parser, new JsonbJsonpMapper());
+        FinalClass fc = fromJson(json, FinalClass.JSONP_PARSER);
 
         assertEquals("baseValue", fc.baseField());
         assertEquals("childValue", fc.childField());
         assertEquals("finalValue", fc.finalField());
 
 
-        parser = provider.createParser(new StringReader(
-            "{\"baseField\":\"baseValue\",\"childField\":\"childValue\"}"));
+        json = "{\"baseField\":\"baseValue\",\"childField\":\"childValue\"}";
 
-        ChildClass cc = ChildClass.JSONP_PARSER.deserialize(parser, new JsonbJsonpMapper());
+        ChildClass cc = fromJson(json, ChildClass.JSONP_PARSER);
 
         assertEquals("baseValue", cc.baseField());
         assertEquals("childValue", cc.childField());

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractRequestIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractRequestIT.java
@@ -82,6 +82,7 @@ import org.opensearch.client.opensearch.indices.GetMappingResponse;
 import org.opensearch.client.opensearch.indices.IndexSettings;
 import org.opensearch.client.opensearch.indices.IndexSettingsAnalysis;
 import org.opensearch.client.opensearch.indices.IndexState;
+import org.opensearch.client.opensearch.indices.Translog;
 import org.opensearch.client.opensearch.model.ModelTestCase;
 import org.opensearch.client.transport.endpoints.BooleanResponse;
 
@@ -130,7 +131,7 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
         var createResponse = javaClient().indices()
                 .create(r -> r.index("test-settings")
                         .settings(s -> s
-                                .translogSyncInterval(Time.of(t -> t.time("10s")))
+                                .translog(Translog.of(tl -> tl.syncInterval(Time.of(t -> t.time("10s")))))
                                 .mapping(m -> m
                                         .fieldNameLength(f -> f.limit(300L))
                                         .totalFields(f -> f.limit(30L))
@@ -165,7 +166,7 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
         var putSettingsResponse = javaClient().indices().putSettings(r -> r
                 .index("test-settings")
                 .settings(s -> s
-                        .translogSyncInterval(Time.of(t -> t.time("5s")))
+                        .translog(Translog.of(tl -> tl.syncInterval(Time.of(t -> t.time("5s")))))
                         .mapping(m -> m
                                 .fieldNameLength(f -> f.limit(400L))
                                 .totalFields(f -> f.limit(130L))
@@ -565,7 +566,7 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
     public void testCompletionSuggesterFailure() throws IOException {
 
         String index = "test-completion-suggester-failure";
-        
+
 
         Property intValueProp = new Property.Builder()
                 .long_(v -> v)
@@ -631,7 +632,7 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
             }
             assumeTrue("The PIT is supported in OpenSearch 2.4.0 and later",
                             Version.fromString(version).onOrAfter(Version.fromString("2.4.0")));
-                    
+
             String index = "test-point-in-time";
 
             javaClient().indices().create(c -> c
@@ -744,7 +745,7 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
     public void testTermSuggester() throws IOException {
 
             String index = "test-term-suggester";
-        
+
             // term suggester does not require a special mapping
             javaClient().indices().create(c -> c
                             .index(index));
@@ -826,7 +827,7 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
                                                         .text(new TextProperty.Builder().analyzer("trigram").build())
                                                         .build()).build())
                                         .build()).build();
-                        
+
 
 			javaClient().indices().create(c -> c
 					.index(index)

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractRequestIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractRequestIT.java
@@ -126,10 +126,11 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
     }
 
     @Test
-    public void testIndexSettingsMapping() throws Exception {
+    public void testIndexSettings() throws Exception {
         var createResponse = javaClient().indices()
                 .create(r -> r.index("test-settings")
                         .settings(s -> s
+                                .translogSyncInterval(Time.of(t -> t.time("10s")))
                                 .mapping(m -> m
                                         .fieldNameLength(f -> f.limit(300L))
                                         .totalFields(f -> f.limit(30L))
@@ -145,6 +146,9 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
         assertNotNull(createdIndexSettings);
         assertNotNull(createdIndexSettings.settings());
         assertNotNull(createdIndexSettings.settings().index());
+        assertNotNull(createdIndexSettings.settings().index().translog());
+        assertNotNull(createdIndexSettings.settings().index().translog().syncInterval());
+        assertEquals("10s", createdIndexSettings.settings().index().translog().syncInterval().time());
         var createdMappingSettings = createdIndexSettings.settings().index().mapping();
         assertNotNull(createdMappingSettings);
         assertNotNull(createdMappingSettings.fieldNameLength());
@@ -161,6 +165,7 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
         var putSettingsResponse = javaClient().indices().putSettings(r -> r
                 .index("test-settings")
                 .settings(s -> s
+                        .translogSyncInterval(Time.of(t -> t.time("5s")))
                         .mapping(m -> m
                                 .fieldNameLength(f -> f.limit(400L))
                                 .totalFields(f -> f.limit(130L))
@@ -175,6 +180,9 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
         assertNotNull(updatedIndexSettings);
         assertNotNull(updatedIndexSettings.settings());
         assertNotNull(updatedIndexSettings.settings().index());
+        assertNotNull(updatedIndexSettings.settings().index().translog());
+        assertNotNull(updatedIndexSettings.settings().index().translog().syncInterval());
+        assertEquals("5s", updatedIndexSettings.settings().index().translog().syncInterval().time());
         var updatedMappingSettings = updatedIndexSettings.settings().index().mapping();
         assertNotNull(updatedMappingSettings);
         assertNotNull(updatedMappingSettings.fieldNameLength());

--- a/java-client/src/test/java/org/opensearch/client/opensearch/json/JsonDataTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/json/JsonDataTest.java
@@ -32,18 +32,18 @@
 
 package org.opensearch.client.opensearch.json;
 
-import org.opensearch.client.json.JsonData;
-import org.opensearch.client.json.JsonpMapper;
-import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
-import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import org.junit.Assert;
 import org.junit.Test;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+import org.opensearch.client.opensearch.model.ModelTestCase;
 
 import java.io.StringReader;
-import java.io.StringWriter;
+
 
 public class JsonDataTest extends Assert {
 
@@ -69,9 +69,7 @@ public class JsonDataTest extends Assert {
         String json = "{\"children\":[{\"doubleValue\":3.2,\"intValue\":2}],\"doubleValue\":2.1,\"intValue\":1," +
             "\"stringValue\":\"foo\"}";
 
-        JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
-        JsonpMapperTest.SomeClass sc =
-            mapper.deserialize(parser, JsonpMapperTest.SomeClass.class);
+        JsonpMapperTest.SomeClass sc = ModelTestCase.fromJson(json, JsonpMapperTest.SomeClass.class, mapper);
 
         assertEquals("foo", sc.getStringValue());
         assertEquals(1, sc.getChildren().size());
@@ -80,13 +78,7 @@ public class JsonDataTest extends Assert {
 
         JsonData data = JsonData.of(sc);
 
-        StringWriter sw = new StringWriter();
-        JsonGenerator generator = mapper.jsonProvider().createGenerator(sw);
-
-        data.serialize(generator, mapper);
-        generator.close();
-
-        assertEquals(json, sw.toString());
+        assertEquals(json, ModelTestCase.toJson(data, mapper));
     }
 
     @Test

--- a/java-client/src/test/java/org/opensearch/client/opensearch/json/JsonpMapperTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/json/JsonpMapperTest.java
@@ -32,25 +32,24 @@
 
 package org.opensearch.client.opensearch.json;
 
-import org.opensearch.client.json.JsonpDeserializer;
-import org.opensearch.client.json.JsonpMapper;
-import org.opensearch.client.json.jackson.JacksonJsonpMapper;
-import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
-import org.opensearch.client.opensearch.IOUtils;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.datatype.jsonp.JSONPModule;
-
 import jakarta.json.Json;
 import jakarta.json.JsonValue;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import org.junit.Assert;
 import org.junit.Test;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+import org.opensearch.client.opensearch.IOUtils;
+import org.opensearch.client.opensearch.model.ModelTestCase;
 
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -186,20 +185,14 @@ public class JsonpMapperTest extends Assert {
         other.setDoubleValue(3.2);
         something.setChildren(Collections.singletonList(other));
 
-        StringWriter strw = new StringWriter();
-        JsonGenerator generator = mapper.jsonProvider().createGenerator(strw);
+        String str = ModelTestCase.toJson(something, mapper);
 
-        mapper.serialize(something, generator);
-
-        generator.close();
-
-        assertEquals(expected, strw.getBuffer().toString());
+        assertEquals(expected, str);
     }
 
     private void testDeserialize(JsonpMapper mapper, String json) {
 
-        JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
-        SomeClass parsed = mapper.deserialize(parser, SomeClass.class);
+        SomeClass parsed = ModelTestCase.fromJson(json, SomeClass.class, mapper);
 
         assertEquals(1, parsed.getIntValue());
         assertEquals(2.1, parsed.getDoubleValue(), 0.0);

--- a/java-client/src/test/java/org/opensearch/client/opensearch/model/BuiltinTypesTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/model/BuiltinTypesTest.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.client.opensearch.model;
 
+import org.junit.Test;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOptions;
@@ -41,13 +42,9 @@ import org.opensearch.client.opensearch._types.aggregations.StringStatsAggregate
 import org.opensearch.client.opensearch._types.query_dsl.SpanGapQuery;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.indices.IndexSettings;
-import org.junit.Test;
 
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
-
-import jakarta.json.stream.JsonParser;
 
 public class BuiltinTypesTest extends ModelTestCase {
 
@@ -239,10 +236,9 @@ public class BuiltinTypesTest extends ModelTestCase {
     public void testNullableStringInArray() {
         // stringOrNullDeserializer allows to handle null events in string arrays
         String json = "[\"lettuce\", null, \"tomato\"]";
-        JsonParser jsonParser = mapper.jsonProvider().createParser(new StringReader(json));
         JsonpDeserializer<String> stringDeserializer = JsonpDeserializer.stringOrNullDeserializer();
 
-        List<String> result = JsonpDeserializer.arrayDeserializer(stringDeserializer).deserialize(jsonParser, mapper);
+        List<String> result = fromJson(json, JsonpDeserializer.arrayDeserializer(stringDeserializer));
 
         List<String> expected = new ArrayList<>();
         expected.add("lettuce");

--- a/java-client/src/test/java/org/opensearch/client/opensearch/model/SerializationTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/model/SerializationTest.java
@@ -32,23 +32,20 @@
 
 package org.opensearch.client.opensearch.model;
 
-import org.opensearch.client.opensearch.cat.NodesResponse;
-import org.opensearch.client.opensearch.core.GetSourceResponse;
-import org.opensearch.client.json.JsonpDeserializable;
-import org.opensearch.client.json.JsonpDeserializer;
-import org.opensearch.client.json.JsonpMapperBase;
-import org.opensearch.client.json.JsonpUtils;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfo;
 import io.github.classgraph.ClassInfoList;
 import io.github.classgraph.ScanResult;
 import jakarta.json.Json;
 import jakarta.json.JsonValue;
-import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
 import org.junit.Test;
-
-import java.io.StringReader;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapperBase;
+import org.opensearch.client.json.JsonpUtils;
+import org.opensearch.client.opensearch.cat.NodesResponse;
+import org.opensearch.client.opensearch.core.GetSourceResponse;
 
 public class SerializationTest extends ModelTestCase {
 
@@ -71,8 +68,7 @@ public class SerializationTest extends ModelTestCase {
             assertNotNull(deserializer);
 
             // Deserialize something dummy to resolve lazy deserializers
-            JsonParser parser = mapper.jsonProvider().createParser(new StringReader("-"));
-            assertThrows(JsonParsingException.class, () -> deserializer.deserialize(parser, mapper));
+            assertThrows(JsonParsingException.class, () -> fromJson("-", deserializer));
         }
 
         // Check that all classes that have a _DESERIALIZER field also have the annotation
@@ -119,7 +115,7 @@ public class SerializationTest extends ModelTestCase {
         JsonpDeserializer<GetSourceResponse<String>> deserializer =
             GetSourceResponse.createGetSourceResponseDeserializer(JsonpDeserializer.stringDeserializer());
 
-        r = deserializer.deserialize(mapper.jsonProvider().createParser(new StringReader(json)), mapper);
+        r = fromJson(json, deserializer);
 
         assertEquals("The value", r.valueBody());
 


### PR DESCRIPTION
### Description
Now we can set translog sync interval option via client.

Additionally, server response contains separate `translog` object, which cannot be deserialized by present translog option deserializers.
It looks like this:
```
{
  "test-settings": {
    "settings": {
      "index": {
        "number_of_shards": "1",
        "translog": {
          "sync_interval": "10s",
          "durability": "async"
        },
        "provided_name": "test-settings",
        "creation_date": "1685967681952",
        "number_of_replicas": "1",
        "uuid": "q4R3eDKjT164eR_NNuY8pQ",
        "version": {
          "created": "136257827"
        }
      }
    }
  }
}
```

Therefore, a corresponding `Translog` class is introduced, similarly to how it is done for the `blocks` property.

### Issues Resolved
Closes #307 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
