### PR TITLE
[Backport] [2.x] JarHell caused by latest software.amazon.awssdk 2.20.141 (#616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fix PutMappingRequest by removing unsupported fields ([#597](https://github.com/opensearch-project/opensearch-java/pull/597))
+- [BUG] JarHell caused by latest software.amazon.awssdk 2.20.141 ([#616](https://github.com/opensearch-project/opensearch-java/pull/616))
 
 ### Security
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -51,6 +51,12 @@ plugins {
     id("com.github.jk1.dependency-license-report") version "2.5"
 }
 
+configurations {
+    all {
+        exclude(group = "software.amazon.awssdk", module = "third-party-jackson-core")
+    }
+}
+
 checkstyle {
     toolVersion = "10.0"
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractCatClientIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractCatClientIT.java
@@ -241,9 +241,15 @@ public abstract class AbstractCatClientIT extends OpenSearchJavaClientTestCase {
                 .pitSegments(r -> r.headers("index,shard,id,segment,size"));
 
         assertNotNull("PitSegmentsResponse.segments() is null", PitSegmentsResponse.valueBody());
-        assertTrue("PitSegmentsResponse.segments().size() == 0",
+
+        if (Version.fromString(version).onOrAfter(Version.fromString("2.10.0"))) {
+            assertTrue("PitSegmentsResponse.segments().size() == 0",
+                PitSegmentsResponse.valueBody().isEmpty());
+        } else {
+            assertTrue("PitSegmentsResponse.segments().size() == 0",
                 PitSegmentsResponse.valueBody().size() > 0);
         }
+    }
 
     private void createIndex(String indexName) throws Exception {
         CreateIndexResponse createResponse = javaClient().indices().create(b -> b.index(indexName));


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/616 to `2.x`