### PR TITLE
[Backport] [2.x] Bumps 'jackson' from 2.14.2 to 2.15.2 (#537)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bumps `com.github.jk1.dependency-license-report` from 2.2 to 2.4
 - Bumps `io.github.classgraph:classgraph` from 4.8.157 to 4.8.160
+- Bumps `jackson` from 2.14.2 to 2.15.2 ((#537)[https://github.com/opensearch-project/opensearch-java/pull/537])
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -140,8 +140,8 @@ val integrationTest = task<Test>("integrationTest") {
 dependencies {
 
     val opensearchVersion = "2.7.0"
-    val jacksonVersion = "2.14.2"
-    val jacksonDatabindVersion = "2.14.2"
+    val jacksonVersion = "2.15.2"
+    val jacksonDatabindVersion = "2.15.2"
 
     // Apache 2.0
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/537 to `2.x`