### PR TITLE
Fix for CVE-2976 + add CVE checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
  - [BUG] JarHell caused by latest software.amazon.awssdk 2.20.141 ([#616](https://github.com/opensearch-project/opensearch-java/pull/616))
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#620](https://github.com/opensearch-project/opensearch-java/pull/620))
+- Fixed CVE-2976 + added CVE checker ([#624](https://github.com/opensearch-project/opensearch-java/pull/624))
 
 ### Security
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -52,8 +52,10 @@ plugins {
     checkstyle
     `maven-publish`
     id("com.github.jk1.dependency-license-report") version "2.5"
+    id("org.owasp.dependencycheck") version "8.4.0"
 }
 apply(plugin = "opensearch.repositories")
+apply(plugin = "org.owasp.dependencycheck")
 
 configurations {
     all {
@@ -62,7 +64,7 @@ configurations {
 }
 
 checkstyle {
-    toolVersion = "10.0"
+    toolVersion = "10.12.3"
 }
 
 java {


### PR DESCRIPTION
### Description
This PR will fix the remaining base branch CVE which requires an update to `checkstyle`'s version, and also add a plugin that can be ran using this command:
`./gradlew java-client:dependencyCheckAnalyze`
This plugin checks all dependencies in Gradle and will let you know of any CVE's that exist.

An example run before the fix:
```
Checking for updates and analyzing dependencies for vulnerabilities
Generating report for project java-client
Found 3 vulnerabilities in project java-client


One or more dependencies were identified with known vulnerabilities in java-client:

guava-31.0.1-jre.jar (pkg:maven/com.google.guava/guava@31.0.1-jre, cpe:2.3:a:google:guava:31.0.1:*:*:*:*:*:*:*) : CVE-2023-2976, CVE-2020-8908
jackson-databind-2.15.2.jar (pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2, cpe:2.3:a:fasterxml:jackson-databind:2.15.2:*:*:*:*:*:*:*) : CVE-2023-35116

```

After the fix: 
```
Checking for updates and analyzing dependencies for vulnerabilities
Generating report for project java-client
Found 1 vulnerabilities in project java-client


One or more dependencies were identified with known vulnerabilities in java-client:

jackson-databind-2.15.2.jar (pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2, cpe:2.3:a:fasterxml:jackson-databind:2.15.2:*:*:*:*:*:*:*) : CVE-2023-35116
```

### Issues Resolved
CVE-2976

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
