### PR TITLE
Make distribution optional in version info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `jackson` from 2.14.2 to 2.15.2 ((#537)[https://github.com/opensearch-project/opensearch-java/pull/537])
 
 ### Changed
+- Make distribution optional in version info ([#594](https://github.com/opensearch-project/opensearch-java/pull/594))
 
 ### Deprecated
 - Deprecate translogDurability and translogFlushThresholdSize in IndexSettings in favor of a separate translog object ([#518](https://github.com/opensearch-project/opensearch-java/pull/518))

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/OpenSearchVersionInfo.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/OpenSearchVersionInfo.java
@@ -79,7 +79,7 @@ public final class OpenSearchVersionInfo implements JsonpSerializable {
 		this.buildHash = ApiTypeHelper.requireNonNull(builder.buildHash, this, "buildHash");
 		this.buildSnapshot = ApiTypeHelper.requireNonNull(builder.buildSnapshot, this, "buildSnapshot");
 		this.buildType = ApiTypeHelper.requireNonNull(builder.buildType, this, "buildType");
-		this.distribution = ApiTypeHelper.requireNonNull(builder.distribution, this, "distribution");
+		this.distribution = builder.distribution;
 		this.luceneVersion = ApiTypeHelper.requireNonNull(builder.luceneVersion, this, "luceneVersion");
 		this.minimumIndexCompatibilityVersion = ApiTypeHelper.requireNonNull(builder.minimumIndexCompatibilityVersion,
 				this, "minimumIndexCompatibilityVersion");


### PR DESCRIPTION
### Description
No longer require `distribution` in `OpenSearchVersionInfo` to be non-null.

### Issues Resolved
Closes #573 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
