### PR TITLE
Make `MultiSearchItem.status` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - [BUG] JarHell caused by latest software.amazon.awssdk 2.20.141 ([#616](https://github.com/opensearch-project/opensearch-java/pull/616))
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#620](https://github.com/opensearch-project/opensearch-java/pull/620))
 - Fixed CVE-2976 + added CVE checker ([#624](https://github.com/opensearch-project/opensearch-java/pull/624))
+- Fix deserialization of MsearchTemplateResponse ([#660](https://github.com/opensearch-project/opensearch-java/pull/660))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/msearch/MultiSearchItem.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/msearch/MultiSearchItem.java
@@ -35,25 +35,26 @@ package org.opensearch.client.opensearch.core.msearch;
 import jakarta.json.stream.JsonGenerator;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.ObjectBuilderDeserializer;
 import org.opensearch.client.json.ObjectDeserializer;
 import org.opensearch.client.opensearch.core.SearchResponse;
-import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.ObjectBuilder;
 
 // typedef: _global.msearch.MultiSearchItem
 
 public class MultiSearchItem<TDocument> extends SearchResponse<TDocument> {
-    private final int status;
+    @Nullable
+    private final Integer status;
 
     // ---------------------------------------------------------------------------------------------
 
     private MultiSearchItem(Builder<TDocument> builder) {
         super(builder);
 
-        this.status = ApiTypeHelper.requireNonNull(builder.status, this, "status");
+        this.status = builder.status;
 
     }
 
@@ -62,17 +63,21 @@ public class MultiSearchItem<TDocument> extends SearchResponse<TDocument> {
     }
 
     /**
-     * Required - API name: {@code status}
+     * API name: {@code status}
      */
-    public final int status() {
+    @Nullable
+    public final Integer status() {
         return this.status;
     }
 
     protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
         super.serializeInternal(generator, mapper);
-        generator.writeKey("status");
-        generator.write(this.status);
+
+        if (this.status != null) {
+            generator.writeKey("status");
+            generator.write(this.status);
+        }
 
     }
 
@@ -85,12 +90,13 @@ public class MultiSearchItem<TDocument> extends SearchResponse<TDocument> {
     public static class Builder<TDocument> extends SearchResponse.AbstractBuilder<TDocument, Builder<TDocument>>
         implements
             ObjectBuilder<MultiSearchItem<TDocument>> {
+        @Nullable
         private Integer status;
 
         /**
-         * Required - API name: {@code status}
+         * API name: {@code status}
          */
-        public final Builder<TDocument> status(int value) {
+        public final Builder<TDocument> status(@Nullable Integer value) {
             this.status = value;
             return this;
         }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractSearchTemplateRequestIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractSearchTemplateRequestIT.java
@@ -85,6 +85,30 @@ public abstract class AbstractSearchTemplateRequestIT extends OpenSearchJavaClie
 
     }
 
+    @Test
+    public void testMultiSearchTemplate() throws Exception {
+        var index = "test-msearch-template";
+        createDocuments(index);
+
+        var searchResponse = javaClient().msearchTemplate(
+            request -> request.searchTemplates(
+                r -> r.header(h -> h.index(index))
+                    .body(
+                        t -> t.id(TEST_SEARCH_TEMPLATE)
+                            .params("title", JsonData.of("Document"))
+                            .params("suggs", JsonData.of(false))
+                            .params("aggs", JsonData.of(false))
+                    )
+            ),
+            SimpleDoc.class
+        );
+
+        assertEquals(1, searchResponse.responses().size());
+        var response = searchResponse.responses().get(0);
+        assertTrue(response.isResult());
+        assertEquals(4, response.result().hits().hits().size());
+    }
+
     private SearchTemplateResponse<SimpleDoc> sendTemplateRequest(String index, String title, boolean suggs, boolean aggs)
         throws IOException {
         return javaClient().searchTemplate(

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractSearchTemplateRequestIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractSearchTemplateRequestIT.java
@@ -106,6 +106,7 @@ public abstract class AbstractSearchTemplateRequestIT extends OpenSearchJavaClie
         assertEquals(1, searchResponse.responses().size());
         var response = searchResponse.responses().get(0);
         assertTrue(response.isResult());
+        assertNull(response.result().status());
         assertEquals(4, response.result().hits().hits().size());
     }
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/json/jackson/JacksonJsonpParserTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/json/jackson/JacksonJsonpParserTest.java
@@ -186,7 +186,7 @@ public class JacksonJsonpParserTest extends ModelTestCase {
 
         assertEquals(2, response.responses().size());
         assertEquals(404, response.responses().get(0).failure().status());
-        assertEquals(200, response.responses().get(1).result().status());
+        assertEquals((Integer)200, response.responses().get(1).result().status());
     }
 
     public static class AttributedJacksonJsonpMapper extends JacksonJsonpMapper {

--- a/java-client/src/test/java/org/opensearch/client/opensearch/json/jackson/JacksonJsonpParserTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/json/jackson/JacksonJsonpParserTest.java
@@ -186,7 +186,7 @@ public class JacksonJsonpParserTest extends ModelTestCase {
 
         assertEquals(2, response.responses().size());
         assertEquals(404, response.responses().get(0).failure().status());
-        assertEquals((Integer)200, response.responses().get(1).result().status());
+        assertEquals((Integer) 200, response.responses().get(1).result().status());
     }
 
     public static class AttributedJacksonJsonpMapper extends JacksonJsonpMapper {


### PR DESCRIPTION
### Description
Make `MultiSearchItem.status` optional as it is returned by regular msearch requests but not in msearchTemplate requests.

### Issues Resolved
Fixes #520 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
