### PR TITLE
Update `httpcomponents` dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `io.github.classgraph:classgraph` from 4.8.157 to 4.8.160
 - Bumps `org.ajoberstar.grgit:grgit-gradle` from 5.0.0 to 5.2.0
 - Bumps `com.github.jk1.dependency-license-report` from 2.2 to 2.4
+- Update `org.apache.httpcomponents.client5:httpclient5` from `5.1.4` to `5.2.1` and `org.apache.httpcomponents.core5:httpcore5` from `5.1.5` to `5.2.2`
 
 ### Changed
 - Migrate client transports to Apache HttpClient / Core 5.x ([#246](https://github.com/opensearch-project/opensearch-java/pull/246))

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -151,9 +151,9 @@ dependencies {
     compileOnly("org.opensearch.client", "opensearch-rest-client", opensearchVersion)
     testImplementation("org.opensearch.test", "framework", opensearchVersion)
 
-    api("org.apache.httpcomponents.client5:httpclient5:5.1.4")
-    api("org.apache.httpcomponents.core5:httpcore5:5.1.5")
-    api("org.apache.httpcomponents.core5:httpcore5-h2:5.1.5")
+    api("org.apache.httpcomponents.client5:httpclient5:5.2.1")
+    api("org.apache.httpcomponents.core5:httpcore5:5.2.2")
+    api("org.apache.httpcomponents.core5:httpcore5-h2:5.2.2")
 
     // Apache 2.0
     // https://search.maven.org/artifact/com.google.code.findbugs/jsr305


### PR DESCRIPTION
### Description
`httpclient5` and `httpcore5` were updated in OpenSearch in https://github.com/opensearch-project/OpenSearch/pull/8434. Java client has to be updated to reflect the changes.
These changes are breaking for SQL plugin IT.
```
opensearch-project-sql $ ./gradlew :integ-test:integTest

...

> Task :integ-test:compileTestJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':integ-test:compileTestJava'.
> Could not resolve all dependencies for configuration ':integ-test:testCompileClasspath'.
   > Conflict(s) found for the following module(s):
       - org.apache.httpcomponents.client5:httpclient5 between versions 5.2.1 and 5.1.4
       - org.apache.httpcomponents.core5:httpcore5 between versions 5.2.2 and 5.1.5
     Run with:
         --scan or
         :integ-test:dependencyInsight --configuration testCompileClasspath --dependency org.apache.httpcomponents.client5:httpclient5
     to get more insight on how to solve the conflict.

...

BUILD FAILED in 14s
35 actionable tasks: 18 executed, 17 up-to-date

opensearch-project-sql $ ./gradlew :integ-test:dependencyInsight --configuration testCompileClasspath --dependency org.apache.httpcomponents.client5:httpclient5
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.6.1
  OS Info               : Windows 11 10.0 (amd64)
  JDK Version           : 17 (Eclipse Temurin JDK)
  JAVA_HOME             : C:\Program Files\Eclipse Adoptium\jdk-17.0.7.7-hotspot
  Random Testing Seed   : BC32CE6B49344BEF
  In FIPS 140 mode      : false
=======================================

> Task :integ-test:dependencyInsight
Dependency resolution failed because of conflict(s) on the following module(s):
   - org.apache.httpcomponents.client5:httpclient5 between versions 5.2.1 and 5.1.4

org.apache.httpcomponents.client5:httpclient5:5.2.1
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 11           |
   Selection reasons:
      - By conflict resolution: between versions 5.2.1 and 5.1.4

org.apache.httpcomponents.client5:httpclient5:5.2.1
\--- org.opensearch.client:opensearch-rest-client-sniffer:3.0.0-SNAPSHOT:20230704.162035-1057
     \--- org.opensearch.test:framework:3.0.0-SNAPSHOT:20230704.162035-1054
          \--- testCompileClasspath

org.apache.httpcomponents.client5:httpclient5:5.1.4 -> 5.2.1
\--- org.opensearch.client:opensearch-rest-client:3.0.0-SNAPSHOT:20230704.155622-1056
     +--- testCompileClasspath
     +--- org.opensearch.test:framework:3.0.0-SNAPSHOT:20230704.162035-1054
     |    \--- testCompileClasspath
     +--- org.opensearch.client:opensearch-rest-high-level-client:3.0.0-SNAPSHOT:20230704.155622-1056
     |    \--- testCompileClasspath
     \--- org.opensearch.client:opensearch-rest-client-sniffer:3.0.0-SNAPSHOT:20230704.162035-1057
          \--- org.opensearch.test:framework:3.0.0-SNAPSHOT:20230704.162035-1054 (*)

(*) - dependencies omitted (listed previously)

A web-based, searchable dependency report is available by adding the --scan option.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1s
4 actionable tasks: 1 executed, 3 up-to-date
```

### Issues Resolved
This PR supersedes #550 and #549.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
