### PR TITLE
Moving "software.amazon.awssdk" dependencies to the compileOnly scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - Migrate client transports to Apache HttpClient / Core 5.x ([#246](https://github.com/opensearch-project/opensearch-java/pull/246))
+- Moved "software.amazon.awssdk" dependencies to the compileOnly scope. ([#628](https://github.com/opensearch-project/opensearch-java/pull/628))
 
 ### Deprecated
 - Deprecate RestClientTransport ([#536](https://github.com/opensearch-project/opensearch-java/pull/536))

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -73,10 +73,6 @@ java {
 
     withJavadocJar()
     withSourcesJar()
-
-    registerFeature("awsSdk2Support") {
-        usingSourceSet(sourceSets.get("main"))
-    }
 }
 
 tasks.withType<ProcessResources> {
@@ -185,8 +181,8 @@ dependencies {
     testImplementation("com.fasterxml.jackson.datatype", "jackson-datatype-jakarta-jsonp", jacksonVersion)
 
     // For AwsSdk2Transport
-    "awsSdk2SupportImplementation"("software.amazon.awssdk","sdk-core","[2.15,3.0)")
-    "awsSdk2SupportImplementation"("software.amazon.awssdk","auth","[2.15,3.0)")
+    compileOnly("software.amazon.awssdk","sdk-core","[2.15,3.0)")
+    compileOnly("software.amazon.awssdk","auth","[2.15,3.0)")
     testImplementation("software.amazon.awssdk","sdk-core","[2.15,3.0)")
     testImplementation("software.amazon.awssdk","auth","[2.15,3.0)")
     testImplementation("software.amazon.awssdk","aws-crt-client","[2.15,3.0)")

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -73,6 +73,10 @@ java {
 
     withJavadocJar()
     withSourcesJar()
+
+    registerFeature("awsSdk2Support") {
+        usingSourceSet(sourceSets.get("main"))
+    }
 }
 
 tasks.withType<ProcessResources> {
@@ -181,8 +185,8 @@ dependencies {
     testImplementation("com.fasterxml.jackson.datatype", "jackson-datatype-jakarta-jsonp", jacksonVersion)
 
     // For AwsSdk2Transport
-    compileOnly("software.amazon.awssdk","sdk-core","[2.15,3.0)")
-    compileOnly("software.amazon.awssdk","auth","[2.15,3.0)")
+    "awsSdk2SupportCompileOnly"("software.amazon.awssdk","sdk-core","[2.15,3.0)")
+    "awsSdk2SupportCompileOnly"("software.amazon.awssdk","auth","[2.15,3.0)")
     testImplementation("software.amazon.awssdk","sdk-core","[2.15,3.0)")
     testImplementation("software.amazon.awssdk","auth","[2.15,3.0)")
     testImplementation("software.amazon.awssdk","aws-crt-client","[2.15,3.0)")


### PR DESCRIPTION
### Description
Current build configuration leaking "software.amazon.awssdk" dependencies to the final POM:
```
    <dependency>
      <groupId>software.amazon.awssdk</groupId>
      <artifactId>sdk-core</artifactId>
      <version>[2.15,3.0)</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>software.amazon.awssdk</groupId>
      <artifactId>auth</artifactId>
      <version>[2.15,3.0)</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
```
Which breaks some maven plugins (notable https://github.com/basepom/dependency-versions-check-maven-plugin) which tries to download all possible versions of the SDK in range.

### Issues Resolved
By changing scope to the `compileOnly`,  we completely  removing this dependencies from final POM

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
