### PR TITLE
Fixing Hit responses when search request has storedFields as none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Removed
 
 ### Fixed
+- Fixed Hit response when search request has storedFields as null ([#698](https://github.com/opensearch-project/opensearch-java/pull/698))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/search/Hit.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/search/Hit.java
@@ -108,7 +108,7 @@ public class Hit<TDocument> implements JsonpSerializable {
     private Hit(Builder<TDocument> builder) {
 
         this.index = ApiTypeHelper.requireNonNull(builder.index, this, "index");
-        this.id = ApiTypeHelper.requireNonNull(builder.id, this, "id");
+        this.id = builder.id;
         this.score = builder.score;
         this.explanation = builder.explanation;
         this.fields = ApiTypeHelper.unmodifiable(builder.fields);
@@ -141,8 +141,9 @@ public class Hit<TDocument> implements JsonpSerializable {
     }
 
     /**
-     * Required - API name: {@code _id}
+     * API name: {@code _id}
      */
+    @Nullable
     public final String id() {
         return this.id;
     }
@@ -283,8 +284,10 @@ public class Hit<TDocument> implements JsonpSerializable {
         generator.writeKey("_index");
         generator.write(this.index);
 
-        generator.writeKey("_id");
-        generator.write(this.id);
+        if (this.id != null) {
+            generator.writeKey("_id");
+            generator.write(this.id);
+        }           
 
         if (this.score != null) {
             generator.writeKey("_score");
@@ -418,6 +421,7 @@ public class Hit<TDocument> implements JsonpSerializable {
     public static class Builder<TDocument> extends ObjectBuilderBase implements ObjectBuilder<Hit<TDocument>> {
         private String index;
 
+        @Nullable
         private String id;
 
         @Nullable
@@ -480,9 +484,9 @@ public class Hit<TDocument> implements JsonpSerializable {
         }
 
         /**
-         * Required - API name: {@code _id}
+         * API name: {@code _id}
          */
-        public final Builder<TDocument> id(String value) {
+        public final Builder<TDocument> id(@Nullable String value) {
             this.id = value;
             return this;
         }

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/search/Hit.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/search/Hit.java
@@ -287,7 +287,7 @@ public class Hit<TDocument> implements JsonpSerializable {
         if (this.id != null) {
             generator.writeKey("_id");
             generator.write(this.id);
-        }           
+        }
 
         if (this.score != null) {
             generator.writeKey("_score");

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractSearchRequestIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractSearchRequestIT.java
@@ -11,7 +11,6 @@ package org.opensearch.client.opensearch.integTest;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.Collectors;
-
 import org.junit.Test;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOrder;
@@ -27,7 +26,8 @@ public abstract class AbstractSearchRequestIT extends OpenSearchJavaClientTestCa
     @Test
     public void shouldReturnSearchResults() throws Exception {
         final String index = "search_request";
-        assertTrue(javaClient().indices()
+        assertTrue(
+            javaClient().indices()
                 .create(
                     b -> b.index(index)
                         .mappings(
@@ -36,7 +36,8 @@ public abstract class AbstractSearchRequestIT extends OpenSearchJavaClientTestCa
                         )
                         .settings(settings -> settings.sort(s -> s.field("name").order(SegmentSortOrder.Asc)))
                 )
-                .acknowledged());
+                .acknowledged()
+        );
 
         createTestDocuments(index);
         javaClient().indices().refresh();
@@ -58,14 +59,23 @@ public abstract class AbstractSearchRequestIT extends OpenSearchJavaClientTestCa
         final SearchResponse<ShopItem> response = javaClient().search(request, ShopItem.class);
         assertEquals(response.hits().hits().size(), 2);
 
-        assertTrue(Arrays.stream(response.hits().hits().get(0).fields().get("name").to(String[].class)).collect(Collectors.toList()).contains("hummer"));
-        assertTrue(Arrays.stream(response.hits().hits().get(1).fields().get("name").to(String[].class)).collect(Collectors.toList()).contains("jammer"));
+        assertTrue(
+            Arrays.stream(response.hits().hits().get(0).fields().get("name").to(String[].class))
+                .collect(Collectors.toList())
+                .contains("hummer")
+        );
+        assertTrue(
+            Arrays.stream(response.hits().hits().get(1).fields().get("name").to(String[].class))
+                .collect(Collectors.toList())
+                .contains("jammer")
+        );
     }
 
     @Test
     public void shouldReturnSearchResultsWithoutStoredFields() throws Exception {
         final String index = "search_request";
-        assertTrue(javaClient().indices()
+        assertTrue(
+            javaClient().indices()
                 .create(
                     b -> b.index(index)
                         .mappings(
@@ -74,7 +84,8 @@ public abstract class AbstractSearchRequestIT extends OpenSearchJavaClientTestCa
                         )
                         .settings(settings -> settings.sort(s -> s.field("name").order(SegmentSortOrder.Asc)))
                 )
-                .acknowledged());
+                .acknowledged()
+        );
 
         createTestDocuments(index);
         javaClient().indices().refresh();
@@ -86,10 +97,7 @@ public abstract class AbstractSearchRequestIT extends OpenSearchJavaClientTestCa
         );
 
         final SearchRequest request = SearchRequest.of(
-            r -> r.index(index)
-                .sort(s -> s.field(f -> f.field("name").order(SortOrder.Asc)))
-                .query(query)
-                .storedFields("_none_")
+            r -> r.index(index).sort(s -> s.field(f -> f.field("name").order(SortOrder.Asc))).query(query).storedFields("_none_")
         );
 
         final SearchResponse<ShopItem> response = javaClient().search(request, ShopItem.class);

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractSearchRequestIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractSearchRequestIT.java
@@ -8,12 +8,10 @@
 
 package org.opensearch.client.opensearch.integTest;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.arrayContaining;
-import static org.hamcrest.Matchers.hasSize;
-
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import org.junit.Test;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOrder;
@@ -27,10 +25,9 @@ import org.opensearch.client.opensearch.indices.SegmentSortOrder;
 public abstract class AbstractSearchRequestIT extends OpenSearchJavaClientTestCase {
 
     @Test
-    public void shouldReturnSearcheResults() throws Exception {
-        final String index = "searches_request";
-        assertThat(
-            javaClient().indices()
+    public void shouldReturnSearchResults() throws Exception {
+        final String index = "search_request";
+        assertTrue(javaClient().indices()
                 .create(
                     b -> b.index(index)
                         .mappings(
@@ -39,9 +36,7 @@ public abstract class AbstractSearchRequestIT extends OpenSearchJavaClientTestCa
                         )
                         .settings(settings -> settings.sort(s -> s.field("name").order(SegmentSortOrder.Asc)))
                 )
-                .acknowledged(),
-            equalTo(true)
-        );
+                .acknowledged());
 
         createTestDocuments(index);
         javaClient().indices().refresh();
@@ -61,10 +56,46 @@ public abstract class AbstractSearchRequestIT extends OpenSearchJavaClientTestCa
         );
 
         final SearchResponse<ShopItem> response = javaClient().search(request, ShopItem.class);
-        assertThat(response.hits().hits(), hasSize(2));
+        assertEquals(response.hits().hits().size(), 2);
 
-        assertThat(response.hits().hits().get(0).fields().get("name").to(String[].class), arrayContaining("hummer"));
-        assertThat(response.hits().hits().get(1).fields().get("name").to(String[].class), arrayContaining("jammer"));
+        assertTrue(Arrays.stream(response.hits().hits().get(0).fields().get("name").to(String[].class)).collect(Collectors.toList()).contains("hummer"));
+        assertTrue(Arrays.stream(response.hits().hits().get(1).fields().get("name").to(String[].class)).collect(Collectors.toList()).contains("jammer"));
+    }
+
+    @Test
+    public void shouldReturnSearchResultsWithoutStoredFields() throws Exception {
+        final String index = "search_request";
+        assertTrue(javaClient().indices()
+                .create(
+                    b -> b.index(index)
+                        .mappings(
+                            m -> m.properties("name", Property.of(p -> p.keyword(v -> v.docValues(true))))
+                                .properties("size", Property.of(p -> p.keyword(v -> v.docValues(true))))
+                        )
+                        .settings(settings -> settings.sort(s -> s.field("name").order(SegmentSortOrder.Asc)))
+                )
+                .acknowledged());
+
+        createTestDocuments(index);
+        javaClient().indices().refresh();
+
+        final Query query = Query.of(
+            q -> q.bool(
+                builder -> builder.filter(filter -> filter.term(TermQuery.of(term -> term.field("size").value(FieldValue.of("huge")))))
+            )
+        );
+
+        final SearchRequest request = SearchRequest.of(
+            r -> r.index(index)
+                .sort(s -> s.field(f -> f.field("name").order(SortOrder.Asc)))
+                .query(query)
+                .storedFields("_none_")
+        );
+
+        final SearchResponse<ShopItem> response = javaClient().search(request, ShopItem.class);
+        assertEquals(response.hits().hits().size(), 2);
+        assertNull(response.hits().hits().get(0).id());
+        assertNull(response.hits().hits().get(1).id());
     }
 
     private void createTestDocuments(String index) throws IOException {


### PR DESCRIPTION
### Description
Same as title

### Issues Resolved
Resolves #696 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
