### PR TITLE
Add scroll to search request serialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Removed
 
 ### Fixed
-- Fix for 'scroll' parameter not serialized to SearchRequest.
+- Fix for 'scroll' parameter not serialized to SearchRequest ([#677](https://github.com/opensearch-project/opensearch-java/pull/677))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Removed
 
 ### Fixed
+- Fix for 'scroll' parameter not serialized to SearchRequest.
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
@@ -963,6 +963,10 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
             generator.writeEnd();
 
         }
+        if (this.scroll != null) {
+            generator.writeKey("scroll");
+            generator.write(this.scroll._toJsonString());
+        }
         if (ApiTypeHelper.isDefined(this.searchAfter)) {
             generator.writeKey("search_after");
             generator.writeStartArray();


### PR DESCRIPTION
### Description
Add the `scroll` parameter when serializing the SearchRequest.

### Issues Resolved
#676 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
