### PR TITLE
TermvectorsResponse fix for optionals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG] JarHell caused by latest software.amazon.awssdk 2.20.141 ([#616](https://github.com/opensearch-project/opensearch-java/pull/616))
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#620](https://github.com/opensearch-project/opensearch-java/pull/620))
 - Fixed CVE-2976 + added CVE checker ([#624](https://github.com/opensearch-project/opensearch-java/pull/624))
+- [BUG] Fix TermvectorsResponse for optional fields. ([#640](https://github.com/opensearch-project/opensearch-java/pull/640))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/TermvectorsResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/TermvectorsResponse.java
@@ -62,7 +62,7 @@ public class TermvectorsResponse implements JsonpSerializable {
 
 	private final long took;
 
-	private final long version;
+	private final Long version;
 
 	// ---------------------------------------------------------------------------------------------
 
@@ -73,7 +73,7 @@ public class TermvectorsResponse implements JsonpSerializable {
 		this.index = ApiTypeHelper.requireNonNull(builder.index, this, "index");
 		this.termVectors = ApiTypeHelper.unmodifiable(builder.termVectors);
 		this.took = ApiTypeHelper.requireNonNull(builder.took, this, "took");
-		this.version = ApiTypeHelper.requireNonNull(builder.version, this, "version");
+		this.version = builder.version;
 
 	}
 
@@ -157,8 +157,10 @@ public class TermvectorsResponse implements JsonpSerializable {
 		generator.writeKey("took");
 		generator.write(this.took);
 
-		generator.writeKey("_version");
-		generator.write(this.version);
+        if (null != this.version) {
+            generator.writeKey("_version");
+            generator.write(this.version);
+        }
 
 	}
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/termvectors/Term.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/termvectors/Term.java
@@ -32,6 +32,10 @@
 
 package org.opensearch.client.opensearch.core.termvectors;
 
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
@@ -41,10 +45,6 @@ import org.opensearch.client.json.ObjectDeserializer;
 import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.ObjectBuilder;
 import org.opensearch.client.util.ObjectBuilderBase;
-import jakarta.json.stream.JsonGenerator;
-import java.util.List;
-import java.util.function.Function;
-import javax.annotation.Nullable;
 
 // typedef: _global.termvectors.Term
 
@@ -57,7 +57,7 @@ public class Term implements JsonpSerializable {
 	@Nullable
 	private final Double score;
 
-	private final int termFreq;
+	private final Integer termFreq;
 
 	private final List<Token> tokens;
 
@@ -70,8 +70,8 @@ public class Term implements JsonpSerializable {
 
 		this.docFreq = builder.docFreq;
 		this.score = builder.score;
-		this.termFreq = ApiTypeHelper.requireNonNull(builder.termFreq, this, "termFreq");
-		this.tokens = ApiTypeHelper.unmodifiableRequired(builder.tokens, this, "tokens");
+		this.termFreq = builder.termFreq;
+		this.tokens = ApiTypeHelper.unmodifiable(builder.tokens);
 		this.ttf = builder.ttf;
 
 	}
@@ -139,8 +139,10 @@ public class Term implements JsonpSerializable {
 			generator.write(this.score);
 
 		}
-		generator.writeKey("term_freq");
-		generator.write(this.termFreq);
+        if (null != this.termFreq) {
+            generator.writeKey("term_freq");
+            generator.write(this.termFreq);
+        }
 
 		if (ApiTypeHelper.isDefined(this.tokens)) {
 			generator.writeKey("tokens");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/termvectors/TermVector.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/termvectors/TermVector.java
@@ -58,7 +58,7 @@ public class TermVector implements JsonpSerializable {
 
 	private TermVector(Builder builder) {
 
-		this.fieldStatistics = ApiTypeHelper.requireNonNull(builder.fieldStatistics, this, "fieldStatistics");
+		this.fieldStatistics = builder.fieldStatistics;
 		this.terms = ApiTypeHelper.unmodifiableRequired(builder.terms, this, "terms");
 
 	}
@@ -92,8 +92,10 @@ public class TermVector implements JsonpSerializable {
 
 	protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
-		generator.writeKey("field_statistics");
-		this.fieldStatistics.serialize(generator, mapper);
+        if (null != this.fieldStatistics) {
+            generator.writeKey("field_statistics");
+            this.fieldStatistics.serialize(generator, mapper);
+        }
 
 		if (ApiTypeHelper.isDefined(this.terms)) {
 			generator.writeKey("terms");

--- a/java-client/src/test/java/org/opensearch/client/opensearch/experiments/ParsingTests.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/experiments/ParsingTests.java
@@ -189,7 +189,8 @@ public class ParsingTests extends ModelTestCase {
         );
 
         String str = toJson(response);
-        assertEquals("{\"found\":true,\"_id\":\"id\",\"_index\":\"index\",\"term_vectors\":{\"key1\":{\"terms\":{\"term1\":{\"score\":0.3}}}},\"took\":0}", str);
+        assertEquals("{\"found\":true,\"_id\":\"id\",\"_index\":\"index\","
+            +"\"term_vectors\":{\"key1\":{\"terms\":{\"term1\":{\"score\":0.3}}}},\"took\":0}", str);
 
         final TermvectorsResponse response2 = fromJson(str, TermvectorsResponse._DESERIALIZER);
         assertEquals(response.index(), response2.index());

--- a/java-client/src/test/java/org/opensearch/client/opensearch/experiments/ParsingTests.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/experiments/ParsingTests.java
@@ -33,13 +33,13 @@
 package org.opensearch.client.opensearch.experiments;
 
 import java.util.List;
-
 import org.junit.Test;
 import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.analysis.Analyzer;
 import org.opensearch.client.opensearch._types.analysis.TokenFilterDefinition;
 import org.opensearch.client.opensearch._types.analysis.TokenizerBuilders;
 import org.opensearch.client.opensearch._types.analysis.TokenizerDefinition;
+import org.opensearch.client.opensearch.core.TermvectorsResponse;
 import org.opensearch.client.opensearch.experiments.api.FooRequest;
 import org.opensearch.client.opensearch.indices.IndexSettings;
 import org.opensearch.client.opensearch.indices.IndexSettingsMapping;
@@ -173,4 +173,27 @@ public class ParsingTests extends ModelTestCase {
         assertEquals(analyzer.cjk().stopwords(), analyzer2.cjk().stopwords());
         assertEquals(analyzer.cjk().stopwordsPath(), analyzer2.cjk().stopwordsPath());
     }
+    @Test
+    public void testTermvectorsResponseOptionals() {
+        // Build a response without any optionals
+        final TermvectorsResponse response = TermvectorsResponse.of(b -> b
+            .index("index")
+            .id("id")
+            .found(true)
+            .took(0)
+            .termVectors("key1", tvb -> tvb
+                .terms("term1", tb -> tb
+                    .score(0.3)
+                )
+            )
+        );
+
+        String str = toJson(response);
+        assertEquals("{\"found\":true,\"_id\":\"id\",\"_index\":\"index\",\"term_vectors\":{\"key1\":{\"terms\":{\"term1\":{\"score\":0.3}}}},\"took\":0}", str);
+
+        final TermvectorsResponse response2 = fromJson(str, TermvectorsResponse._DESERIALIZER);
+        assertEquals(response.index(), response2.index());
+    }
+
+
 }


### PR DESCRIPTION
### Description
This makes optional fields in TermvectorsResponse optional.

### Issues Resolved
Closes [639]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
