### PR TITLE
Fixing partial success results for msearch template (#709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fix partial success results for msearch_template ([#709](https://github.com/opensearch-project/opensearch-java/pull/709))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/ErrorResponse.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/ErrorResponse.java
@@ -62,14 +62,14 @@ public class ErrorResponse implements JsonpSerializable {
 
     private final ErrorCause error;
 
-    private final int status;
+    private final Integer status;
 
     // ---------------------------------------------------------------------------------------------
 
     private ErrorResponse(Builder builder) {
 
         this.error = ApiTypeHelper.requireNonNull(builder.error, this, "error");
-        this.status = ApiTypeHelper.requireNonNull(builder.status, this, "status");
+        this.status = builder.status;
 
     }
 
@@ -87,7 +87,7 @@ public class ErrorResponse implements JsonpSerializable {
     /**
      * Required - API name: {@code status}
      */
-    public final int status() {
+    public final Integer status() {
         return this.status;
     }
 
@@ -105,8 +105,10 @@ public class ErrorResponse implements JsonpSerializable {
         generator.writeKey("error");
         this.error.serialize(generator, mapper);
 
-        generator.writeKey("status");
-        generator.write(this.status);
+        if (this.status != null) {
+            generator.writeKey("status");
+            generator.write(this.status);
+        }
 
     }
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractClusterClientIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractClusterClientIT.java
@@ -96,11 +96,8 @@ public abstract class AbstractClusterClientIT extends OpenSearchJavaClientTestCa
             fail();
         } catch (OpenSearchException e) {
             assertNotNull(e);
-            assertEquals(e.response().status(), 400);
-            assertEquals(
-                e.getMessage(),
-                "Request failed: [illegal_argument_exception] " + "transient setting [no_idea_what_you_are_talking_about], not recognized"
-            );
+            assertEquals(e.response().status().intValue(), 400);
+            assertTrue(e.getMessage().contains("transient setting [no_idea_what_you_are_talking_about], not recognized"));
         }
     }
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractRequestIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractRequestIT.java
@@ -335,7 +335,7 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
         assertTrue(msearch.responses().get(0).isResult());
         assertEquals(1, msearch.responses().get(0).result().hits().hits().size());
         assertTrue(msearch.responses().get(1).isFailure());
-        assertEquals(404, msearch.responses().get(1).failure().status());
+        assertEquals(404, msearch.responses().get(1).failure().status().intValue());
     }
 
     @Test

--- a/java-client/src/test/java/org/opensearch/client/opensearch/json/jackson/JacksonJsonpParserTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/json/jackson/JacksonJsonpParserTest.java
@@ -185,7 +185,7 @@ public class JacksonJsonpParserTest extends ModelTestCase {
         MsearchResponse<Foo> response = fromJson(json, MsearchResponse.class, mapper);
 
         assertEquals(2, response.responses().size());
-        assertEquals(404, response.responses().get(0).failure().status());
+        assertEquals(404, response.responses().get(0).failure().status().intValue());
         assertEquals((Integer) 200, response.responses().get(1).result().status());
     }
 


### PR DESCRIPTION
* Fixing partial success results for msearch template



* Adding changelog



* Spotless apply



---------

### Description
Backport #709 to 2.x

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
