### PR TITLE
[Backport] [2.x] Fix for CVE-2976 + add CVE checker (#624)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix PutMappingRequest by removing unsupported fields ([#597](https://github.com/opensearch-project/opensearch-java/pull/597))
 - [BUG] JarHell caused by latest software.amazon.awssdk 2.20.141 ([#616](https://github.com/opensearch-project/opensearch-java/pull/616))
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#620](https://github.com/opensearch-project/opensearch-java/pull/620))
+- Fixed CVE-2976 + added CVE checker ([#624](https://github.com/opensearch-project/opensearch-java/pull/624))
 
 ### Security
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -49,7 +49,10 @@ plugins {
     checkstyle
     `maven-publish`
     id("com.github.jk1.dependency-license-report") version "2.5"
+    id("org.owasp.dependencycheck") version "8.4.0"
 }
+
+apply(plugin = "org.owasp.dependencycheck")
 
 configurations {
     all {
@@ -58,7 +61,7 @@ configurations {
 }
 
 checkstyle {
-    toolVersion = "10.0"
+    toolVersion = "10.12.3"
 }
 
 java {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/624 to `2.x`