### PR TITLE
Add integration test to create and delete PIT with AwsSdk2Transport

### DIFF
--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/aws/AwsSdk2SearchIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/aws/AwsSdk2SearchIT.java
@@ -13,12 +13,18 @@ import org.junit.Assert;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch.core.IndexRequest;
 import org.opensearch.client.opensearch.core.IndexResponse;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.pit.CreatePitRequest;
+import org.opensearch.client.opensearch.core.pit.CreatePitResponse;
+import org.opensearch.client.opensearch.core.pit.DeletePitRequest;
+import org.opensearch.client.opensearch.core.pit.DeletePitResponse;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -42,6 +48,20 @@ public class AwsSdk2SearchIT extends AwsSdk2TransportTestCase {
     @Test
     public void testAsyncAsyncClient() throws Exception {
         testClientAsync(true);
+    }
+
+    @Test
+    public void testCreateDeletePit() throws Exception {
+        final OpenSearchClient client = getClient(false, null, null);
+
+        final CreatePitResponse createPitResponse = client.createPit(CreatePitRequest.of(createPitRequest -> createPitRequest
+                .keepAlive(new Time.Builder().time("10m").build())
+                .targetIndexes(Collections.singletonList(TEST_INDEX))));
+        Assert.assertNotNull(createPitResponse);
+        Assert.assertNotNull(createPitResponse.pitId());
+
+        final DeletePitResponse deletePitResponse = client.deletePit(DeletePitRequest.of(deletePitBuilder -> deletePitBuilder.pitId(Collections.singletonList(createPitResponse.pitId()))));
+        Assert.assertNotNull(deletePitResponse);
     }
 
     void testClient(boolean async) throws Exception {


### PR DESCRIPTION
### Description
Adds an integration test to create and then delete a PIT on a domain. This test currently fails with 

```
org.opensearch.client.opensearch.integTest.aws.AwsSdk2SearchIT > testCreateDeletePit FAILED
2023-06-08T00:22:10.947-0500 [DEBUG] [TestEventLogger]     org.opensearch.client.opensearch._types.OpenSearchException: Request failed: [security_exception] The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
2023-06-08T00:22:10.947-0500 [DEBUG] [TestEventLogger] 
2023-06-08T00:22:10.947-0500 [DEBUG] [TestEventLogger]     The Canonical String for this request should have been
2023-06-08T00:22:10.947-0500 [DEBUG] [TestEventLogger]     'DELETE
2023-06-08T00:22:10.947-0500 [DEBUG] [TestEventLogger]     /_search/point_in_time

```

### Issues Resolved
Related to #521 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
