### PR TITLE
Fix PutTemplateRequest deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
+- Fix PutTemplateRequest field deserialization ([#417](https://github.com/opensearch-project/opensearch-java/pull/723))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
-- Fix PutTemplateRequest field deserialization ([#417](https://github.com/opensearch-project/opensearch-java/pull/723))
+- Fix PutTemplateRequest field deserialization ([#723](https://github.com/opensearch-project/opensearch-java/pull/723))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/PutTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/PutTemplateRequest.java
@@ -586,8 +586,10 @@ public class PutTemplateRequest extends RequestBase implements JsonpSerializable
     protected static void setupPutTemplateRequestDeserializer(ObjectDeserializer<PutTemplateRequest.Builder> op) {
 
         op.add(Builder::aliases, JsonpDeserializer.stringMapDeserializer(Alias._DESERIALIZER), "aliases");
+        op.add(Builder::create, JsonpDeserializer.booleanDeserializer(), "create");
         op.add(Builder::indexPatterns, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "index_patterns");
         op.add(Builder::mappings, TypeMapping._DESERIALIZER, "mappings");
+        op.add(Builder::name, JsonpDeserializer.stringDeserializer(), "name");
         op.add(Builder::order, JsonpDeserializer.integerDeserializer(), "order");
         op.add(Builder::settings, JsonpDeserializer.stringMapDeserializer(JsonData._DESERIALIZER), "settings");
         op.add(Builder::version, JsonpDeserializer.longDeserializer(), "version");

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/PutTemplateRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/PutTemplateRequestTest.java
@@ -34,7 +34,7 @@ public class PutTemplateRequestTest extends Assert {
 
         assertEquals(putTemplateRequest.name(), "test");
         assertEquals(putTemplateRequest.indexPatterns(), List.of("*"));
-        assertEquals((long) putTemplateRequest.order(), 1L);
+        assertEquals((int) putTemplateRequest.order(), 1);
         assertEquals(putTemplateRequest.create(), true);
     }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/PutTemplateRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/PutTemplateRequestTest.java
@@ -12,33 +12,26 @@ import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch.indices.PutTemplateRequest;
 
 public class PutTemplateRequestTest extends Assert {
-    private static String INDEX_NAME_FIELD = "name";
-    private static String INDEX_PATTERNS_FIELD = "index_patterns";
-    private static String CREATE_FIELD = "create";
-    private static String ORDER_FIELD = "order";
 
     @Test
     public void deserialize_validFieldsIncluded_RequestIsBuilt() throws JsonProcessingException {
-        // Arrange
         final JsonpMapper mapper = new JsonbJsonpMapper();
         final Map<String, Object> indexTemplateMap = Map.of(
-            INDEX_NAME_FIELD,
+            "name",
             "test",
-            INDEX_PATTERNS_FIELD,
+            "index_patterns",
             "*",
-            CREATE_FIELD,
+            "create",
             true,
-            ORDER_FIELD,
+            "order",
             1
 
         );
         final String indexTemplate = new ObjectMapper().writeValueAsString(indexTemplateMap);
         final var parser = mapper.jsonProvider().createParser(new StringReader(indexTemplate));
 
-        // Act
         final PutTemplateRequest putTemplateRequest = PutTemplateRequest._DESERIALIZER.deserialize(parser, mapper);
 
-        // Assert
         assertEquals(putTemplateRequest.name(), "test");
         assertEquals(putTemplateRequest.indexPatterns(), List.of("*"));
         assertEquals((long) putTemplateRequest.order(), 1L);

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/PutTemplateRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/PutTemplateRequestTest.java
@@ -16,17 +16,8 @@ public class PutTemplateRequestTest extends Assert {
     @Test
     public void deserialize_validFieldsIncluded_RequestIsBuilt() throws JsonProcessingException {
         final JsonpMapper mapper = new JsonbJsonpMapper();
-        final Map<String, Object> indexTemplateMap = Map.of(
-            "name",
-            "test",
-            "index_patterns",
-            "*",
-            "create",
-            true,
-            "order",
-            1
+        final Map<String, Object> indexTemplateMap = Map.of("name", "test", "index_patterns", "*", "create", true, "order", 1);
 
-        );
         final String indexTemplate = new ObjectMapper().writeValueAsString(indexTemplateMap);
         final var parser = mapper.jsonProvider().createParser(new StringReader(indexTemplate));
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/PutTemplateRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/PutTemplateRequestTest.java
@@ -1,0 +1,47 @@
+package org.opensearch.client.opensearch.core;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.StringReader;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+import org.opensearch.client.opensearch.indices.PutTemplateRequest;
+
+public class PutTemplateRequestTest extends Assert {
+    private static String INDEX_NAME_FIELD = "name";
+    private static String INDEX_PATTERNS_FIELD = "index_patterns";
+    private static String CREATE_FIELD = "create";
+    private static String ORDER_FIELD = "order";
+
+    @Test
+    public void deserialize_validFieldsIncluded_RequestIsBuilt() throws JsonProcessingException {
+        // Arrange
+        final JsonpMapper mapper = new JsonbJsonpMapper();
+        final Map<String, Object> indexTemplateMap = Map.of(
+            INDEX_NAME_FIELD,
+            "test",
+            INDEX_PATTERNS_FIELD,
+            "*",
+            CREATE_FIELD,
+            true,
+            ORDER_FIELD,
+            1
+
+        );
+        final String indexTemplate = new ObjectMapper().writeValueAsString(indexTemplateMap);
+        final var parser = mapper.jsonProvider().createParser(new StringReader(indexTemplate));
+
+        // Act
+        final PutTemplateRequest putTemplateRequest = PutTemplateRequest._DESERIALIZER.deserialize(parser, mapper);
+
+        // Assert
+        assertEquals(putTemplateRequest.name(), "test");
+        assertEquals(putTemplateRequest.indexPatterns(), List.of("*"));
+        assertEquals((long) putTemplateRequest.order(), 1L);
+        assertEquals(putTemplateRequest.create(), true);
+    }
+}


### PR DESCRIPTION
### Description
Link to issue [417](https://github.com/opensearch-project/opensearch-java/issues/417)

This PR adds in the missing deserialization steps to the PutTemplateRequest _DESERIALIZER which would result in the error
`Missing required property 'PutTemplateRequest.name'` if you tried to deserialize a request object.

### Issues Resolved
https://github.com/opensearch-project/opensearch-java/issues/417

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
