### PR TITLE
fix(parent/agg): deserialize parent aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
+- Deserialize aggregation containing a parent aggregation ([#706](https://github.com/opensearch-project/opensearch-java/pull/706))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/aggregations/Aggregate.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/aggregations/Aggregate.java
@@ -136,6 +136,8 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
 
         Nested("nested"),
 
+        Parent("parent"),
+
         PercentilesBucket("percentiles_bucket"),
 
         Range("range"),
@@ -892,6 +894,23 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
      */
     public NestedAggregate nested() {
         return TaggedUnionUtils.get(this, Kind.Nested);
+    }
+
+    /**
+     * Is this variant instance of kind {@code parent}?
+     */
+    public boolean isParent() {
+        return _kind == Kind.Parent;
+    }
+
+    /**
+     * Get the {@code parent} variant value.
+     *
+     * @throws IllegalStateException
+     *             if the current variant is not of the {@code parent} kind.
+     */
+    public ParentAggregate parent() {
+        return TaggedUnionUtils.get(this, Kind.Parent);
     }
 
     /**
@@ -1754,6 +1773,16 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
             return this;
         }
 
+        public ObjectBuilder<Aggregate> parent(ParentAggregate v) {
+            this._kind = Kind.Parent;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Aggregate> parent(Function<ParentAggregate.Builder, ObjectBuilder<ParentAggregate>> fn) {
+            return this.parent(fn.apply(new ParentAggregate.Builder()).build());
+        }
+
         public ObjectBuilder<Aggregate> percentilesBucket(
             Function<PercentilesBucketAggregate.Builder, ObjectBuilder<PercentilesBucketAggregate>> fn
         ) {
@@ -2075,6 +2104,7 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
         deserializers.put("missing", MissingAggregate._DESERIALIZER);
         deserializers.put("multi_terms", MultiTermsAggregate._DESERIALIZER);
         deserializers.put("nested", NestedAggregate._DESERIALIZER);
+        deserializers.put("parent", ParentAggregate._DESERIALIZER);
         deserializers.put("percentiles_bucket", PercentilesBucketAggregate._DESERIALIZER);
         deserializers.put("range", RangeAggregate._DESERIALIZER);
         deserializers.put("rate", RateAggregate._DESERIALIZER);

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/aggregations/ParentAggregate.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/aggregations/ParentAggregate.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.aggregations;
+
+import java.util.function.Function;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ObjectBuilder;
+
+// typedef: _types.aggregations.ParentAggregate
+
+@JsonpDeserializable
+public class ParentAggregate extends SingleBucketAggregateBase implements AggregateVariant {
+    // ---------------------------------------------------------------------------------------------
+
+    private ParentAggregate(Builder builder) {
+        super(builder);
+
+    }
+
+    public static ParentAggregate of(Function<Builder, ObjectBuilder<ParentAggregate>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    @Override
+    public Aggregate.Kind _aggregateKind() {
+        return Aggregate.Kind.Parent;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link ParentAggregate}.
+     */
+
+    public static class Builder extends SingleBucketAggregateBase.AbstractBuilder<Builder> implements ObjectBuilder<ParentAggregate> {
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        /**
+         * Builds a {@link ParentAggregate}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public ParentAggregate build() {
+            _checkSingleUse();
+
+            return new ParentAggregate(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link ParentAggregate}
+     */
+    public static final JsonpDeserializer<ParentAggregate> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        ParentAggregate::setupParentAggregateDeserializer
+    );
+
+    protected static void setupParentAggregateDeserializer(ObjectDeserializer<ParentAggregate.Builder> op) {
+        SingleBucketAggregateBase.setupSingleBucketAggregateBaseDeserializer(op);
+    }
+
+}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/AggregateResponseTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/AggregateResponseTest.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch.core;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.json.stream.JsonParser;
+import java.io.StringReader;
+import java.util.Map;
+import org.junit.Test;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.ParentAggregate;
+import org.opensearch.client.opensearch.model.ModelTestCase;
+
+public class AggregateResponseTest extends ModelTestCase {
+
+    @Test
+    public void shouldCreateParentAggregate() {
+        // given
+        final Aggregate aggregate = Aggregate.of((b) -> b.parent((p) -> p.docCount(789L)));
+
+        // when
+        final ParentAggregate parentAggregate = aggregate.parent();
+
+        // then
+        assertEquals(parentAggregate._aggregateKind(), Aggregate.Kind.Parent);
+        assertEquals(parentAggregate.docCount(), 789L);
+    }
+
+    @Test
+    public void shouldDeserializeParentAggregate() throws JsonProcessingException {
+        // given
+        final String parentAggreationJson = "{\"took\": 3,\"timed_out\": false,"
+            + "\"_shards\": {\"total\": 1,\"successful\": 1,\"skipped\": 0,\"failed\": 0},"
+            + "\"hits\": {\"total\": {\"value\": 0,\"relation\": \"eq\"},\"hits\": []},"
+            + "\"aggregations\": {\"parent#foo\": {\"doc_count\": 123456}}}";
+        final JsonParser parser = mapper.jsonProvider().createParser(new StringReader(parentAggreationJson));
+
+        // when
+        final SearchResponse<Object> response = SearchResponse._DESERIALIZER.deserialize(parser, mapper);
+
+        // then
+        final Map<String, Aggregate> aggregations = response.aggregations();
+        assertFalse(aggregations.isEmpty());
+        assertTrue(aggregations.containsKey("foo"));
+        assertEquals(aggregations.get("foo").parent()._aggregateKind(), Aggregate.Kind.Parent);
+        assertEquals(aggregations.get("foo").parent().docCount(), 123456L);
+    }
+}


### PR DESCRIPTION
### Description
When performing a parent aggregation, the deserialization of the search response failed because the parent aggregate deserializer was not registered.

This PR introduces a `ParentAggregate` and provides a `_DESERIALIZER` that is being used to deserialize the search response containing the results of the parent aggregation.

If possible could you please backport this bug fix up to version 2.5 of the java client.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
