### PR TITLE
[Backport 2.x] Moving "software.amazon.awssdk" dependencies to the compileOnly scope (#628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `io.github.classgraph:classgraph` from 4.8.160 to 4.8.161
   
 ### Changed
+- Moved "software.amazon.awssdk" dependencies to the compileOnly scope. ([#628](https://github.com/opensearch-project/opensearch-java/pull/628))
 
 ### Deprecated
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -180,8 +180,8 @@ dependencies {
     implementation("org.apache.httpcomponents.core5", "httpcore5", "5.1.5")
 
     // For AwsSdk2Transport
-    "awsSdk2SupportImplementation"("software.amazon.awssdk","sdk-core","[2.15,3.0)")
-    "awsSdk2SupportImplementation"("software.amazon.awssdk","auth","[2.15,3.0)")
+    "awsSdk2SupportCompileOnly"("software.amazon.awssdk","sdk-core","[2.15,3.0)")
+    "awsSdk2SupportCompileOnly"("software.amazon.awssdk","auth","[2.15,3.0)")
     testImplementation("software.amazon.awssdk","sdk-core","[2.15,3.0)")
     testImplementation("software.amazon.awssdk","auth","[2.15,3.0)")
     testImplementation("software.amazon.awssdk","aws-crt-client","[2.15,3.0)")


### PR DESCRIPTION
### Description
Backporting #628 to 2.x

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
