### PR TITLE
[Backport 2.x] TermvectorsResponse fix for optionals. (#642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#620](https://github.com/opensearch-project/opensearch-java/pull/620))
 - Fixed CVE-2976 + added CVE checker ([#624](https://github.com/opensearch-project/opensearch-java/pull/624))
 - Fix parsing of GetFieldMappingResponse ([#641](https://github.com/opensearch-project/opensearch-java/pull/641))
+- Fix TermvectorsResponse for optional fields ([#642](https://github.com/opensearch-project/opensearch-java/pull/642))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/termvectors/Term.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/termvectors/Term.java
@@ -32,6 +32,10 @@
 
 package org.opensearch.client.opensearch.core.termvectors;
 
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
@@ -41,10 +45,6 @@ import org.opensearch.client.json.ObjectDeserializer;
 import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.ObjectBuilder;
 import org.opensearch.client.util.ObjectBuilderBase;
-import jakarta.json.stream.JsonGenerator;
-import java.util.List;
-import java.util.function.Function;
-import javax.annotation.Nullable;
 
 // typedef: _global.termvectors.Term
 
@@ -57,7 +57,7 @@ public class Term implements JsonpSerializable {
 	@Nullable
 	private final Double score;
 
-	private final int termFreq;
+	private final Integer termFreq;
 
 	private final List<Token> tokens;
 
@@ -70,8 +70,8 @@ public class Term implements JsonpSerializable {
 
 		this.docFreq = builder.docFreq;
 		this.score = builder.score;
-		this.termFreq = ApiTypeHelper.requireNonNull(builder.termFreq, this, "termFreq");
-		this.tokens = ApiTypeHelper.unmodifiableRequired(builder.tokens, this, "tokens");
+		this.termFreq = builder.termFreq;
+		this.tokens = ApiTypeHelper.unmodifiable(builder.tokens);
 		this.ttf = builder.ttf;
 
 	}
@@ -139,8 +139,10 @@ public class Term implements JsonpSerializable {
 			generator.write(this.score);
 
 		}
-		generator.writeKey("term_freq");
-		generator.write(this.termFreq);
+		if (null != this.termFreq) {
+			generator.writeKey("term_freq");
+			generator.write(this.termFreq);
+		}
 
 		if (ApiTypeHelper.isDefined(this.tokens)) {
 			generator.writeKey("tokens");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/termvectors/TermVector.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/termvectors/TermVector.java
@@ -58,7 +58,7 @@ public class TermVector implements JsonpSerializable {
 
 	private TermVector(Builder builder) {
 
-		this.fieldStatistics = ApiTypeHelper.requireNonNull(builder.fieldStatistics, this, "fieldStatistics");
+		this.fieldStatistics = builder.fieldStatistics;
 		this.terms = ApiTypeHelper.unmodifiableRequired(builder.terms, this, "terms");
 
 	}
@@ -92,8 +92,10 @@ public class TermVector implements JsonpSerializable {
 
 	protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
-		generator.writeKey("field_statistics");
-		this.fieldStatistics.serialize(generator, mapper);
+		if (null != this.fieldStatistics) {
+			generator.writeKey("field_statistics");
+			this.fieldStatistics.serialize(generator, mapper);
+		}
 
 		if (ApiTypeHelper.isDefined(this.terms)) {
 			generator.writeKey("terms");

--- a/java-client/src/test/java/org/opensearch/client/opensearch/experiments/ParsingTests.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/experiments/ParsingTests.java
@@ -40,6 +40,7 @@ import org.opensearch.client.opensearch._types.analysis.Analyzer;
 import org.opensearch.client.opensearch._types.analysis.TokenFilterDefinition;
 import org.opensearch.client.opensearch._types.analysis.TokenizerBuilders;
 import org.opensearch.client.opensearch._types.analysis.TokenizerDefinition;
+import org.opensearch.client.opensearch.core.TermvectorsResponse;
 import org.opensearch.client.opensearch._types.mapping.FieldMapping;
 import org.opensearch.client.opensearch._types.mapping.Property;
 import org.opensearch.client.opensearch._types.mapping.TermVectorOption;
@@ -247,6 +248,30 @@ public class ParsingTests extends ModelTestCase {
         assertEquals(field1Analyzer, textProperty.analyzer());
 
         assertNotNull(mappings.get(field3Name));
+    }
+ 
+    @Test
+    public void testTermvectorsResponseOptionals() {
+        // Build a response without any optionals
+        final TermvectorsResponse response = TermvectorsResponse.of(b -> b
+            .index("index")
+            .id("id")
+            .version(1)
+            .found(true)
+            .took(0)
+            .termVectors("key1", tvb -> tvb
+                .terms("term1", tb -> tb
+                    .score(0.3)
+                )
+            )
+        );
+
+        String str = toJson(response);
+        assertEquals("{\"found\":true,\"_id\":\"id\",\"_index\":\"index\","
+            +"\"term_vectors\":{\"key1\":{\"terms\":{\"term1\":{\"score\":0.3}}}},\"took\":0,\"_version\":1}", str);
+
+        final TermvectorsResponse response2 = fromJson(str, TermvectorsResponse._DESERIALIZER);
+        assertEquals(response.index(), response2.index());
     }
 
 }


### PR DESCRIPTION
* TermvectorsResponse fix for optionals.



* Add Changelog.



* Tabs vs. spaces fix.



* Version is not optional.



* Changelog fix.



* Period removed.



---------

### Description
Backport #642 to 2.x.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
