### PR TITLE
Fixes #553: fix max_analyzer_offset field to match OS 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
 - Fixed Suggesters for Completion, Term, and Phrase and refactored the Suggestion class ([#477](https://github.com/opensearch-project/opensearch-java/pull/477))
+- Fix highlight max_analyzer_offset field name to match with the one introduced in OpenSearch 2.2.0 ([#555](https://github.com/opensearch-project/opensearch-java/pull/555))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/search/Highlight.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/search/Highlight.java
@@ -112,7 +112,7 @@ public class Highlight implements JsonpSerializable {
 	private final Query highlightQuery;
 
 	@Nullable
-	private final String maxAnalyzedOffset;
+	private final String maxAnalyzerOffset;
 
 	// ---------------------------------------------------------------------------------------------
 
@@ -137,7 +137,7 @@ public class Highlight implements JsonpSerializable {
 		this.requireFieldMatch = builder.requireFieldMatch;
 		this.tagsSchema = builder.tagsSchema;
 		this.highlightQuery = builder.highlightQuery;
-		this.maxAnalyzedOffset = builder.maxAnalyzedOffset;
+		this.maxAnalyzerOffset = builder.maxAnalyzerOffset;
 
 	}
 
@@ -295,11 +295,11 @@ public class Highlight implements JsonpSerializable {
 	}
 
 	/**
-	 * API name: {@code max_analyzed_offset}
+	 * API name: {@code max_analyzer_offset}
 	 */
 	@Nullable
-	public final String maxAnalyzedOffset() {
-		return this.maxAnalyzedOffset;
+	public final String maxAnalyzerOffset() {
+		return this.maxAnalyzerOffset;
 	}
 
 	/**
@@ -419,9 +419,9 @@ public class Highlight implements JsonpSerializable {
 			this.highlightQuery.serialize(generator, mapper);
 
 		}
-		if (this.maxAnalyzedOffset != null) {
-			generator.writeKey("max_analyzed_offset");
-			generator.write(this.maxAnalyzedOffset);
+		if (this.maxAnalyzerOffset != null) {
+			generator.writeKey("max_analyzer_offset");
+			generator.write(this.maxAnalyzerOffset);
 
 		}
 
@@ -491,7 +491,7 @@ public class Highlight implements JsonpSerializable {
 		private Query highlightQuery;
 
 		@Nullable
-		private String maxAnalyzedOffset;
+		private String maxAnalyzerOffset;
 
 		/**
 		 * Required - API name: {@code fields}
@@ -705,10 +705,10 @@ public class Highlight implements JsonpSerializable {
 		}
 
 		/**
-		 * API name: {@code max_analyzed_offset}
+		 * API name: {@code max_analyzer_offset}
 		 */
-		public final Builder maxAnalyzedOffset(@Nullable String value) {
-			this.maxAnalyzedOffset = value;
+		public final Builder maxAnalyzerOffset(@Nullable String value) {
+			this.maxAnalyzerOffset = value;
 			return this;
 		}
 
@@ -756,7 +756,7 @@ public class Highlight implements JsonpSerializable {
 		op.add(Builder::requireFieldMatch, JsonpDeserializer.booleanDeserializer(), "require_field_match");
 		op.add(Builder::tagsSchema, HighlighterTagsSchema._DESERIALIZER, "tags_schema");
 		op.add(Builder::highlightQuery, Query._DESERIALIZER, "highlight_query");
-		op.add(Builder::maxAnalyzedOffset, JsonpDeserializer.stringDeserializer(), "max_analyzed_offset");
+		op.add(Builder::maxAnalyzerOffset, JsonpDeserializer.stringDeserializer(), "max_analyzer_offset");
 
 	}
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractHighlightIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractHighlightIT.java
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.client.opensearch.integTest;
 
 import org.junit.Test;

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractHighlightIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractHighlightIT.java
@@ -1,0 +1,164 @@
+package org.opensearch.client.opensearch.integTest;
+
+import org.junit.Test;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Highlight;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.util.ObjectBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public abstract class AbstractHighlightIT extends OpenSearchJavaClientTestCase {
+
+    @Test
+    public void testDefaultHighlight() throws Exception {
+        String index = "queries_highlight";
+        createTestDocuments(index);
+
+        List<Map<String, List<String>>> highlights = highlightQuery("spread",
+                h -> h.fields("content", b -> b));
+
+        assertEquals(2, highlights.size());
+        for (Map<String, List<String>> hit : highlights) {
+            assertEquals(1, hit.size());
+            assertEquals(1, hit.get("content").size());
+            assertTrue(hit.get("content").get(0).contains("<em>spread</em>"));
+        }
+    }
+
+    @Test
+    public void testMultiFieldHighlight() throws Exception {
+        String index = "queries_highlight";
+        createTestDocuments(index);
+
+        List<Map<String, List<String>>> highlights = highlightQuery("real decades",
+                h -> h.fields("title", b -> b).fields("content", b -> b));
+
+        assertEquals(3, highlights.size());
+        for (Map<String, List<String>> hit : highlights) {
+            assertEquals(2, hit.size());
+            assertEquals(1, hit.get("title").size());
+            assertTrue(hit.get("title").get(0).contains("<em>Real</em>"));
+            assertEquals(1, hit.get("content").size());
+            assertTrue(hit.get("content").get(0).contains("<em>decades</em>"));
+        }
+    }
+
+    @Test
+    public void testDifferentMarkersHighlight() throws Exception {
+        String index = "queries_highlight";
+        createTestDocuments(index);
+
+        List<Map<String, List<String>>> highlights = highlightQuery("spread",
+                h -> h.preTags("<b>").postTags("</b>").fields("content", b -> b));
+
+        assertEquals(2, highlights.size());
+        for (Map<String, List<String>> hit : highlights) {
+            assertEquals(1, hit.size());
+            assertEquals(1, hit.get("content").size());
+            assertTrue(hit.get("content").get(0).contains("<b>spread</b>"));
+        }
+    }
+
+    @Test
+    public void testAnalyzerOffset() throws Exception {
+
+        String[] versionNumber = javaClient().info().version().number().split("\\.");
+        int major = Integer.parseInt(versionNumber[0]);
+        int minor = Integer.parseInt(versionNumber[1]);
+
+        // The max_analyzer_offset setting was introduced in OpenSearch 2.2.0
+        // before that, the max_analyzer_offset thrown an unknown field exception
+        // For more details, see:
+        // https://github.com/opensearch-project/OpenSearch/pull/4031
+        // https://github.com/opensearch-project/OpenSearch/pull/3893
+        if (major >= 2 && minor >= 2) {
+            String index = "queries_highlight";
+            createTestDocuments(index);
+            List<Map<String, List<String>>> highlights = highlightQuery("real",
+                    h -> h.maxAnalyzerOffset("5").fields("title", b -> b));
+
+            assertEquals(3, highlights.size());
+            assertEquals(0, highlights.get(0).size());
+            assertEquals(1, highlights.get(1).size());
+            assertEquals(1, highlights.get(2).size());
+
+            assertTrue(highlights.get(1).get("title").get(0).contains("<em>Real</em>"));
+            assertTrue(highlights.get(2).get("title").get(0).contains("<em>Real</em>"));
+        }
+    }
+
+    private List<Map<String, List<String>>> highlightQuery(String query,
+                                                           Function<Highlight.Builder, ObjectBuilder<Highlight>> fn)
+            throws IOException {
+        SearchResponse<Article> response = javaClient()
+                .search(s -> s
+                        .query(q -> q
+                                .simpleQueryString(sqs -> sqs
+                                        .fields("title", "content", "author")
+                                        .query(query)))
+                        .highlight(fn), Article.class);
+        return response.hits().hits().stream().map(Hit::highlight).collect(Collectors.toList());
+    }
+
+    private void createTestDocuments(String index) throws IOException {
+        javaClient().create(_1 -> _1.index(index).id("1").document(createArticle(
+                        "Superheroes are Real", "Meet these man avoid the fire spread during last decades.", "John Doe"))
+                .refresh(Refresh.True));
+        javaClient().create(_1 -> _1.index(index).id("2").document(createArticle(
+                        "Real Slow Ideas", "Why some innovations spread quick while others take decades to catch hold.", "John Foo"))
+                .refresh(Refresh.True));
+        javaClient().create(_1 -> _1.index(index).id("3").document(createArticle(
+                        "Real Two Degrees", "How the world failed on climate change during the decades.", "Anne Doe"))
+                .refresh(Refresh.True));
+    }
+
+    private Article createArticle(String title, String content, String author) {
+        return new Article(title, content, author);
+    }
+
+    public static class Article {
+        public String title;
+        public String content;
+        public String author;
+
+        public Article() {
+        }
+
+        public Article(String title, String content, String author) {
+            this.title = title;
+            this.content = content;
+            this.author = author;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(final String title) {
+            this.title = title;
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public void setContent(final String content) {
+            this.content = content;
+        }
+
+        public String getAuthor() {
+            return author;
+        }
+
+        public void setAuthor(final String author) {
+            this.author = author;
+        }
+    }
+
+}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/httpclient5/HighlightIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/httpclient5/HighlightIT.java
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.client.opensearch.integTest.httpclient5;
 
 import org.opensearch.client.opensearch.integTest.AbstractHighlightIT;

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/httpclient5/HighlightIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/httpclient5/HighlightIT.java
@@ -1,0 +1,6 @@
+package org.opensearch.client.opensearch.integTest.httpclient5;
+
+import org.opensearch.client.opensearch.integTest.AbstractHighlightIT;
+
+public class HighlightIT extends AbstractHighlightIT implements HttpClient5TransportSupport {
+}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/restclient/HighlightIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/restclient/HighlightIT.java
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.client.opensearch.integTest.restclient;
 
 import org.apache.hc.core5.http.HttpHost;

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/restclient/HighlightIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/restclient/HighlightIT.java
@@ -1,0 +1,18 @@
+package org.opensearch.client.opensearch.integTest.restclient;
+
+import org.apache.hc.core5.http.HttpHost;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.integTest.AbstractHighlightIT;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.opensearch.common.settings.Settings;
+
+import java.io.IOException;
+
+public class HighlightIT extends AbstractHighlightIT {
+    @Override
+    public OpenSearchTransport buildTransport(Settings settings, HttpHost[] hosts) throws IOException {
+        return new RestClientTransport(buildClient(settings, hosts), new JacksonJsonpMapper());
+    }
+
+}


### PR DESCRIPTION
Fix field `max_analyzed_offset` to `max_analyzer_offset`

### Description
The current field `max_analyzed_offset` used in ElasticSearch doesn't match the field added to OpenSearch version 2.2.0, `max_analyzer_offset`.
This means the current client implementation have two problems:
1. It doesn't work for versions before version 2.2.0, because no equivalent field exist on OpenSearch
2. It doesn't workf for version after 2.2.0, because the field is misspelled

For further information see:
- https://github.com/opensearch-project/OpenSearch/pull/4031
- https://github.com/opensearch-project/OpenSearch/pull/3893

### Issues Resolved
- https://github.com/opensearch-project/opensearch-java/issues/553

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
