### PR TITLE
Set httpcore5 to 5.2 to be compatible with httpclient5 5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `org.ajoberstar.grgit:grgit-gradle` from 5.0.0 to 5.2.0
 - Bumps `com.github.jk1.dependency-license-report` from 2.2 to 2.4
 - Update `org.apache.httpcomponents.client5:httpclient5` from `5.1.4` to `5.2.1` and `org.apache.httpcomponents.core5:httpcore5` from `5.1.5` to `5.2.2`
+- Update `org.apache.httpcomponents.client5:httpcore5` from `5.2.2` to `5.2` to be compatible with `org.apache.httpcomponents.core5:httpclient5:5.2.1`
 
 ### Changed
 - Migrate client transports to Apache HttpClient / Core 5.x ([#246](https://github.com/opensearch-project/opensearch-java/pull/246))

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -152,8 +152,8 @@ dependencies {
     testImplementation("org.opensearch.test", "framework", opensearchVersion)
 
     api("org.apache.httpcomponents.client5:httpclient5:5.2.1")
-    api("org.apache.httpcomponents.core5:httpcore5:5.2.2")
-    api("org.apache.httpcomponents.core5:httpcore5-h2:5.2.2")
+    api("org.apache.httpcomponents.core5:httpcore5:5.2")
+    api("org.apache.httpcomponents.core5:httpcore5-h2:5.2")
 
     // Apache 2.0
     // https://search.maven.org/artifact/com.google.code.findbugs/jsr305


### PR DESCRIPTION
### Description

`org.apache.httpcomponents.client5:httpclient5:5.2.1` is [compatible with httpcore5:5.2](https://github.com/apache/httpcomponents-client/blob/rel/v5.2.1/pom.xml#L65) and the recent upgrade to 5.2.2 is causing problems running an [extension using the SDK](https://github.com/opensearch-project/opensearch-sdk-java/issues/857). I am opening a PR to downgrade the version to 5.2 which is compatible with httpclient:5.2.1

### Issues Resolved

https://github.com/opensearch-project/opensearch-sdk-java/issues/857

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
