### PR TITLE
Exclude Apache HttpClient5 transitive dependencies on Apache HttpCore5

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -151,7 +151,9 @@ dependencies {
     compileOnly("org.opensearch.client", "opensearch-rest-client", opensearchVersion)
     testImplementation("org.opensearch.test", "framework", opensearchVersion)
 
-    api("org.apache.httpcomponents.client5:httpclient5:5.2.1")
+    api("org.apache.httpcomponents.client5:httpclient5:5.2.1") {
+      exclude(group = "org.apache.httpcomponents.core5")
+    }
     api("org.apache.httpcomponents.core5:httpcore5:5.2.2")
     api("org.apache.httpcomponents.core5:httpcore5-h2:5.2.2")
 


### PR DESCRIPTION
### Description
For some reasons, Gradle still tries to bring transitive dependencies on Apache HttpCore5 (from Apache HttpClient5 ) nonetheless we explicitly provide those.

![image](https://github.com/opensearch-project/opensearch-java/assets/509855/9ba1b200-2d7c-4269-ad84-e58bfe2961eb)

Excluding those to get:

![image](https://github.com/opensearch-project/opensearch-java/assets/509855/f7118929-f270-4049-869e-f74e130bc0e1)


Thanks a lot to @cwperks for highlighting that

### Issues Resolved
Related to https://github.com/opensearch-project/opensearch-sdk-java/issues/857

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
