### PR TITLE
[Backport] [2.x] Add JDK compatibility matrix to COMPATIBILITY.md (#713)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,4 +1,5 @@
 - [Compatibility with OpenSearch](#compatibility-with-opensearch)
+- [Compatibility with JDK](#compatibility-with-jdk)
 - [Upgrading](#upgrading)
 
 ## Compatibility with OpenSearch
@@ -8,7 +9,17 @@ The below matrix shows the compatibility of the [`opensearch-java-client`](https
 | Client Version | OpenSearch Version |
 |----------------|--------------------|
 | 1.0.0          | 1.x                |
-| 2.x.0          | 1.3.13-2.10.0       |
+| 2.x.0          | 1.3.13-2.10.0      |
+
+
+## Compatibility with JDK
+
+The below matrix shows the compatibility of the [`opensearch-java-client`](https://search.maven.org/artifact/org.opensearch.client/opensearch-java) with JDK versions.
+
+| Client Version | JDK                |
+|----------------|--------------------|
+| 1.0.0          | 8                  |
+| 2.x.0          | 11 / 17 / 21       |
 
 ## Upgrading
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/713 to `2.x`