### PR TITLE
JarHell caused by latest software.amazon.awssdk 2.20.141

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+ - [BUG] JarHell caused by latest software.amazon.awssdk 2.20.141 ([#616](https://github.com/opensearch-project/opensearch-java/pull/616))
 
 ### Security
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -55,6 +55,12 @@ plugins {
 }
 apply(plugin = "opensearch.repositories")
 
+configurations {
+    all {
+        exclude(group = "software.amazon.awssdk", module = "third-party-jackson-core")
+    }
+}
+
 checkstyle {
     toolVersion = "10.0"
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractCatClientIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractCatClientIT.java
@@ -241,9 +241,15 @@ public abstract class AbstractCatClientIT extends OpenSearchJavaClientTestCase {
                 .pitSegments(r -> r.headers("index,shard,id,segment,size"));
 
         assertNotNull("PitSegmentsResponse.segments() is null", PitSegmentsResponse.valueBody());
-        assertTrue("PitSegmentsResponse.segments().size() == 0",
+
+        if (Version.fromString(version).onOrAfter(Version.fromString("2.10.0"))) {
+            assertTrue("PitSegmentsResponse.segments().size() == 0",
+                PitSegmentsResponse.valueBody().isEmpty());
+        } else {
+            assertTrue("PitSegmentsResponse.segments().size() == 0",
                 PitSegmentsResponse.valueBody().size() > 0);
         }
+    }
 
     private void createIndex(String indexName) throws Exception {
         CreateIndexResponse createResponse = javaClient().indices().create(b -> b.index(indexName));


### PR DESCRIPTION
### Description
JarHell caused by latest software.amazon.awssdk 2.20.141

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-java/issues/615

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
