### PR TITLE
Added size attribute to MultiTermsAggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Document HTTP/2 support ([#330](https://github.com/opensearch-project/opensearch-java/pull/330))
 - Added support for "cjk" analyzer ([#604](https://github.com/opensearch-project/opensearch-java/pull/604))
 - Added support for wrapper queries ([#630](https://github.com/opensearch-project/opensearch-java/pull/630))
+- Added size attribute to MultiTermsAggregation ([#627](https://github.com/opensearch-project/opensearch-java/pull/627))
 
 ### Dependencies
 - Bumps `org.ajoberstar.grgit:grgit-gradle` from 5.0.0 to 5.2.0

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/aggregations/MultiTermsAggregation.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/aggregations/MultiTermsAggregation.java
@@ -43,11 +43,16 @@ import jakarta.json.stream.JsonGenerator;
 import java.util.List;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 // typedef: _types.aggregations.MultiTermsAggregation
 
 @JsonpDeserializable
 public class MultiTermsAggregation extends BucketAggregationBase implements AggregationVariant {
 	private final List<MultiTermLookup> terms;
+
+	@Nullable
+	private final Integer size;
 
 	// ---------------------------------------------------------------------------------------------
 
@@ -55,7 +60,7 @@ public class MultiTermsAggregation extends BucketAggregationBase implements Aggr
 		super(builder);
 
 		this.terms = ApiTypeHelper.unmodifiableRequired(builder.terms, this, "terms");
-
+		this.size = builder.size;
 	}
 
 	public static MultiTermsAggregation of(Function<Builder, ObjectBuilder<MultiTermsAggregation>> fn) {
@@ -77,9 +82,22 @@ public class MultiTermsAggregation extends BucketAggregationBase implements Aggr
 		return this.terms;
 	}
 
+	/**
+	 * API name: {@code size}
+	 */
+	@Nullable
+	public final Integer size() {
+		return this.size;
+	}
+
 	protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
 		super.serializeInternal(generator, mapper);
+		if (this.size != null) {
+			generator.writeKey("size");
+			generator.write(this.size);
+
+		}
 		if (ApiTypeHelper.isDefined(this.terms)) {
 			generator.writeKey("terms");
 			generator.writeStartArray();
@@ -103,6 +121,9 @@ public class MultiTermsAggregation extends BucketAggregationBase implements Aggr
 			implements
 				ObjectBuilder<MultiTermsAggregation> {
 		private List<MultiTermLookup> terms;
+
+		@Nullable
+		private Integer size;
 
 		/**
 		 * Required - API name: {@code terms}
@@ -133,6 +154,14 @@ public class MultiTermsAggregation extends BucketAggregationBase implements Aggr
 			return terms(fn.apply(new MultiTermLookup.Builder()).build());
 		}
 
+		/**
+		 * API name: {@code size}
+		 */
+		public final Builder size(@Nullable Integer value) {
+			this.size = value;
+			return this;
+		}
+
 		@Override
 		protected Builder self() {
 			return this;
@@ -161,8 +190,8 @@ public class MultiTermsAggregation extends BucketAggregationBase implements Aggr
 
 	protected static void setupMultiTermsAggregationDeserializer(ObjectDeserializer<MultiTermsAggregation.Builder> op) {
 		BucketAggregationBase.setupBucketAggregationBaseDeserializer(op);
+		op.add(Builder::size, JsonpDeserializer.integerDeserializer(), "size");
 		op.add(Builder::terms, JsonpDeserializer.arrayDeserializer(MultiTermLookup._DESERIALIZER), "terms");
-
 	}
 
 }


### PR DESCRIPTION
### Description

Added size attribute to MultiTermsAggregation to retreive other hit sizes than the default value of the attribute.
Code for the added attribute was taken from TermsAggregation class.
This pull request replaces [#614](https://github.com/opensearch-project/opensearch-java/pull/614), as [dblock](https://github.com/dblock) suggested that the changes should go to the main branch.
Please backfort this code to 2.x.

### Issues Resolved

- https://github.com/opensearch-project/opensearch-java/issues/534 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.