### PR TITLE
Add indexing and search index settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ## [Unreleased 2.x]
 
 ### Added
+- Added support for indexing and search index settings ([#667](https://github.com/opensearch-project/opensearch-java/pull/667))
 
 ### Dependencies
 

--- a/guides/index_templates.md
+++ b/guides/index_templates.md
@@ -1,0 +1,79 @@
+- [Index templates](#index-templates)
+    - [Setup](#setup)
+
+
+# Index templates
+
+Index templates let you initialize new indexes with predefined mappings and settings.
+For example, if you continuously index log data, you can define an index template so that all of these indexes have
+the same number of shards and replicas.
+
+## Setup
+
+To get started, first create a client, create an index template. In this example, an index template is created,
+composed of two component templates:
+
+- `index-settings` which specifies index settings such as shard configuration and slowlog settings
+- `index-mappings` which specifies the field mappings
+
+```java
+import org.apache.hc.core5.http.HttpHost;
+
+final HttpHost[] hosts = new HttpHost[] {
+    new HttpHost("http", "localhost", 9200)
+  };
+
+final OpenSearchTransport transport = ApacheHttpClient5TransportBuilder
+    .builder(hosts)
+    .setMapper(new JacksonJsonpMapper())
+    .build();
+OpenSearchClient client = new OpenSearchClient(transport);
+
+final var indexSettingsComponentTemplate = "index-settings";
+PutComponentTemplateRequest putComponentTemplateRequest = PutComponentTemplateRequest.of(
+    c -> c.name(indexSettingsComponentTemplate)
+        .settings(
+            s -> s.numberOfShards("2")
+                .numberOfReplicas("1")
+                .indexing(
+                    i -> i.slowlog(
+                        sl -> sl.level("info")
+                            .reformat(true)
+                            .threshold(th -> th.index(ith -> ith.warn(Time.of(t -> t.time("2s")))))
+                    )
+                )
+                .search(
+                    se -> se.slowlog(sl -> sl.level("info").threshold(th -> th.query(q -> q.warn(Time.of(t -> t.time("2s"))))))
+                )
+        )
+);
+client.cluster().putComponentTemplate(putComponentTemplateRequest);
+
+final var indexMappingsComponentTemplate = "index-mappings";
+putComponentTemplateRequest = PutComponentTemplateRequest.of(
+    c -> c.name(indexMappingsComponentTemplate).mappings(m -> m.properties("age", p -> p.integer(i -> i)))
+);
+client.cluster().putComponentTemplate(putComponentTemplateRequest);
+
+final var indexTemplateName = "my-index-template";
+PutIndexTemplateRequest putIndexTemplateRequest = PutIndexTemplateRequest.of(
+    it -> it.name(indexTemplateName)
+        .indexPatterns("my-index-*")
+        .composedOf(List.of(indexSettingsComponentTemplate, indexMappingsComponentTemplate))
+);
+
+client.indices().putIndexTemplate(putIndexTemplateRequest);
+```
+
+## Usage
+
+Create an index with a name that matches the index template's `indexPatterns`
+
+```java
+String indexName = "my-index-1";
+client.indices().create(CreateIndexRequest.of(c -> c.index(indexName)));
+```
+
+The index will be created with the index settings and mappings defined by the `my-index-template` index template.
+
+You can find a working sample of the above code in [IndexTemplates.java](../samples/src/main/java/org/opensearch/client/samples/IndexTemplates.java).

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexSettings.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexSettings.java
@@ -216,6 +216,12 @@ public class IndexSettings implements JsonpSerializable {
     private final IndexSettingsMapping mapping;
 
     @Nullable
+    private final IndexSettingsIndexing indexing;
+
+    @Nullable
+    private final IndexSettingsSearch search;
+
+    @Nullable
     private final Boolean knn;
 
     @Nullable
@@ -280,6 +286,8 @@ public class IndexSettings implements JsonpSerializable {
         this.analysis = builder.analysis;
         this.settings = builder.settings;
         this.mapping = builder.mapping;
+        this.indexing = builder.indexing;
+        this.search = builder.search;
         this.knn = builder.knn;
         this.knnAlgoParamEfSearch = builder.knnAlgoParamEfSearch;
 
@@ -749,6 +757,22 @@ public class IndexSettings implements JsonpSerializable {
     }
 
     /**
+     * API name: {@code indexing}
+     */
+    @Nullable
+    public final IndexSettingsIndexing indexing() {
+        return this.indexing;
+    }
+
+    /**
+     * API name: {@code search}
+     */
+    @Nullable
+    public final IndexSettingsSearch search() {
+        return this.search;
+    }
+
+    /**
      * API name: {@code knn}
      */
     @Nullable
@@ -1055,6 +1079,16 @@ public class IndexSettings implements JsonpSerializable {
             this.mapping.serialize(generator, mapper);
 
         }
+        if (this.indexing != null) {
+            generator.writeKey("indexing");
+            this.indexing.serialize(generator, mapper);
+
+        }
+        if (this.search != null) {
+            generator.writeKey("search");
+            this.search.serialize(generator, mapper);
+
+        }
         if (this.knn != null) {
             generator.writeKey("knn");
             generator.write(this.knn);
@@ -1239,6 +1273,12 @@ public class IndexSettings implements JsonpSerializable {
 
         @Nullable
         private IndexSettingsMapping mapping;
+
+        @Nullable
+        private IndexSettingsIndexing indexing;
+
+        @Nullable
+        private IndexSettingsSearch search;
 
         @Nullable
         private Boolean knn;
@@ -1822,6 +1862,36 @@ public class IndexSettings implements JsonpSerializable {
         }
 
         /**
+         * API name: {@code indexing}
+         */
+        public final Builder indexing(@Nullable IndexSettingsIndexing value) {
+            this.indexing = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code indexing}
+         */
+        public final Builder indexing(Function<IndexSettingsIndexing.Builder, ObjectBuilder<IndexSettingsIndexing>> fn) {
+            return this.indexing(fn.apply(new IndexSettingsIndexing.Builder()).build());
+        }
+
+        /**
+         * API name: {@code search}
+         */
+        public final Builder search(@Nullable IndexSettingsSearch value) {
+            this.search = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code search}
+         */
+        public final Builder search(Function<IndexSettingsSearch.Builder, ObjectBuilder<IndexSettingsSearch>> fn) {
+            return this.search(fn.apply(new IndexSettingsSearch.Builder()).build());
+        }
+
+        /**
          * Builds a {@link IndexSettings}.
          *
          * @throws NullPointerException
@@ -1995,6 +2065,8 @@ public class IndexSettings implements JsonpSerializable {
         op.add(Builder::analysis, IndexSettingsAnalysis._DESERIALIZER, "analysis", "index.analysis");
         op.add(Builder::settings, IndexSettings._DESERIALIZER, "settings");
         op.add(Builder::mapping, IndexSettingsMapping._DESERIALIZER, "mapping");
+        op.add(Builder::indexing, IndexSettingsIndexing._DESERIALIZER, "indexing");
+        op.add(Builder::search, IndexSettingsSearch._DESERIALIZER, "search");
         op.add(Builder::knn, JsonpDeserializer.booleanDeserializer(), "knn", "index.knn");
         op.add(
             Builder::knnAlgoParamEfSearch,

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexSettingsIndexing.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexSettingsIndexing.java
@@ -1,0 +1,140 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch.indices;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.*;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+@JsonpDeserializable
+public class IndexSettingsIndexing implements JsonpSerializable {
+    @Nullable
+    private final IndexingSlowlog slowlog;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private IndexSettingsIndexing(Builder builder) {
+
+        this.slowlog = builder.slowlog;
+
+    }
+
+    public static IndexSettingsIndexing of(Function<Builder, ObjectBuilder<IndexSettingsIndexing>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * API name: {@code slowlog}
+     */
+    @Nullable
+    public final IndexingSlowlog slowlog() {
+        return this.slowlog;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        if (this.slowlog != null) {
+            generator.writeKey("slowlog");
+            this.slowlog.serialize(generator, mapper);
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link IndexSettingsIndexing}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<IndexSettingsIndexing> {
+        @Nullable
+        private IndexingSlowlog slowlog;
+
+        /**
+         * API name: {@code slowlog}
+         */
+        public final Builder slowlog(@Nullable IndexingSlowlog value) {
+            this.slowlog = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code slowlog}
+         */
+        public final Builder slowlog(Function<IndexingSlowlog.Builder, ObjectBuilder<IndexingSlowlog>> fn) {
+            return this.slowlog(fn.apply(new IndexingSlowlog.Builder()).build());
+        }
+
+        /**
+         * Builds a {@link IndexSettingsIndexing}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public IndexSettingsIndexing build() {
+            _checkSingleUse();
+
+            return new IndexSettingsIndexing(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link IndexSettingsIndexing}
+     */
+    public static final JsonpDeserializer<IndexSettingsIndexing> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        IndexSettingsIndexing::setupSettingsSearchDeserializer
+    );
+
+    protected static void setupSettingsSearchDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::slowlog, IndexingSlowlog._DESERIALIZER, "slowlog");
+
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexSettingsSearch.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexSettingsSearch.java
@@ -1,0 +1,176 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch.indices;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.*;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+@JsonpDeserializable
+public class IndexSettingsSearch implements JsonpSerializable {
+    @Nullable
+    private final SearchIdle idle;
+
+    @Nullable
+    private final SearchSlowlog slowlog;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private IndexSettingsSearch(Builder builder) {
+
+        this.idle = builder.idle;
+        this.slowlog = builder.slowlog;
+
+    }
+
+    public static IndexSettingsSearch of(Function<Builder, ObjectBuilder<IndexSettingsSearch>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * API name: {@code idle}
+     */
+    @Nullable
+    public final SearchIdle idle() {
+        return this.idle;
+    }
+
+    /**
+     * API name: {@code slowlog}
+     */
+    @Nullable
+    public final SearchSlowlog slowlog() {
+        return this.slowlog;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        if (this.idle != null) {
+            generator.writeKey("idle");
+            this.idle.serialize(generator, mapper);
+
+        }
+        if (this.slowlog != null) {
+            generator.writeKey("slowlog");
+            this.slowlog.serialize(generator, mapper);
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link IndexSettingsSearch}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<IndexSettingsSearch> {
+        @Nullable
+        private SearchIdle idle;
+
+        @Nullable
+        private SearchSlowlog slowlog;
+
+        /**
+         * API name: {@code idle}
+         */
+        public final Builder idle(@Nullable SearchIdle value) {
+            this.idle = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code idle}
+         */
+        public final Builder idle(Function<SearchIdle.Builder, ObjectBuilder<SearchIdle>> fn) {
+            return this.idle(fn.apply(new SearchIdle.Builder()).build());
+        }
+
+        /**
+         * API name: {@code slowlog}
+         */
+        public final Builder slowlog(@Nullable SearchSlowlog value) {
+            this.slowlog = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code slowlog}
+         */
+        public final Builder slowlog(Function<SearchSlowlog.Builder, ObjectBuilder<SearchSlowlog>> fn) {
+            return this.slowlog(fn.apply(new SearchSlowlog.Builder()).build());
+        }
+
+        /**
+         * Builds a {@link IndexSettingsSearch}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public IndexSettingsSearch build() {
+            _checkSingleUse();
+
+            return new IndexSettingsSearch(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link IndexSettingsSearch}
+     */
+    public static final JsonpDeserializer<IndexSettingsSearch> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        IndexSettingsSearch::setupSettingsSearchDeserializer
+    );
+
+    protected static void setupSettingsSearchDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::idle, SearchIdle._DESERIALIZER, "idle");
+        op.add(Builder::slowlog, SearchSlowlog._DESERIALIZER, "slowlog");
+
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexingSlowlog.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexingSlowlog.java
@@ -1,0 +1,232 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch.indices;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+@JsonpDeserializable
+public class IndexingSlowlog implements JsonpSerializable {
+    @Nullable
+    private final String level;
+
+    @Nullable
+    private final Integer source;
+
+    @Nullable
+    private final Boolean reformat;
+
+    @Nullable
+    private final IndexingSlowlogThresholds threshold;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private IndexingSlowlog(Builder builder) {
+
+        this.level = builder.level;
+        this.source = builder.source;
+        this.reformat = builder.reformat;
+        this.threshold = builder.threshold;
+
+    }
+
+    public static IndexingSlowlog of(Function<Builder, ObjectBuilder<IndexingSlowlog>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * API name: {@code level}
+     */
+    @Nullable
+    public final String level() {
+        return this.level;
+    }
+
+    /**
+     * API name: {@code source}
+     */
+    @Nullable
+    public final Integer source() {
+        return this.source;
+    }
+
+    /**
+     * API name: {@code reformat}
+     */
+    @Nullable
+    public final Boolean reformat() {
+        return this.reformat;
+    }
+
+    /**
+     * API name: {@code threshold}
+     */
+    @Nullable
+    public final IndexingSlowlogThresholds threshold() {
+        return this.threshold;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        if (this.level != null) {
+            generator.writeKey("level");
+            generator.write(this.level);
+
+        }
+        if (this.source != null) {
+            generator.writeKey("source");
+            generator.write(this.source);
+
+        }
+        if (this.reformat != null) {
+            generator.writeKey("reformat");
+            generator.write(this.reformat);
+
+        }
+        if (this.threshold != null) {
+            generator.writeKey("threshold");
+            this.threshold.serialize(generator, mapper);
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link IndexingSlowlog}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<IndexingSlowlog> {
+        @Nullable
+        private String level;
+
+        @Nullable
+        private Integer source;
+
+        @Nullable
+        private Boolean reformat;
+
+        @Nullable
+        private IndexingSlowlogThresholds threshold;
+
+        /**
+         * API name: {@code level}
+         */
+        public final Builder level(@Nullable String value) {
+            this.level = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code source}
+         */
+        public final Builder source(@Nullable Integer value) {
+            this.source = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code reformat}
+         */
+        public final Builder reformat(@Nullable Boolean value) {
+            this.reformat = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code threshold}
+         */
+        public final Builder threshold(@Nullable IndexingSlowlogThresholds value) {
+            this.threshold = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code threshold}
+         */
+        public final Builder threshold(Function<IndexingSlowlogThresholds.Builder, ObjectBuilder<IndexingSlowlogThresholds>> fn) {
+            return this.threshold(fn.apply(new IndexingSlowlogThresholds.Builder()).build());
+        }
+
+        /**
+         * Builds a {@link IndexingSlowlog}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public IndexingSlowlog build() {
+            _checkSingleUse();
+
+            return new IndexingSlowlog(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link IndexingSlowlog}
+     */
+    public static final JsonpDeserializer<IndexingSlowlog> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        IndexingSlowlog::setupIndexingSlowlogSettingsDeserializer
+    );
+
+    protected static void setupIndexingSlowlogSettingsDeserializer(ObjectDeserializer<IndexingSlowlog.Builder> op) {
+
+        op.add(Builder::level, JsonpDeserializer.stringDeserializer(), "level");
+        op.add(Builder::source, JsonpDeserializer.integerDeserializer(), "source");
+        op.add(Builder::reformat, JsonpDeserializer.booleanDeserializer(), "reformat");
+        op.add(Builder::threshold, IndexingSlowlogThresholds._DESERIALIZER, "threshold");
+
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexingSlowlogThresholds.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/IndexingSlowlogThresholds.java
@@ -1,0 +1,157 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch.indices;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+@JsonpDeserializable
+public class IndexingSlowlogThresholds implements JsonpSerializable {
+    @Nullable
+    private final SlowlogThresholdLevels index;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private IndexingSlowlogThresholds(Builder builder) {
+
+        this.index = builder.index;
+
+    }
+
+    public static IndexingSlowlogThresholds of(Function<Builder, ObjectBuilder<IndexingSlowlogThresholds>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * The indexing slow log, similar in functionality to the search slow log. The
+     * log file name ends with <code>_index_indexing_slowlog.json</code>. Log and
+     * the thresholds are configured in the same way as the search slowlog.
+     * <p>
+     * API name: {@code index}
+     */
+    @Nullable
+    public final SlowlogThresholdLevels index() {
+        return this.index;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        if (this.index != null) {
+            generator.writeKey("index");
+            this.index.serialize(generator, mapper);
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link IndexingSlowlogThresholds}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<IndexingSlowlogThresholds> {
+        @Nullable
+        private SlowlogThresholdLevels index;
+
+        /**
+         * The indexing slow log, similar in functionality to the search slow log. The
+         * log file name ends with <code>_index_indexing_slowlog.json</code>. Log and
+         * the thresholds are configured in the same way as the search slowlog.
+         * <p>
+         * API name: {@code index}
+         */
+        public final Builder index(@Nullable SlowlogThresholdLevels value) {
+            this.index = value;
+            return this;
+        }
+
+        /**
+         * The indexing slow log, similar in functionality to the search slow log. The
+         * log file name ends with <code>_index_indexing_slowlog.json</code>. Log and
+         * the thresholds are configured in the same way as the search slowlog.
+         * <p>
+         * API name: {@code index}
+         */
+        public final Builder index(Function<SlowlogThresholdLevels.Builder, ObjectBuilder<SlowlogThresholdLevels>> fn) {
+            return this.index(fn.apply(new SlowlogThresholdLevels.Builder()).build());
+        }
+
+        /**
+         * Builds a {@link IndexingSlowlogThresholds}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public IndexingSlowlogThresholds build() {
+            _checkSingleUse();
+
+            return new IndexingSlowlogThresholds(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link IndexingSlowlogThresholds}
+     */
+    public static final JsonpDeserializer<IndexingSlowlogThresholds> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        IndexingSlowlogThresholds::setupIndexingSlowlogTresholdsDeserializer
+    );
+
+    protected static void setupIndexingSlowlogTresholdsDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::index, SlowlogThresholdLevels._DESERIALIZER, "index");
+
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/SearchIdle.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/SearchIdle.java
@@ -1,0 +1,141 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch.indices;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.*;
+import org.opensearch.client.opensearch._types.Time;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+@JsonpDeserializable
+public class SearchIdle implements JsonpSerializable {
+    @Nullable
+    private final Time after;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private SearchIdle(Builder builder) {
+
+        this.after = builder.after;
+
+    }
+
+    public static SearchIdle of(Function<Builder, ObjectBuilder<SearchIdle>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * API name: {@code after}
+     */
+    @Nullable
+    public final Time after() {
+        return this.after;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        if (this.after != null) {
+            generator.writeKey("after");
+            this.after.serialize(generator, mapper);
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link SearchIdle}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SearchIdle> {
+        @Nullable
+        private Time after;
+
+        /**
+         * API name: {@code after}
+         */
+        public final Builder after(@Nullable Time value) {
+            this.after = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code after}
+         */
+        public final Builder after(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+            return this.after(fn.apply(new Time.Builder()).build());
+        }
+
+        /**
+         * Builds a {@link SearchIdle}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public SearchIdle build() {
+            _checkSingleUse();
+
+            return new SearchIdle(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link SearchIdle}
+     */
+    public static final JsonpDeserializer<SearchIdle> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        SearchIdle::setupSearchIdleDeserializer
+    );
+
+    protected static void setupSearchIdleDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::after, Time._DESERIALIZER, "after");
+
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/SearchSlowlog.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/SearchSlowlog.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch.indices;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.*;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+@JsonpDeserializable
+public class SearchSlowlog implements JsonpSerializable {
+    @Nullable
+    private final String level;
+
+    @Nullable
+    private final SearchSlowlogThresholds threshold;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private SearchSlowlog(Builder builder) {
+
+        this.level = builder.level;
+        this.threshold = builder.threshold;
+
+    }
+
+    public static SearchSlowlog of(Function<Builder, ObjectBuilder<SearchSlowlog>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * API name: {@code level}
+     */
+    @Nullable
+    public final String level() {
+        return this.level;
+    }
+
+    /**
+     * API name: {@code threshold}
+     */
+    @Nullable
+    public final SearchSlowlogThresholds threshold() {
+        return this.threshold;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        if (this.level != null) {
+            generator.writeKey("level");
+            generator.write(this.level);
+
+        }
+
+        if (this.threshold != null) {
+            generator.writeKey("threshold");
+            this.threshold.serialize(generator, mapper);
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link SearchSlowlog}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SearchSlowlog> {
+        @Nullable
+        private String level;
+
+        @Nullable
+        private SearchSlowlogThresholds threshold;
+
+        /**
+         * API name: {@code level}
+         */
+        public final Builder level(@Nullable String value) {
+            this.level = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code threshold}
+         */
+        public final Builder threshold(@Nullable SearchSlowlogThresholds value) {
+            this.threshold = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code threshold}
+         */
+        public final Builder threshold(Function<SearchSlowlogThresholds.Builder, ObjectBuilder<SearchSlowlogThresholds>> fn) {
+            return this.threshold(fn.apply(new SearchSlowlogThresholds.Builder()).build());
+        }
+
+        /**
+         * Builds a {@link SearchSlowlog}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public SearchSlowlog build() {
+            _checkSingleUse();
+
+            return new SearchSlowlog(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link SearchSlowlog}
+     */
+    public static final JsonpDeserializer<SearchSlowlog> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        SearchSlowlog::setupIndexingSlowlogSettingsDeserializer
+    );
+
+    protected static void setupIndexingSlowlogSettingsDeserializer(ObjectDeserializer<SearchSlowlog.Builder> op) {
+
+        op.add(Builder::level, JsonpDeserializer.stringDeserializer(), "level");
+        op.add(Builder::threshold, SearchSlowlogThresholds._DESERIALIZER, "threshold");
+
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/SearchSlowlogThresholds.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/SearchSlowlogThresholds.java
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch.indices;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+@JsonpDeserializable
+public class SearchSlowlogThresholds implements JsonpSerializable {
+    @Nullable
+    private final SlowlogThresholdLevels query;
+
+    @Nullable
+    private final SlowlogThresholdLevels fetch;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private SearchSlowlogThresholds(Builder builder) {
+
+        this.query = builder.query;
+        this.fetch = builder.fetch;
+
+    }
+
+    public static SearchSlowlogThresholds of(Function<Builder, ObjectBuilder<SearchSlowlogThresholds>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * API name: {@code query}
+     */
+    @Nullable
+    public final SlowlogThresholdLevels query() {
+        return this.query;
+    }
+
+    /**
+     * API name: {@code fetch}
+     */
+    @Nullable
+    public final SlowlogThresholdLevels fetch() {
+        return this.fetch;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        if (this.query != null) {
+            generator.writeKey("query");
+            this.query.serialize(generator, mapper);
+
+        }
+        if (this.fetch != null) {
+            generator.writeKey("fetch");
+            this.fetch.serialize(generator, mapper);
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link SearchSlowlogThresholds}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SearchSlowlogThresholds> {
+        @Nullable
+        private SlowlogThresholdLevels query;
+
+        @Nullable
+        private SlowlogThresholdLevels fetch;
+
+        /**
+         * API name: {@code query}
+         */
+        public final Builder query(@Nullable SlowlogThresholdLevels value) {
+            this.query = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code query}
+         */
+        public final Builder query(Function<SlowlogThresholdLevels.Builder, ObjectBuilder<SlowlogThresholdLevels>> fn) {
+            return this.query(fn.apply(new SlowlogThresholdLevels.Builder()).build());
+        }
+
+        /**
+         * API name: {@code fetch}
+         */
+        public final Builder fetch(@Nullable SlowlogThresholdLevels value) {
+            this.fetch = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code fetch}
+         */
+        public final Builder fetch(Function<SlowlogThresholdLevels.Builder, ObjectBuilder<SlowlogThresholdLevels>> fn) {
+            return this.fetch(fn.apply(new SlowlogThresholdLevels.Builder()).build());
+        }
+
+        /**
+         * Builds a {@link SearchSlowlogThresholds}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public SearchSlowlogThresholds build() {
+            _checkSingleUse();
+
+            return new SearchSlowlogThresholds(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link SearchSlowlogThresholds}
+     */
+    public static final JsonpDeserializer<SearchSlowlogThresholds> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        SearchSlowlogThresholds::setupIndexingSlowlogTresholdsDeserializer
+    );
+
+    protected static void setupIndexingSlowlogTresholdsDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::query, SlowlogThresholdLevels._DESERIALIZER, "query");
+        op.add(Builder::fetch, SlowlogThresholdLevels._DESERIALIZER, "fetch");
+
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/SlowlogThresholdLevels.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/SlowlogThresholdLevels.java
@@ -1,0 +1,255 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch.indices;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.opensearch._types.Time;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: indices._types.SlowlogTresholdLevels
+
+@JsonpDeserializable
+public class SlowlogThresholdLevels implements JsonpSerializable {
+    @Nullable
+    private final Time warn;
+
+    @Nullable
+    private final Time info;
+
+    @Nullable
+    private final Time debug;
+
+    @Nullable
+    private final Time trace;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private SlowlogThresholdLevels(Builder builder) {
+
+        this.warn = builder.warn;
+        this.info = builder.info;
+        this.debug = builder.debug;
+        this.trace = builder.trace;
+
+    }
+
+    public static SlowlogThresholdLevels of(Function<Builder, ObjectBuilder<SlowlogThresholdLevels>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * API name: {@code warn}
+     */
+    @Nullable
+    public final Time warn() {
+        return this.warn;
+    }
+
+    /**
+     * API name: {@code info}
+     */
+    @Nullable
+    public final Time info() {
+        return this.info;
+    }
+
+    /**
+     * API name: {@code debug}
+     */
+    @Nullable
+    public final Time debug() {
+        return this.debug;
+    }
+
+    /**
+     * API name: {@code trace}
+     */
+    @Nullable
+    public final Time trace() {
+        return this.trace;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        if (this.warn != null) {
+            generator.writeKey("warn");
+            this.warn.serialize(generator, mapper);
+
+        }
+        if (this.info != null) {
+            generator.writeKey("info");
+            this.info.serialize(generator, mapper);
+
+        }
+        if (this.debug != null) {
+            generator.writeKey("debug");
+            this.debug.serialize(generator, mapper);
+
+        }
+        if (this.trace != null) {
+            generator.writeKey("trace");
+            this.trace.serialize(generator, mapper);
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link SlowlogThresholdLevels}.
+     */
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SlowlogThresholdLevels> {
+        @Nullable
+        private Time warn;
+
+        @Nullable
+        private Time info;
+
+        @Nullable
+        private Time debug;
+
+        @Nullable
+        private Time trace;
+
+        /**
+         * API name: {@code warn}
+         */
+        public final Builder warn(@Nullable Time value) {
+            this.warn = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code warn}
+         */
+        public final Builder warn(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+            return this.warn(fn.apply(new Time.Builder()).build());
+        }
+
+        /**
+         * API name: {@code info}
+         */
+        public final Builder info(@Nullable Time value) {
+            this.info = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code info}
+         */
+        public final Builder info(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+            return this.info(fn.apply(new Time.Builder()).build());
+        }
+
+        /**
+         * API name: {@code debug}
+         */
+        public final Builder debug(@Nullable Time value) {
+            this.debug = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code debug}
+         */
+        public final Builder debug(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+            return this.debug(fn.apply(new Time.Builder()).build());
+        }
+
+        /**
+         * API name: {@code trace}
+         */
+        public final Builder trace(@Nullable Time value) {
+            this.trace = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code trace}
+         */
+        public final Builder trace(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+            return this.trace(fn.apply(new Time.Builder()).build());
+        }
+
+        /**
+         * Builds a {@link SlowlogThresholdLevels}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public SlowlogThresholdLevels build() {
+            _checkSingleUse();
+
+            return new SlowlogThresholdLevels(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link SlowlogThresholdLevels}
+     */
+    public static final JsonpDeserializer<SlowlogThresholdLevels> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        SlowlogThresholdLevels::setupSlowlogTresholdLevelsDeserializer
+    );
+
+    protected static void setupSlowlogTresholdLevelsDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::warn, Time._DESERIALIZER, "warn");
+        op.add(Builder::info, Time._DESERIALIZER, "info");
+        op.add(Builder::debug, Time._DESERIALIZER, "debug");
+        op.add(Builder::trace, Time._DESERIALIZER, "trace");
+
+    }
+
+}

--- a/samples/src/main/java/org/opensearch/client/samples/IndexTemplates.java
+++ b/samples/src/main/java/org/opensearch/client/samples/IndexTemplates.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.samples;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.client.opensearch._types.Time;
+import org.opensearch.client.opensearch.cluster.PutComponentTemplateRequest;
+import org.opensearch.client.opensearch.indices.*;
+
+import java.util.List;
+
+/**
+ * Run with: <c>./gradlew :samples:run -Dsamples.mainClass=IndexTemplates</c>
+ */
+public class IndexTemplates {
+    private static final Logger LOGGER = LogManager.getLogger(IndexTemplates.class);
+
+    public static void main(String[] args) {
+        try {
+            var client = SampleClient.create();
+
+            var version = client.info().version();
+            LOGGER.info("Server: {}@{}", version.distribution(), version.number());
+
+            final var indexTemplateName = "my-index-template";
+
+            if (!client.indices().existsIndexTemplate(t -> t.name(indexTemplateName)).value()) {
+                DeleteIndexTemplateRequest deleteIndexTemplateRequest = DeleteIndexTemplateRequest.of(i -> i.name(indexTemplateName));
+
+                LOGGER.info("Deleting index template {}", indexTemplateName);
+                client.indices().deleteIndexTemplate(deleteIndexTemplateRequest);
+            }
+
+            // Create an index template composed of two component templates, one for index settings, and one for mappings
+            String indexSettingsComponentTemplate = "index-settings";
+            PutComponentTemplateRequest putComponentTemplateRequest = PutComponentTemplateRequest.of(
+                c -> c.name(indexSettingsComponentTemplate)
+                    .settings(
+                        s -> s.numberOfShards("2")
+                            .numberOfReplicas("1")
+                            .indexing(
+                                i -> i.slowlog(
+                                    sl -> sl.level("info")
+                                        .reformat(true)
+                                        .threshold(th -> th.index(ith -> ith.warn(Time.of(t -> t.time("2s")))))
+                                )
+                            )
+                            .search(
+                                se -> se.slowlog(sl -> sl.level("info").threshold(th -> th.query(q -> q.warn(Time.of(t -> t.time("2s"))))))
+                            )
+                    )
+            );
+            LOGGER.info("Creating component template {}", indexSettingsComponentTemplate);
+            client.cluster().putComponentTemplate(putComponentTemplateRequest);
+
+            String indexMappingsComponentTemplate = "index-mappings";
+            putComponentTemplateRequest = PutComponentTemplateRequest.of(
+                c -> c.name(indexMappingsComponentTemplate).mappings(m -> m.properties("age", p -> p.integer(i -> i)))
+            );
+            LOGGER.info("Creating component template {}", indexMappingsComponentTemplate);
+            client.cluster().putComponentTemplate(putComponentTemplateRequest);
+
+            PutIndexTemplateRequest putIndexTemplateRequest = PutIndexTemplateRequest.of(
+                it -> it.name(indexTemplateName)
+                    .indexPatterns("my-index-*")
+                    .composedOf(List.of(indexSettingsComponentTemplate, indexMappingsComponentTemplate))
+            );
+
+            LOGGER.info("Creating index template {}", indexTemplateName);
+            client.indices().putIndexTemplate(putIndexTemplateRequest);
+
+            String indexName = "my-index-1";
+            if (client.indices().exists(r -> r.index(indexName)).value()) {
+                LOGGER.info("Deleting index {}", indexName);
+                client.indices().delete(DeleteIndexRequest.of(d -> d.index(indexName)));
+            }
+
+            LOGGER.info("Creating index {}", indexName);
+            client.indices().create(CreateIndexRequest.of(c -> c.index(indexName)));
+
+            GetMappingResponse getMappingResponse = client.indices().getMapping(GetMappingRequest.of(m -> m.index(indexName)));
+            // mappings for the index should contain those defined in component template
+            LOGGER.info("Mappings {} found for index {}", getMappingResponse.result().get(indexName).mappings(), indexName);
+
+            GetIndicesSettingsResponse getSettingsResponse = client.indices()
+                .getSettings(GetIndicesSettingsRequest.of(m -> m.index(indexName)));
+            // settings for the index should contain those defined in component template
+            LOGGER.info("Settings {} found for index {}", getSettingsResponse.result().get(indexName).settings(), indexName);
+
+            LOGGER.info("Deleting index {}", indexName);
+            client.indices().delete(DeleteIndexRequest.of(d -> d.index(indexName)));
+        } catch (Exception e) {
+            LOGGER.error("Unexpected exception", e);
+        }
+    }
+}

--- a/samples/src/main/java/org/opensearch/client/samples/IndexTemplates.java
+++ b/samples/src/main/java/org/opensearch/client/samples/IndexTemplates.java
@@ -8,13 +8,12 @@
 
 package org.opensearch.client.samples;
 
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch.cluster.PutComponentTemplateRequest;
 import org.opensearch.client.opensearch.indices.*;
-
-import java.util.List;
 
 /**
  * Run with: <c>./gradlew :samples:run -Dsamples.mainClass=IndexTemplates</c>
@@ -25,21 +24,19 @@ public class IndexTemplates {
     public static void main(String[] args) {
         try {
             var client = SampleClient.create();
-
             var version = client.info().version();
             LOGGER.info("Server: {}@{}", version.distribution(), version.number());
 
             final var indexTemplateName = "my-index-template";
 
-            if (!client.indices().existsIndexTemplate(t -> t.name(indexTemplateName)).value()) {
+            if (client.indices().existsIndexTemplate(t -> t.name(indexTemplateName)).value()) {
                 DeleteIndexTemplateRequest deleteIndexTemplateRequest = DeleteIndexTemplateRequest.of(i -> i.name(indexTemplateName));
-
                 LOGGER.info("Deleting index template {}", indexTemplateName);
                 client.indices().deleteIndexTemplate(deleteIndexTemplateRequest);
             }
 
             // Create an index template composed of two component templates, one for index settings, and one for mappings
-            String indexSettingsComponentTemplate = "index-settings";
+            final var indexSettingsComponentTemplate = "index-settings";
             PutComponentTemplateRequest putComponentTemplateRequest = PutComponentTemplateRequest.of(
                 c -> c.name(indexSettingsComponentTemplate)
                     .settings(
@@ -60,7 +57,7 @@ public class IndexTemplates {
             LOGGER.info("Creating component template {}", indexSettingsComponentTemplate);
             client.cluster().putComponentTemplate(putComponentTemplateRequest);
 
-            String indexMappingsComponentTemplate = "index-mappings";
+            final var indexMappingsComponentTemplate = "index-mappings";
             putComponentTemplateRequest = PutComponentTemplateRequest.of(
                 c -> c.name(indexMappingsComponentTemplate).mappings(m -> m.properties("age", p -> p.integer(i -> i)))
             );
@@ -76,7 +73,7 @@ public class IndexTemplates {
             LOGGER.info("Creating index template {}", indexTemplateName);
             client.indices().putIndexTemplate(putIndexTemplateRequest);
 
-            String indexName = "my-index-1";
+            final var indexName = "my-index-1";
             if (client.indices().exists(r -> r.index(indexName)).value()) {
                 LOGGER.info("Deleting index {}", indexName);
                 client.indices().delete(DeleteIndexRequest.of(d -> d.index(indexName)));


### PR DESCRIPTION
### Description

This PR adds indexing and search settings to index settings. These settings allow configuring of slow logs for indexing and search, as well as setting search idle after.

Search idle after duplicates the individual
`IndexSettings::searchIdleAfter` property, but this pattern is already present e.g. `IndexSettings::blocks` and `IndexSettings::blocksReadOnly`, `IndexSettings::blocksRead`, etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
