### PR TITLE
Update `httpcomponents` dependencies. (#554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `com.github.jk1.dependency-license-report` from 2.2 to 2.4
 - Bumps `io.github.classgraph:classgraph` from 4.8.157 to 4.8.160
 - Bumps `jackson` from 2.14.2 to 2.15.2 ((#537)[https://github.com/opensearch-project/opensearch-java/pull/537])
+- Update `org.apache.httpcomponents.client5:httpclient5` from `5.1.4` to `5.2.1` and `org.apache.httpcomponents.core5:httpcore5` from `5.1.5` to `5.2.2`
 
 ### Changed
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -128,8 +128,8 @@ OpenSearchClient client = new OpenSearchClient(transport);
 The Apache HttpClient 5 based transport has dependences on Apache HttpClient 5 and Apache HttpCore 5 which has to be added to the project explicitly.
 
 ```gradle
-    implementation("org.apache.httpcomponents.client5", "httpclient5", "5.1.4")
-    implementation("org.apache.httpcomponents.core5", "httpcore5", "5.1.5")
+    implementation("org.apache.httpcomponents.client5", "httpclient5", "5.2.1")
+    implementation("org.apache.httpcomponents.core5", "httpcore5", "5.2.2")
 ```
 
 ## Create an index


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/554 to `2.x`