### PR TITLE
Add missing "Cancelled" property to TaskInfo response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix partial success results for msearch_template ([#709](https://github.com/opensearch-project/opensearch-java/pull/709))
-- Fix missing "cancelled" property in Info class ([#730](https://github.com/opensearch-project/opensearch-java/pull/730))
+- Fix missing "cancelled" property in Info class ([#731](https://github.com/opensearch-project/opensearch-java/pull/731))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix partial success results for msearch_template ([#709](https://github.com/opensearch-project/opensearch-java/pull/709))
+- Fix missing "cancelled" property in Info class ([#730](https://github.com/opensearch-project/opensearch-java/pull/730))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/tasks/Info.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/tasks/Info.java
@@ -331,7 +331,7 @@ public class Info implements JsonpSerializable {
         /**
          * Required - API name: {@code cancellable}
          */
-        public final Builder cancellable(boolean value) {
+        public final Builder cancellable(Boolean value) {
             this.cancellable = value;
             return this;
         }
@@ -339,7 +339,7 @@ public class Info implements JsonpSerializable {
         /**
          * API name: {@code cancelled}
          */
-        public final Builder cancelled(boolean value) {
+        public final Builder cancelled(@Nullable Boolean value) {
             this.cancelled = value;
             return this;
         }

--- a/java-client/src/main/java/org/opensearch/client/opensearch/tasks/Info.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/tasks/Info.java
@@ -53,7 +53,10 @@ import org.opensearch.client.util.ObjectBuilderBase;
 public class Info implements JsonpSerializable {
     private final String action;
 
-    private final boolean cancellable;
+    @Nullable
+    private final Boolean cancelled;
+
+    private final Boolean cancellable;
 
     private final List<Info> children;
 
@@ -84,6 +87,7 @@ public class Info implements JsonpSerializable {
 
         this.action = ApiTypeHelper.requireNonNull(builder.action, this, "action");
         this.cancellable = ApiTypeHelper.requireNonNull(builder.cancellable, this, "cancellable");
+        this.cancelled = builder.cancelled;
         this.children = ApiTypeHelper.unmodifiable(builder.children);
         this.description = builder.description;
         this.headers = ApiTypeHelper.unmodifiableRequired(builder.headers, this, "headers");
@@ -106,6 +110,14 @@ public class Info implements JsonpSerializable {
      */
     public final String action() {
         return this.action;
+    }
+
+    /**
+     * API name: {@code action}
+     */
+    @Nullable
+    public final Boolean cancelled() {
+        return this.cancelled;
     }
 
     /**
@@ -205,6 +217,10 @@ public class Info implements JsonpSerializable {
         generator.writeKey("cancellable");
         generator.write(this.cancellable);
 
+        if (this.cancelled != null) {
+            generator.writeKey("cancelled");
+            generator.write(this.cancelled);
+        }
         if (ApiTypeHelper.isDefined(this.children)) {
             generator.writeKey("children");
             generator.writeStartArray();
@@ -278,6 +294,9 @@ public class Info implements JsonpSerializable {
         private Boolean cancellable;
 
         @Nullable
+        private Boolean cancelled;
+
+        @Nullable
         private List<Info> children;
 
         @Nullable
@@ -314,6 +333,14 @@ public class Info implements JsonpSerializable {
          */
         public final Builder cancellable(boolean value) {
             this.cancellable = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code cancelled}
+         */
+        public final Builder cancelled(boolean value) {
+            this.cancelled = value;
             return this;
         }
 
@@ -461,6 +488,7 @@ public class Info implements JsonpSerializable {
 
         op.add(Builder::action, JsonpDeserializer.stringDeserializer(), "action");
         op.add(Builder::cancellable, JsonpDeserializer.booleanDeserializer(), "cancellable");
+        op.add(Builder::cancelled, JsonpDeserializer.booleanDeserializer(), "cancelled");
         op.add(Builder::children, JsonpDeserializer.arrayDeserializer(Info._DESERIALIZER), "children");
         op.add(Builder::description, JsonpDeserializer.stringDeserializer(), "description");
         op.add(

--- a/java-client/src/test/java/org/opensearch/client/opensearch/tasks/InfoTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/tasks/InfoTest.java
@@ -1,0 +1,90 @@
+package org.opensearch.client.opensearch.tasks;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+import org.opensearch.client.util.MissingRequiredPropertyException;
+
+public class InfoTest extends Assert {
+
+    @Test
+    public void deserialize_validInfo_infoDeserializesCorrectly() throws JsonProcessingException {
+
+        Map<String, Object> infoMap = new HashMap<>();
+
+        infoMap.put("action", "test-action");
+        infoMap.put("cancelled", true);
+        infoMap.put("cancellable", true);
+        infoMap.put("description", "test-description");
+        infoMap.put("id", 123L);
+        infoMap.put("node", "test-node");
+        infoMap.put("running_time_in_nanos", 1234567);
+        infoMap.put("start_time_in_millis", 12345678);
+        infoMap.put("type", "test-type");
+        infoMap.put("parent_task_id", "test-parent-id");
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("header-key-1", List.of("header-1", "header-2"));
+        headers.put("header-key-2", List.of("header-3", "header-4"));
+
+        infoMap.put("headers", headers);
+
+        final JsonpMapper mapper = new JsonbJsonpMapper();
+        final String infoJson = new ObjectMapper().writeValueAsString(infoMap);
+        final var parser = mapper.jsonProvider().createParser(new StringReader(infoJson));
+
+        final Info info = Info._DESERIALIZER.deserialize(parser, mapper);
+
+        assertTrue(info.cancelled());
+        assertEquals("test-action", info.action());
+        assertTrue(info.cancellable());
+        assertEquals("test-description", info.description());
+        assertEquals(123L, info.id());
+        assertEquals("test-node", info.node());
+        assertEquals(1234567, info.runningTimeInNanos());
+        assertEquals(12345678, info.startTimeInMillis());
+        assertEquals("test-type", info.type());
+        assertEquals("test-parent-id", info.parentTaskId());
+
+        Map<String, List<String>> infoHeaders = info.headers();
+        assertEquals(List.of("header-1", "header-2"), infoHeaders.get("header-key-1"));
+        assertEquals(List.of("header-3", "header-4"), infoHeaders.get("header-key-2"));
+    }
+
+    @Test
+    public void deserialize_infoWithNullableProperties_missingRequiredPropertyExceptionNotThrown() throws JsonProcessingException {
+
+        Map<String, Object> infoMap = new HashMap<>();
+
+        infoMap.put("action", "test-action");
+        infoMap.put("cancellable", true);
+        infoMap.put("id", 123L);
+        infoMap.put("node", "test-node");
+        infoMap.put("running_time_in_nanos", 1234567);
+        infoMap.put("start_time_in_millis", 12345678);
+        infoMap.put("type", "test-type");
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("header-key-1", List.of("header-1", "header-2"));
+        headers.put("header-key-2", List.of("header-3", "header-4"));
+
+        infoMap.put("headers", headers);
+
+        final JsonpMapper mapper = new JsonbJsonpMapper();
+        final String infoJson = new ObjectMapper().writeValueAsString(infoMap);
+        final var parser = mapper.jsonProvider().createParser(new StringReader(infoJson));
+
+        try {
+            Info._DESERIALIZER.deserialize(parser, mapper);
+        } catch (MissingRequiredPropertyException e) {
+            fail("Nullable properties should not be required");
+        }
+    }
+}


### PR DESCRIPTION
### Description
While working on another feature I noticed the "cancelled" property was missing from the task info class.

Based on the ApiSpec https://github.com/elastic/elasticsearch-specification/blob/main/specification/tasks/_types/TaskInfo.ts
I have left this nullable.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
