### PR TITLE
Add support for approximate k-NN queries

### DIFF
--- a/.github/workflows/test-integration-unreleased.yml
+++ b/.github/workflows/test-integration-unreleased.yml
@@ -3,8 +3,7 @@ name: Integration with Unreleased OpenSearch
 on:
   push:
     branches:
-      - "*"
-#      - "main"
+      - "main"
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/test-integration-unreleased.yml
+++ b/.github/workflows/test-integration-unreleased.yml
@@ -3,7 +3,8 @@ name: Integration with Unreleased OpenSearch
 on:
   push:
     branches:
-      - "main"
+      - "*"
+#      - "main"
   pull_request:
     branches:
       - "main"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased 2.x]
 
 ### Added
-- Add support for knn_vector field type ([#529](https://github.com/opensearch-project/opensearch-java/pull/524))
+- Add support for knn_vector field type ([#524](https://github.com/opensearch-project/opensearch-java/pull/524))
 - Add translog option object and missing translog sync interval option in index settings ([#518](https://github.com/opensearch-project/opensearch-java/pull/518))
+- Add support for approximate k-NN queries ([#548](https://github.com/opensearch-project/opensearch-java/pull/548))
 
 ### Dependencies
 - Bumps `jackson` from 2.14.2 to 2.15.2 ((#537)[https://github.com/opensearch-project/opensearch-java/pull/537])

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/KnnVectorMethod.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/KnnVectorMethod.java
@@ -79,6 +79,14 @@ public class KnnVectorMethod implements JsonpSerializable {
         }
 
         /**
+         * API name: {@code parameters}
+         */
+        public final Builder parameters(String key, JsonData value) {
+            this.parameters = _mapPut(this.parameters, key, value);
+            return this;
+        }
+
+        /**
          * Builds a {@link KnnVectorMethod}.
          *
          * @throws NullPointerException

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/KnnVectorMethod.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/KnnVectorMethod.java
@@ -202,10 +202,12 @@ public class KnnVectorMethod implements JsonpSerializable {
 
         if (this.parameters != null) {
             generator.writeKey("parameters");
+            generator.writeStartObject();
             for (Map.Entry<String, JsonData> item0 : this.parameters.entrySet()) {
                 generator.writeKey(item0.getKey());
                 item0.getValue().serialize(generator, mapper);
             }
+            generator.writeEnd();
         }
 
     }

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/KnnVectorProperty.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/KnnVectorProperty.java
@@ -66,6 +66,13 @@ public class KnnVectorProperty extends PropertyBase implements PropertyVariant {
 		}
 
 		/**
+		 * API name: {@code method}
+		 */
+		public final Builder method(Function<KnnVectorMethod.Builder, ObjectBuilder<KnnVectorMethod>> fn) {
+			return this.method(fn.apply(new KnnVectorMethod.Builder()).build());
+		}
+
+		/**
 		 * Builds a {@link KnnVectorProperty}.
 		 *
 		 * @throws NullPointerException

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQuery.java
@@ -1,0 +1,202 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch._types.query_dsl;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+
+@JsonpDeserializable
+public class KnnQuery extends QueryBase implements QueryVariant {
+    private final String field;
+    private final float[] vector;
+    private final int k;
+    @Nullable
+    private final Query filter;
+
+    private KnnQuery(Builder builder) {
+        super(builder);
+
+        this.field = ApiTypeHelper.requireNonNull(builder.field, this, "field");
+        this.vector = ApiTypeHelper.requireNonNull(builder.vector, this, "vector");
+        this.k = ApiTypeHelper.requireNonNull(builder.k, this, "k");
+        this.filter = builder.filter;
+    }
+
+    public static KnnQuery of(Function<Builder, ObjectBuilder<KnnQuery>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Query variant kind.
+     * @return The query variant kind.
+     */
+    @Override
+    public Query.Kind _queryKind() {
+        return Query.Kind.Knn;
+    }
+
+    /**
+     * Required - The target field.
+     * @return The target field.
+     */
+    public final String field() {
+        return this.field;
+    }
+
+    /**
+     * Required - The vector to search for.
+     * @return The vector to search for.
+     */
+    public final float[] vector() {
+        return this.vector;
+    }
+
+    /**
+     * Required - The number of neighbors the search of each graph will return.
+     * @return The number of neighbors to return.
+     */
+    public final int k() {
+        return this.k;
+    }
+
+    /**
+     * Optional - A query to filter the results of the query.
+     * @return The filter query.
+     */
+    @Nullable
+    public final Query filter() {
+        return this.filter;
+    }
+
+    @Override
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject(this.field);
+
+        super.serializeInternal(generator, mapper);
+
+        // TODO: Implement the rest of the serialization.
+
+        generator.writeKey("vector");
+        generator.writeStartArray();
+        for (float value : this.vector) {
+            generator.write(value);
+        }
+        generator.writeEnd();
+
+        generator.write("k", this.k);
+
+        if (this.filter != null) {
+            generator.writeKey("filter");
+            this.filter.serialize(generator, mapper);
+        }
+
+        generator.writeEnd();
+    }
+
+    /**
+     * Builder for {@link KnnQuery}.
+     */
+    public static class Builder extends QueryBase.AbstractBuilder<Builder> implements ObjectBuilder<KnnQuery> {
+        @Nullable
+        private String field;
+        @Nullable
+        private float[] vector;
+        @Nullable
+        private Integer k;
+        @Nullable
+        private Query filter;
+
+        /**
+         * Required - The target field.
+         * @param field The target field.
+         * @return This builder.
+         */
+        public Builder field(@Nullable String field) {
+            this.field = field;
+            return this;
+        }
+
+        /**
+         * Required - The vector to search for.
+         *
+         * @param vector The vector to search for.
+         * @return This builder.
+         */
+        public Builder vector(@Nullable float[] vector) {
+            this.vector = vector;
+            return this;
+        }
+
+        /**
+         * Required - The number of neighbors the search of each graph will return.
+         *
+         * @param k The number of neighbors to return.
+         * @return This builder.
+         */
+        public Builder k(@Nullable Integer k) {
+            this.k = k;
+            return this;
+        }
+
+        /**
+         * Optional - A query to filter the results of the knn query.
+         *
+         * @param filter The filter query.
+         * @return This builder.
+         */
+        public Builder filter(@Nullable Query filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        /**
+         * Builds a {@link KnnQuery}.
+         *
+         * @return The built {@link KnnQuery}.
+         */
+        @Override
+        public KnnQuery build() {
+            _checkSingleUse();
+
+            return new KnnQuery(this);
+        }
+    }
+
+    public static final JsonpDeserializer<KnnQuery> _DESERIALIZER = ObjectBuilderDeserializer
+            .lazy(Builder::new, KnnQuery::setupKnnQueryDeserializer);
+
+    protected static void setupKnnQueryDeserializer(ObjectDeserializer<Builder> op) {
+        setupQueryBaseDeserializer(op);
+        op.add((b, v) -> {
+            float[] vector = new float[v.size()];
+            int i = 0;
+            for (Float value : v) {
+                vector[i++] = value;
+            }
+            b.vector(vector);
+        }, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.floatDeserializer()), "vector");
+        op.add(Builder::k, JsonpDeserializer.integerDeserializer(), "k");
+        op.add(Builder::filter, Query._DESERIALIZER, "filter");
+
+        op.setKey(Builder::field, JsonpDeserializer.stringDeserializer());
+    }
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/Query.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/Query.java
@@ -103,6 +103,8 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 
 		Intervals("intervals"),
 
+		Knn("knn"),
+
 		Match("match"),
 
 		MatchAll("match_all"),
@@ -533,6 +535,23 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 	 */
 	public IntervalsQuery intervals() {
 		return TaggedUnionUtils.get(this, Kind.Intervals);
+	}
+
+	/**
+	 * Is this variant instance of kind {@code knn}?
+	 */
+	public boolean isKnn() {
+		return _kind == Kind.Knn;
+	}
+
+	/**
+	 * Get the {@code knn} variant value.
+	 *
+	 * @throws IllegalStateException
+	 *             if the current variant is not of the {@code knn} kind.
+	 */
+	public KnnQuery knn() {
+		return TaggedUnionUtils.get(this, Kind.Knn);
 	}
 
 	/**
@@ -1340,6 +1359,16 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 			return this.intervals(fn.apply(new IntervalsQuery.Builder()).build());
 		}
 
+		public ObjectBuilder<Query> knn(KnnQuery v) {
+			this._kind = Kind.Knn;
+			this._value = v;
+			return this;
+		}
+
+		public ObjectBuilder<Query> knn(Function<KnnQuery.Builder, ObjectBuilder<KnnQuery>> fn) {
+			return this.knn(fn.apply(new KnnQuery.Builder()).build());
+		}
+
 		public ObjectBuilder<Query> match(MatchQuery v) {
 			this._kind = Kind.Match;
 			this._value = v;
@@ -1728,6 +1757,7 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 		op.add(Builder::hasParent, HasParentQuery._DESERIALIZER, "has_parent");
 		op.add(Builder::ids, IdsQuery._DESERIALIZER, "ids");
 		op.add(Builder::intervals, IntervalsQuery._DESERIALIZER, "intervals");
+		op.add(Builder::knn, KnnQuery._DESERIALIZER, "knn");
 		op.add(Builder::match, MatchQuery._DESERIALIZER, "match");
 		op.add(Builder::matchAll, MatchAllQuery._DESERIALIZER, "match_all");
 		op.add(Builder::matchBoolPrefix, MatchBoolPrefixQuery._DESERIALIZER, "match_bool_prefix");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/QueryBuilders.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/QueryBuilders.java
@@ -183,6 +183,13 @@ public class QueryBuilders {
 	}
 
 	/**
+	 * Creates a builder for the {@link KnnQuery knn} {@code Query} variant.
+	 */
+	public static KnnQuery.Builder knn() {
+		return new KnnQuery.Builder();
+	}
+
+	/**
 	 * Creates a builder for the {@link MatchQuery match} {@code Query} variant.
 	 */
 	public static MatchQuery.Builder match() {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexSettings.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexSettings.java
@@ -1066,7 +1066,7 @@ public class IndexSettings implements JsonpSerializable {
 
 		}
 		if (this.knnAlgoParamEfSearch != null) {
-			generator.writeKey("knn.algo_param_ef_search");
+			generator.writeKey("knn.algo_param.ef_search");
 			generator.write(this.knnAlgoParamEfSearch);
 
 		}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractKnnIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractKnnIT.java
@@ -73,12 +73,16 @@ public abstract class AbstractKnnIT extends OpenSearchJavaClientTestCase {
 
         assertEquals(2, hits.size());
         assertEquals(5.5f, hits.get(0).source().price, 0.01f);
-        assertEquals(4.4f, hits.get(1).source().price, 0.01f);
+        assertEquals(10.3f, hits.get(1).source().price, 0.01f);
     }
 
     private static class Doc {
         public float[] vector;
         public float price;
+
+        Doc() {
+
+        }
 
         Doc(float[] vector, float price) {
             this.vector = vector;

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractKnnIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractKnnIT.java
@@ -8,7 +8,9 @@
 
 package org.opensearch.client.opensearch.integTest;
 
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.junit.Test;
 import org.opensearch.client.json.JsonData;
@@ -18,6 +20,8 @@ import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 public abstract class AbstractKnnIT extends OpenSearchJavaClientTestCase {
     @Test
     public void testCanIndexAndSearchKnn() throws Exception {
+        assumeKnnInstalled();
+
         final String indexName = "knn-index-and-search";
 
         var createIndexResponse = javaClient()
@@ -74,6 +78,17 @@ public abstract class AbstractKnnIT extends OpenSearchJavaClientTestCase {
         assertEquals(2, hits.size());
         assertEquals(5.5f, hits.get(0).source().price, 0.01f);
         assertEquals(10.3f, hits.get(1).source().price, 0.01f);
+    }
+
+    private void assumeKnnInstalled() throws IOException {
+        var plugins = javaClient().cat().plugins();
+
+        var knnInstalled = plugins
+                .valueBody()
+                .stream()
+                .anyMatch(p -> Objects.equals(p.component(), "opensearch-knn"));
+
+        assumeTrue("KNN plugin is not installed", knnInstalled);
     }
 
     private static class Doc {

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractKnnIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractKnnIT.java
@@ -1,0 +1,80 @@
+package org.opensearch.client.opensearch.integTest;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+
+public abstract class AbstractKnnIT extends OpenSearchJavaClientTestCase {
+    @Test
+    public void testCanIndexAndSearchKnn() throws Exception {
+        final String indexName = "knn-index-and-search";
+
+        var createIndexResponse = javaClient()
+                .indices()
+                .create(c -> c
+                        .index(indexName)
+                        .settings(s -> s
+                                .knn(true)
+                                .knnAlgoParamEfSearch(100))
+                        .mappings(m -> m
+                                .properties("vector", p -> p
+                                        .knnVector(k -> k
+                                                .dimension(4)
+                                                .method(km -> km
+                                                        .name("hnsw")
+                                                        .spaceType("l2")
+                                                        .engine("nmslib")
+                                                        .parameters("ef_construction", JsonData.of(256))
+                                                        .parameters("m", JsonData.of(16)))))));
+
+        assertEquals(true, createIndexResponse.acknowledged());
+
+        var docs = new Doc[] {
+                new Doc(new float[] { 1.5f, 5.5f, 4.5f, 6.4f }, 10.3f),
+                new Doc(new float[] { 2.5f, 3.5f, 5.6f, 6.7f }, 5.5f),
+                new Doc(new float[] { 4.5f, 5.5f, 6.7f, 3.7f }, 4.4f),
+                new Doc(new float[] { 1.5f, 5.5f, 4.5f, 6.4f }, 8.9f)
+        };
+        var bulkOps = Arrays.stream(docs)
+                .map(d -> BulkOperation.of(o -> o.index(i -> i.document(d))))
+                .collect(Collectors.toList());
+
+        var bulkResponse = javaClient()
+                .bulk(b -> b
+                        .index(indexName)
+                        .refresh(Refresh.WaitFor)
+                        .operations(bulkOps));
+
+        assertFalse(bulkResponse.errors());
+
+        var searchResponse = javaClient()
+                .search(s -> s
+                        .index(indexName)
+                        .size(2)
+                        .query(q -> q
+                                .knn(k -> k
+                                        .field("vector")
+                                        .vector(new float[] { 2.0f, 3.0f, 5.0f, 6.0f })
+                                        .k(2))),
+                    Doc.class);
+
+        var hits = searchResponse.hits().hits();
+
+        assertEquals(2, hits.size());
+        assertEquals(5.5f, hits.get(0).source().price, 0.01f);
+        assertEquals(4.4f, hits.get(1).source().price, 0.01f);
+    }
+
+    private static class Doc {
+        public float[] vector;
+        public float price;
+
+        public Doc(float[] vector, float price) {
+            this.vector = vector;
+            this.price = price;
+        }
+    }
+}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractKnnIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractKnnIT.java
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.client.opensearch.integTest;
 
 import java.util.Arrays;
@@ -72,7 +80,7 @@ public abstract class AbstractKnnIT extends OpenSearchJavaClientTestCase {
         public float[] vector;
         public float price;
 
-        public Doc(float[] vector, float price) {
+        Doc(float[] vector, float price) {
             this.vector = vector;
             this.price = price;
         }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/httpclient5/KnnIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/httpclient5/KnnIT.java
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.client.opensearch.integTest.httpclient5;
 
 import org.opensearch.client.opensearch.integTest.AbstractKnnIT;

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/httpclient5/KnnIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/httpclient5/KnnIT.java
@@ -1,0 +1,6 @@
+package org.opensearch.client.opensearch.integTest.httpclient5;
+
+import org.opensearch.client.opensearch.integTest.AbstractKnnIT;
+
+public class KnnIT extends AbstractKnnIT implements HttpClient5TransportSupport {
+}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/restclient/KnnIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/restclient/KnnIT.java
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.client.opensearch.integTest.restclient;
 
 import java.io.IOException;

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/restclient/KnnIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/restclient/KnnIT.java
@@ -1,0 +1,16 @@
+package org.opensearch.client.opensearch.integTest.restclient;
+
+import java.io.IOException;
+import org.apache.hc.core5.http.HttpHost;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.integTest.AbstractKnnIT;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.opensearch.common.settings.Settings;
+
+public class KnnIT extends AbstractKnnIT {
+    @Override
+    public OpenSearchTransport buildTransport(Settings settings, HttpHost[] hosts) throws IOException {
+        return new RestClientTransport(buildClient(settings, hosts), new JacksonJsonpMapper());
+    }
+}


### PR DESCRIPTION
### Description
Adds support for the approximate k-NN query type to pair with the support for the `knn_vector` type added in #524. Along with a couple bug fixes for that support.

### Issues Resolved
#539 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
