### PR TITLE
[Backport 2.x] Bump org.eclipse.parsson:parsson from 1.1.2 to 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `com.github.jk1.dependency-license-report` from 1.19 to 2.2
-- Bumps `org.eclipse.parsson:parsson` from 1.1.1 to 1.1.2
+- Bumps `org.eclipse.parsson:parsson` from 1.1.2 to 1.1.4
 
 ### Changed
 - Improve time taken by Github actions by using cache ([#439](https://github.com/opensearch-project/opensearch-java/pull/439))

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -154,7 +154,7 @@ dependencies {
     // Needed even if using Jackson to have an implementation of the Jsonp object model
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // https://github.com/eclipse-ee4j/parsson
-    api("org.eclipse.parsson:parsson:1.1.2")
+    api("org.eclipse.parsson:parsson:1.1.4")
 
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // http://json-b.net/


### PR DESCRIPTION
### Description
Backporting #582 #595

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
