### PR TITLE
Fix Maven local repository location (post Gradle 8.4 update)

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -208,7 +208,7 @@ dependencies {
 }
 
 licenseReport {
-    renderers = arrayOf(SpdxReporter(File(rootProject.buildDir, "release/dependencies.csv")))
+    renderers = arrayOf(SpdxReporter(rootProject.layout.buildDirectory.file("release/dependencies.csv").get().getAsFile()))
     excludeGroups = arrayOf("org.opensearch.client")
 }
 
@@ -296,7 +296,7 @@ publishing {
                 }
             }
         }
-        maven("${rootProject.buildDir}/repository") {
+        maven(rootProject.layout.buildDirectory.dir("repository")) {
             name = "localRepo"
         }
     }


### PR DESCRIPTION
### Description
Fix Maven local repository location (post Gradle 8.4 update)

### Issues Resolved
It seems like Gradle changed `buildDirectory` from `dir` to `property` so it resolved to 

```
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /home/user/opensearch-java/build))/repository
```

Failing the release drafter:

```
 tar: build: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
Error: Process completed with exit code 2
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
