### PR TITLE
Fixes #283

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Add support for knn_vector field type ([#529](https://github.com/opensearch-project/opensearch-java/pull/524))
+- Adds the option to set slices=auto for UpdateByQueryRequest, DeleteByQueryRequest and ReindexRequest ([#538](https://github.com/opensearch-project/opensearch-java/pull/538))
 
 ### Dependencies
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/DeleteByQueryRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/DeleteByQueryRequest.java
@@ -509,7 +509,7 @@ public class DeleteByQueryRequest extends RequestBase implements JsonpSerializab
 
 	/**
 	 * The number of slices this task should be divided into. Defaults to 1, meaning
-	 * the task isn't sliced into subtasks. Can be set to <code>auto</code>.
+	 * the task isn't sliced into subtasks. Can be set to 0 for <code>auto</code>.
 	 * <p>
 	 * API name: {@code slices}
 	 */
@@ -1125,7 +1125,7 @@ public class DeleteByQueryRequest extends RequestBase implements JsonpSerializab
 
 		/**
 		 * The number of slices this task should be divided into. Defaults to 1, meaning
-		 * the task isn't sliced into subtasks. Can be set to <code>auto</code>.
+		 * the task isn't sliced into subtasks. Can be set to 0 for <code>auto</code>.
 		 * <p>
 		 * API name: {@code slices}
 		 */
@@ -1327,7 +1327,7 @@ public class DeleteByQueryRequest extends RequestBase implements JsonpSerializab
 			request -> {
 				Map<String, String> params = new HashMap<>();
 				if (request.slices != null) {
-					params.put("slices", String.valueOf(request.slices));
+					params.put("slices", request.slices == 0 ? "auto" : String.valueOf(request.slices));
 				}
 				if (request.df != null) {
 					params.put("df", request.df);

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/ReindexRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/ReindexRequest.java
@@ -219,7 +219,7 @@ public class ReindexRequest extends RequestBase implements JsonpSerializable {
 
 	/**
 	 * The number of slices this task should be divided into. Defaults to 1, meaning
-	 * the task isn't sliced into subtasks. Can be set to <code>auto</code>.
+	 * the task isn't sliced into subtasks. Can be set to 0 for <code>auto</code>.
 	 * <p>
 	 * API name: {@code slices}
 	 */
@@ -467,7 +467,7 @@ public class ReindexRequest extends RequestBase implements JsonpSerializable {
 
 		/**
 		 * The number of slices this task should be divided into. Defaults to 1, meaning
-		 * the task isn't sliced into subtasks. Can be set to <code>auto</code>.
+		 * the task isn't sliced into subtasks. Can be set to 0 for <code>auto</code>.
 		 * <p>
 		 * API name: {@code slices}
 		 */
@@ -605,7 +605,7 @@ public class ReindexRequest extends RequestBase implements JsonpSerializable {
 			request -> {
 				Map<String, String> params = new HashMap<>();
 				if (request.slices != null) {
-					params.put("slices", String.valueOf(request.slices));
+					params.put("slices", request.slices == 0 ? "auto" : String.valueOf(request.slices));
 				}
 				if (request.requestsPerSecond != null) {
 					params.put("requests_per_second", String.valueOf(request.requestsPerSecond));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/UpdateByQueryRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/UpdateByQueryRequest.java
@@ -525,7 +525,7 @@ public class UpdateByQueryRequest extends RequestBase implements JsonpSerializab
 
 	/**
 	 * The number of slices this task should be divided into. Defaults to 1, meaning
-	 * the task isn't sliced into subtasks. Can be set to <code>auto</code>.
+	 * the task isn't sliced into subtasks. Can be set to 0 for <code>auto</code>.
 	 * <p>
 	 * API name: {@code slices}
 	 */
@@ -1181,7 +1181,7 @@ public class UpdateByQueryRequest extends RequestBase implements JsonpSerializab
 
 		/**
 		 * The number of slices this task should be divided into. Defaults to 1, meaning
-		 * the task isn't sliced into subtasks. Can be set to <code>auto</code>.
+		 * the task isn't sliced into subtasks. Can be set to 0 for <code>auto</code>.
 		 * <p>
 		 * API name: {@code slices}
 		 */
@@ -1397,7 +1397,7 @@ public class UpdateByQueryRequest extends RequestBase implements JsonpSerializab
 			request -> {
 				Map<String, String> params = new HashMap<>();
 				if (request.slices != null) {
-					params.put("slices", String.valueOf(request.slices));
+					params.put("slices", request.slices == 0 ? "auto" : String.valueOf(request.slices));
 				}
 				if (request.df != null) {
 					params.put("df", request.df);

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/DeleteByQueryRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/DeleteByQueryRequestTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch.core;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class DeleteByQueryRequestTest extends Assert {
+    @Test
+    public void testEndpointSlicesAuto() {
+        DeleteByQueryRequest deleteByQueryRequest = DeleteByQueryRequest.of(b -> b
+                .index("test-index")
+                .slices(0L));
+        Map<String, String> queryParameters = DeleteByQueryRequest._ENDPOINT.queryParameters(deleteByQueryRequest);
+        assertTrue("Must have a slices query parameter", queryParameters.containsKey("slices"));
+        assertEquals("auto", queryParameters.get("slices"));
+    }
+
+    @Test
+    public void DeleteByQueryRequest() {
+        DeleteByQueryRequest deleteByQueryRequest = DeleteByQueryRequest.of(b -> b
+                .index("test-index")
+                .slices(6L));
+        Map<String, String> queryParameters = DeleteByQueryRequest._ENDPOINT.queryParameters(deleteByQueryRequest);
+        assertTrue("Must have a slices query parameter", queryParameters.containsKey("slices"));
+        assertEquals("6", queryParameters.get("slices"));
+    }
+}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/ReindexRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/ReindexRequestTest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch.core;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class ReindexRequestTest extends Assert {
+    @Test
+    public void testEndpointSlicesAuto() {
+        ReindexRequest reindexRequest = ReindexRequest.of(b -> b
+                .slices(0L));
+        Map<String, String> queryParameters = ReindexRequest._ENDPOINT.queryParameters(reindexRequest);
+        assertTrue("Must have a slices query parameter", queryParameters.containsKey("slices"));
+        assertEquals("auto", queryParameters.get("slices"));
+    }
+
+    @Test
+    public void testEndpointSlicesNumber() {
+        ReindexRequest reindexRequest = ReindexRequest.of(b -> b
+                .slices(6L));
+        Map<String, String> queryParameters = ReindexRequest._ENDPOINT.queryParameters(reindexRequest);
+        assertTrue("Must have a slices query parameter", queryParameters.containsKey("slices"));
+        assertEquals("6", queryParameters.get("slices"));
+    }
+}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/UpdateByQueryRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/UpdateByQueryRequestTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch.core;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class UpdateByQueryRequestTest extends Assert {
+    @Test
+    public void testEndpointSlicesAuto() {
+        UpdateByQueryRequest updateByQueryRequest = UpdateByQueryRequest.of(b -> b
+                .index("test-index")
+                .slices(0L));
+        Map<String, String> queryParameters = UpdateByQueryRequest._ENDPOINT.queryParameters(updateByQueryRequest);
+        assertTrue("Must have a slices query parameter", queryParameters.containsKey("slices"));
+        assertEquals("auto", queryParameters.get("slices"));
+    }
+
+    @Test
+    public void testEndpointSlicesNumber() {
+        UpdateByQueryRequest updateByQueryRequest = UpdateByQueryRequest.of(b -> b
+                .index("test-index")
+                .slices(6L));
+        Map<String, String> queryParameters = UpdateByQueryRequest._ENDPOINT.queryParameters(updateByQueryRequest);
+        assertTrue("Must have a slices query parameter", queryParameters.containsKey("slices"));
+        assertEquals("6", queryParameters.get("slices"));
+    }
+}


### PR DESCRIPTION
### Description
Adds the option to set slices=auto for UpdateByQueryRequest, DeleteByQueryRequest and ReindexRequest.
Using value 0 (zero) to express auto slicing.
This maintains consistency with https://github.com/elastic/elasticsearch/pull/53068

### Issues Resolved
Fixes #283 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
