### PR TITLE
Add support for Flat Objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Added
 - Added support for icu_collation_keyword type ([#725](https://github.com/opensearch-project/opensearch-java/pull/725))
+- Added support for flat_object field property ([#735](https://github.com/opensearch-project/opensearch-java/pull/735))
 
 ### Dependencies
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -7,6 +7,7 @@
     - [Creating an index](#creating-an-index)
       - [With default settings](#with-default-settings)
       - [With custom settings and mappings](#with-custom-settings-and-mappings)
+      - [With FlatObject mappings](#with-flat-object-mappings)
     - [Indexing data](#indexing-data)
     - [Searching for a document](#searching-for-a-document)
     - [Deleting a document](#deleting-a-document)
@@ -136,6 +137,18 @@ CreateIndexRequest createIndexRequest = new CreateIndexRequest.Builder()
         .build();
 client.indices().create(createIndexRequest);
 ```
+#### With flat object mappings
+OpenSearch supports FlatObject mappings from version 2.7.0 without additional parameters.
+
+```java
+final CreateIndexRequest createIndexRequest = new CreateIndexRequest.Builder().index(indexName)
+                    .mappings(m -> m.properties("issue", Property.of(p -> p.flatObject(new FlatObjectProperty.Builder().build()))))
+                    .build();
+client.indices().create(createIndexRequest);
+```
+
+You can find a working sample of the above code in [FlatObjectBasics.java](./samples/src/main/java/org/opensearch/client/samples/FlatObjectBasics.java).
+
 
 ### Indexing data
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/FieldType.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/FieldType.java
@@ -107,7 +107,7 @@ public enum FieldType implements JsonEnum {
 
     RankFeatures("rank_features"),
 
-    Flattened("flattened"),
+    FlatObject("flat_object"),
 
     Shape("shape"),
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/FlatObjectProperty.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/FlatObjectProperty.java
@@ -42,10 +42,10 @@ import org.opensearch.client.json.ObjectBuilderDeserializer;
 import org.opensearch.client.json.ObjectDeserializer;
 import org.opensearch.client.util.ObjectBuilder;
 
-// typedef: _types.mapping.FlattenedProperty
+// typedef: _types.mapping.FlatObjectProperty
 
 @JsonpDeserializable
-public class FlattenedProperty extends PropertyBase implements PropertyVariant {
+public class FlatObjectProperty extends PropertyBase implements PropertyVariant {
     @Nullable
     private final Double boost;
 
@@ -75,7 +75,7 @@ public class FlattenedProperty extends PropertyBase implements PropertyVariant {
 
     // ---------------------------------------------------------------------------------------------
 
-    private FlattenedProperty(Builder builder) {
+    private FlatObjectProperty(Builder builder) {
         super(builder);
 
         this.boost = builder.boost;
@@ -90,7 +90,7 @@ public class FlattenedProperty extends PropertyBase implements PropertyVariant {
 
     }
 
-    public static FlattenedProperty of(Function<Builder, ObjectBuilder<FlattenedProperty>> fn) {
+    public static FlatObjectProperty of(Function<Builder, ObjectBuilder<FlatObjectProperty>> fn) {
         return fn.apply(new Builder()).build();
     }
 
@@ -99,7 +99,7 @@ public class FlattenedProperty extends PropertyBase implements PropertyVariant {
      */
     @Override
     public Property.Kind _propertyKind() {
-        return Property.Kind.Flattened;
+        return Property.Kind.FlatObject;
     }
 
     /**
@@ -176,7 +176,7 @@ public class FlattenedProperty extends PropertyBase implements PropertyVariant {
 
     protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
-        generator.write("type", "flattened");
+        generator.write("type", "flat_object");
         super.serializeInternal(generator, mapper);
         if (this.boost != null) {
             generator.writeKey("boost");
@@ -228,10 +228,10 @@ public class FlattenedProperty extends PropertyBase implements PropertyVariant {
     // ---------------------------------------------------------------------------------------------
 
     /**
-     * Builder for {@link FlattenedProperty}.
+     * Builder for {@link FlatObjectProperty}.
      */
 
-    public static class Builder extends PropertyBase.AbstractBuilder<Builder> implements ObjectBuilder<FlattenedProperty> {
+    public static class Builder extends PropertyBase.AbstractBuilder<Builder> implements ObjectBuilder<FlatObjectProperty> {
         @Nullable
         private Double boost;
 
@@ -337,29 +337,29 @@ public class FlattenedProperty extends PropertyBase implements PropertyVariant {
         }
 
         /**
-         * Builds a {@link FlattenedProperty}.
+         * Builds a {@link FlatObjectProperty}.
          *
          * @throws NullPointerException
          *             if some of the required fields are null.
          */
-        public FlattenedProperty build() {
+        public FlatObjectProperty build() {
             _checkSingleUse();
 
-            return new FlattenedProperty(this);
+            return new FlatObjectProperty(this);
         }
     }
 
     // ---------------------------------------------------------------------------------------------
 
     /**
-     * Json deserializer for {@link FlattenedProperty}
+     * Json deserializer for {@link FlatObjectProperty}
      */
-    public static final JsonpDeserializer<FlattenedProperty> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+    public static final JsonpDeserializer<FlatObjectProperty> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
         Builder::new,
-        FlattenedProperty::setupFlattenedPropertyDeserializer
+        FlatObjectProperty::setupFlatObjectPropertyDeserializer
     );
 
-    protected static void setupFlattenedPropertyDeserializer(ObjectDeserializer<FlattenedProperty.Builder> op) {
+    protected static void setupFlatObjectPropertyDeserializer(ObjectDeserializer<FlatObjectProperty.Builder> op) {
         PropertyBase.setupPropertyBaseDeserializer(op);
         op.add(Builder::boost, JsonpDeserializer.doubleDeserializer(), "boost");
         op.add(Builder::depthLimit, JsonpDeserializer.integerDeserializer(), "depth_limit");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/FlatObjectProperty.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/FlatObjectProperty.java
@@ -34,7 +34,6 @@ package org.opensearch.client.opensearch._types.mapping;
 
 import jakarta.json.stream.JsonGenerator;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
@@ -46,47 +45,11 @@ import org.opensearch.client.util.ObjectBuilder;
 
 @JsonpDeserializable
 public class FlatObjectProperty extends PropertyBase implements PropertyVariant {
-    @Nullable
-    private final Double boost;
-
-    @Nullable
-    private final Integer depthLimit;
-
-    @Nullable
-    private final Boolean docValues;
-
-    @Nullable
-    private final Boolean eagerGlobalOrdinals;
-
-    @Nullable
-    private final Boolean index;
-
-    @Nullable
-    private final IndexOptions indexOptions;
-
-    @Nullable
-    private final String nullValue;
-
-    @Nullable
-    private final String similarity;
-
-    @Nullable
-    private final Boolean splitQueriesOnWhitespace;
 
     // ---------------------------------------------------------------------------------------------
 
     private FlatObjectProperty(Builder builder) {
         super(builder);
-
-        this.boost = builder.boost;
-        this.depthLimit = builder.depthLimit;
-        this.docValues = builder.docValues;
-        this.eagerGlobalOrdinals = builder.eagerGlobalOrdinals;
-        this.index = builder.index;
-        this.indexOptions = builder.indexOptions;
-        this.nullValue = builder.nullValue;
-        this.similarity = builder.similarity;
-        this.splitQueriesOnWhitespace = builder.splitQueriesOnWhitespace;
 
     }
 
@@ -102,127 +65,10 @@ public class FlatObjectProperty extends PropertyBase implements PropertyVariant 
         return Property.Kind.FlatObject;
     }
 
-    /**
-     * API name: {@code boost}
-     */
-    @Nullable
-    public final Double boost() {
-        return this.boost;
-    }
-
-    /**
-     * API name: {@code depth_limit}
-     */
-    @Nullable
-    public final Integer depthLimit() {
-        return this.depthLimit;
-    }
-
-    /**
-     * API name: {@code doc_values}
-     */
-    @Nullable
-    public final Boolean docValues() {
-        return this.docValues;
-    }
-
-    /**
-     * API name: {@code eager_global_ordinals}
-     */
-    @Nullable
-    public final Boolean eagerGlobalOrdinals() {
-        return this.eagerGlobalOrdinals;
-    }
-
-    /**
-     * API name: {@code index}
-     */
-    @Nullable
-    public final Boolean index() {
-        return this.index;
-    }
-
-    /**
-     * API name: {@code index_options}
-     */
-    @Nullable
-    public final IndexOptions indexOptions() {
-        return this.indexOptions;
-    }
-
-    /**
-     * API name: {@code null_value}
-     */
-    @Nullable
-    public final String nullValue() {
-        return this.nullValue;
-    }
-
-    /**
-     * API name: {@code similarity}
-     */
-    @Nullable
-    public final String similarity() {
-        return this.similarity;
-    }
-
-    /**
-     * API name: {@code split_queries_on_whitespace}
-     */
-    @Nullable
-    public final Boolean splitQueriesOnWhitespace() {
-        return this.splitQueriesOnWhitespace;
-    }
-
     protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
         generator.write("type", "flat_object");
         super.serializeInternal(generator, mapper);
-        if (this.boost != null) {
-            generator.writeKey("boost");
-            generator.write(this.boost);
-
-        }
-        if (this.depthLimit != null) {
-            generator.writeKey("depth_limit");
-            generator.write(this.depthLimit);
-
-        }
-        if (this.docValues != null) {
-            generator.writeKey("doc_values");
-            generator.write(this.docValues);
-
-        }
-        if (this.eagerGlobalOrdinals != null) {
-            generator.writeKey("eager_global_ordinals");
-            generator.write(this.eagerGlobalOrdinals);
-
-        }
-        if (this.index != null) {
-            generator.writeKey("index");
-            generator.write(this.index);
-
-        }
-        if (this.indexOptions != null) {
-            generator.writeKey("index_options");
-            this.indexOptions.serialize(generator, mapper);
-        }
-        if (this.nullValue != null) {
-            generator.writeKey("null_value");
-            generator.write(this.nullValue);
-
-        }
-        if (this.similarity != null) {
-            generator.writeKey("similarity");
-            generator.write(this.similarity);
-
-        }
-        if (this.splitQueriesOnWhitespace != null) {
-            generator.writeKey("split_queries_on_whitespace");
-            generator.write(this.splitQueriesOnWhitespace);
-
-        }
-
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -232,104 +78,6 @@ public class FlatObjectProperty extends PropertyBase implements PropertyVariant 
      */
 
     public static class Builder extends PropertyBase.AbstractBuilder<Builder> implements ObjectBuilder<FlatObjectProperty> {
-        @Nullable
-        private Double boost;
-
-        @Nullable
-        private Integer depthLimit;
-
-        @Nullable
-        private Boolean docValues;
-
-        @Nullable
-        private Boolean eagerGlobalOrdinals;
-
-        @Nullable
-        private Boolean index;
-
-        @Nullable
-        private IndexOptions indexOptions;
-
-        @Nullable
-        private String nullValue;
-
-        @Nullable
-        private String similarity;
-
-        @Nullable
-        private Boolean splitQueriesOnWhitespace;
-
-        /**
-         * API name: {@code boost}
-         */
-        public final Builder boost(@Nullable Double value) {
-            this.boost = value;
-            return this;
-        }
-
-        /**
-         * API name: {@code depth_limit}
-         */
-        public final Builder depthLimit(@Nullable Integer value) {
-            this.depthLimit = value;
-            return this;
-        }
-
-        /**
-         * API name: {@code doc_values}
-         */
-        public final Builder docValues(@Nullable Boolean value) {
-            this.docValues = value;
-            return this;
-        }
-
-        /**
-         * API name: {@code eager_global_ordinals}
-         */
-        public final Builder eagerGlobalOrdinals(@Nullable Boolean value) {
-            this.eagerGlobalOrdinals = value;
-            return this;
-        }
-
-        /**
-         * API name: {@code index}
-         */
-        public final Builder index(@Nullable Boolean value) {
-            this.index = value;
-            return this;
-        }
-
-        /**
-         * API name: {@code index_options}
-         */
-        public final Builder indexOptions(@Nullable IndexOptions value) {
-            this.indexOptions = value;
-            return this;
-        }
-
-        /**
-         * API name: {@code null_value}
-         */
-        public final Builder nullValue(@Nullable String value) {
-            this.nullValue = value;
-            return this;
-        }
-
-        /**
-         * API name: {@code similarity}
-         */
-        public final Builder similarity(@Nullable String value) {
-            this.similarity = value;
-            return this;
-        }
-
-        /**
-         * API name: {@code split_queries_on_whitespace}
-         */
-        public final Builder splitQueriesOnWhitespace(@Nullable Boolean value) {
-            this.splitQueriesOnWhitespace = value;
-            return this;
-        }
 
         @Override
         protected Builder self() {
@@ -361,15 +109,6 @@ public class FlatObjectProperty extends PropertyBase implements PropertyVariant 
 
     protected static void setupFlatObjectPropertyDeserializer(ObjectDeserializer<FlatObjectProperty.Builder> op) {
         PropertyBase.setupPropertyBaseDeserializer(op);
-        op.add(Builder::boost, JsonpDeserializer.doubleDeserializer(), "boost");
-        op.add(Builder::depthLimit, JsonpDeserializer.integerDeserializer(), "depth_limit");
-        op.add(Builder::docValues, JsonpDeserializer.booleanDeserializer(), "doc_values");
-        op.add(Builder::eagerGlobalOrdinals, JsonpDeserializer.booleanDeserializer(), "eager_global_ordinals");
-        op.add(Builder::index, JsonpDeserializer.booleanDeserializer(), "index");
-        op.add(Builder::indexOptions, IndexOptions._DESERIALIZER, "index_options");
-        op.add(Builder::nullValue, JsonpDeserializer.stringDeserializer(), "null_value");
-        op.add(Builder::similarity, JsonpDeserializer.stringDeserializer(), "similarity");
-        op.add(Builder::splitQueriesOnWhitespace, JsonpDeserializer.booleanDeserializer(), "split_queries_on_whitespace");
 
         op.ignore("type");
     }

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/Property.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/Property.java
@@ -84,7 +84,7 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
 
         Alias("alias"),
 
-        Flattened("flattened"),
+        FlatObject("flat_object"),
 
         Float("float"),
 
@@ -404,8 +404,8 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
     /**
      * Is this variant instance of kind {@code flattened}?
      */
-    public boolean isFlattened() {
-        return _kind == Kind.Flattened;
+    public boolean isFlatObject() {
+        return _kind == Kind.FlatObject;
     }
 
     /**
@@ -414,8 +414,8 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
      * @throws IllegalStateException
      *             if the current variant is not of the {@code flattened} kind.
      */
-    public FlattenedProperty flattened() {
-        return TaggedUnionUtils.get(this, Kind.Flattened);
+    public FlatObjectProperty flatObject() {
+        return TaggedUnionUtils.get(this, Kind.FlatObject);
     }
 
     /**
@@ -1098,14 +1098,14 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
             return this.alias(fn.apply(new FieldAliasProperty.Builder()).build());
         }
 
-        public ObjectBuilder<Property> flattened(FlattenedProperty v) {
-            this._kind = Kind.Flattened;
+        public ObjectBuilder<Property> flatObject(FlatObjectProperty v) {
+            this._kind = Kind.FlatObject;
             this._value = v;
             return this;
         }
 
-        public ObjectBuilder<Property> flattened(Function<FlattenedProperty.Builder, ObjectBuilder<FlattenedProperty>> fn) {
-            return this.flattened(fn.apply(new FlattenedProperty.Builder()).build());
+        public ObjectBuilder<Property> flatObject(Function<FlatObjectProperty.Builder, ObjectBuilder<FlatObjectProperty>> fn) {
+            return this.flatObject(fn.apply(new FlatObjectProperty.Builder()).build());
         }
 
         public ObjectBuilder<Property> float_(FloatNumberProperty v) {
@@ -1457,7 +1457,7 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
         op.add(Builder::double_, DoubleNumberProperty._DESERIALIZER, "double");
         op.add(Builder::doubleRange, DoubleRangeProperty._DESERIALIZER, "double_range");
         op.add(Builder::alias, FieldAliasProperty._DESERIALIZER, "alias");
-        op.add(Builder::flattened, FlattenedProperty._DESERIALIZER, "flattened");
+        op.add(Builder::flatObject, FlatObjectProperty._DESERIALIZER, "flat_object");
         op.add(Builder::float_, FloatNumberProperty._DESERIALIZER, "float");
         op.add(Builder::floatRange, FloatRangeProperty._DESERIALIZER, "float_range");
         op.add(Builder::geoPoint, GeoPointProperty._DESERIALIZER, "geo_point");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/Property.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/Property.java
@@ -402,17 +402,17 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
     }
 
     /**
-     * Is this variant instance of kind {@code flattened}?
+     * Is this variant instance of kind {@code flat_oject}?
      */
     public boolean isFlatObject() {
         return _kind == Kind.FlatObject;
     }
 
     /**
-     * Get the {@code flattened} variant value.
+     * Get the {@code flat_object} variant value.
      *
      * @throws IllegalStateException
-     *             if the current variant is not of the {@code flattened} kind.
+     *             if the current variant is not of the {@code flat_object} kind.
      */
     public FlatObjectProperty flatObject() {
         return TaggedUnionUtils.get(this, Kind.FlatObject);

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/Property.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/Property.java
@@ -402,7 +402,7 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
     }
 
     /**
-     * Is this variant instance of kind {@code flat_oject}?
+     * Is this variant instance of kind {@code flat_object}?
      */
     public boolean isFlatObject() {
         return _kind == Kind.FlatObject;

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/PropertyBuilders.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/mapping/PropertyBuilders.java
@@ -134,11 +134,11 @@ public class PropertyBuilders {
     }
 
     /**
-     * Creates a builder for the {@link FlattenedProperty flattened}
+     * Creates a builder for the {@link FlatObjectProperty flatObject}
      * {@code Property} variant.
      */
-    public static FlattenedProperty.Builder flattened() {
-        return new FlattenedProperty.Builder();
+    public static FlatObjectProperty.Builder flatObject() {
+        return new FlatObjectProperty.Builder();
     }
 
     /**

--- a/samples/src/main/java/org/opensearch/client/samples/FlatObjectBasics.java
+++ b/samples/src/main/java/org/opensearch/client/samples/FlatObjectBasics.java
@@ -1,0 +1,111 @@
+package org.opensearch.client.samples;
+
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.mapping.FlatObjectProperty;
+import org.opensearch.client.opensearch._types.mapping.Property;
+import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.samples.util.IssueDocument;
+
+public class FlatObjectBasics {
+    private static final Logger LOGGER = LogManager.getLogger(IndexingBasics.class);
+
+    public static void main(String[] args) {
+        try {
+            var client = SampleClient.create();
+
+            var version = client.info().version();
+            LOGGER.info("Server: {}@{}", version.distribution(), version.number());
+
+            final var indexName = "flat_object-sample";
+
+            // Create a new index with an "issue" field with flat_object type
+            if (!client.indices().exists(e -> e.index(indexName)).value()) {
+                final CreateIndexRequest createIndexRequest = new CreateIndexRequest.Builder().index(indexName)
+                    .mappings(m -> m.properties("issue", Property.of(p -> p.flatObject(new FlatObjectProperty.Builder().build()))))
+                    .build();
+                client.indices().create(createIndexRequest);
+            }
+
+            // Index some flat object documents
+            final IssueDocument issueDocument = new IssueDocument();
+            final IssueDocument.Issue issue = new IssueDocument.Issue();
+            issue.setNumber("123456");
+            final IssueDocument.Labels labels = new IssueDocument.Labels();
+            labels.setBackport(List.of("1.3", "2.0"));
+            labels.setVersion("2.1");
+            final IssueDocument.Category category = new IssueDocument.Category();
+            category.setType("API");
+            category.setLevel("enhancement");
+
+            labels.setCategory(category);
+            issue.setLabels(labels);
+
+            issueDocument.setIssue(issue);
+            final IndexRequest<IssueDocument> indexRequest = new IndexRequest.Builder<IssueDocument>().index(indexName)
+                .id("1")
+                .document(issueDocument)
+                .build();
+
+            client.index(indexRequest);
+
+            // Index second document
+            final IssueDocument document2 = new IssueDocument();
+            final IssueDocument.Issue issue2 = new IssueDocument.Issue();
+            issue2.setNumber("123457");
+
+            IssueDocument.Labels labels2 = new IssueDocument.Labels();
+            labels2.setVersion("2.2");
+
+            IssueDocument.Category category2 = new IssueDocument.Category();
+            category2.setType("API");
+            category2.setLevel("bug");
+
+            labels2.setCategory(category2);
+            issue2.setLabels(labels2);
+
+            document2.setIssue(issue2);
+
+            final IndexRequest<IssueDocument> indexRequest2 = new IndexRequest.Builder<IssueDocument>().index(indexName)
+                .id("2")
+                .document(document2)
+                .build();
+
+            client.index(indexRequest2);
+
+            // wait for the document to index - as refresh period is set to 3s
+            Thread.sleep(3000);
+
+            // Search for the documents
+            // Ref: https://opensearch.org/docs/latest/field-types/supported-field-types/flat-object/
+            // Even if you don’t know the field names, you can search for a leaf value in the entire flat object.
+            // For example, the following request searches for all issues labeled as bugs
+            SearchRequest searchRequest = new SearchRequest.Builder().index(indexName)
+                .query(q -> q.match(m -> m.field("issue").query(FieldValue.of("bug"))))
+                .build();
+
+            SearchResponse<IssueDocument> searchResponse = client.search(searchRequest, IssueDocument.class);
+            for (var hit : searchResponse.hits().hits()) {
+                LOGGER.info("Found {} with score {}", hit.source(), hit.score());
+            }
+
+            // Alternatively, if you know the subfield name in which to search, provide the field’s path in dot notation
+            SearchRequest searchRequest2 = new SearchRequest.Builder().index(indexName)
+                .query(q -> q.match(m -> m.field("issue.labels.category.level").query(FieldValue.of("bug"))))
+                .build();
+
+            SearchResponse<IssueDocument> searchResponse2 = client.search(searchRequest2, IssueDocument.class);
+            for (var hit : searchResponse2.hits().hits()) {
+                LOGGER.info("Found {} with score {}", hit.source(), hit.score());
+            }
+
+        } catch (Exception e) {
+            LOGGER.error("Unexpected exception", e);
+        }
+    }
+}

--- a/samples/src/main/java/org/opensearch/client/samples/util/IssueDocument.java
+++ b/samples/src/main/java/org/opensearch/client/samples/util/IssueDocument.java
@@ -1,0 +1,94 @@
+package org.opensearch.client.samples.util;
+
+import java.util.List;
+
+public class IssueDocument {
+
+    private Issue issue;
+
+    // Getter and setter for "issue"
+    public Issue getIssue() {
+        return issue;
+    }
+
+    public void setIssue(Issue issue) {
+        this.issue = issue;
+    }
+
+    public static class Issue {
+        private String number;
+        private Labels labels;
+
+        // Getters and setters for "number" and "labels"
+        public String getNumber() {
+            return number;
+        }
+
+        public void setNumber(String number) {
+            this.number = number;
+        }
+
+        public Labels getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Labels labels) {
+            this.labels = labels;
+        }
+
+    }
+
+    public static class Labels {
+        private String version;
+        private List<String> backport;
+        private Category category;
+
+        // Getters and setters for "version", "backport", and "category"
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+
+        public List<String> getBackport() {
+            return backport;
+        }
+
+        public void setBackport(List<String> backport) {
+            this.backport = backport;
+        }
+
+        public Category getCategory() {
+            return category;
+        }
+
+        public void setCategory(Category category) {
+            this.category = category;
+        }
+
+    }
+
+    public static class Category {
+        private String type;
+        private String level;
+
+        // Getters and setters for "type" and "level"
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getLevel() {
+            return level;
+        }
+
+        public void setLevel(String level) {
+            this.level = level;
+        }
+    }
+}

--- a/samples/src/main/java/org/opensearch/client/samples/util/IssueDocument.java
+++ b/samples/src/main/java/org/opensearch/client/samples/util/IssueDocument.java
@@ -6,7 +6,6 @@ public class IssueDocument {
 
     private Issue issue;
 
-    // Getter and setter for "issue"
     public Issue getIssue() {
         return issue;
     }
@@ -19,7 +18,6 @@ public class IssueDocument {
         private String number;
         private Labels labels;
 
-        // Getters and setters for "number" and "labels"
         public String getNumber() {
             return number;
         }
@@ -43,7 +41,6 @@ public class IssueDocument {
         private List<String> backport;
         private Category category;
 
-        // Getters and setters for "version", "backport", and "category"
         public String getVersion() {
             return version;
         }
@@ -74,7 +71,6 @@ public class IssueDocument {
         private String type;
         private String level;
 
-        // Getters and setters for "type" and "level"
         public String getType() {
             return type;
         }


### PR DESCRIPTION
### Description
_Describe what this change achieves._
"Flattened" is the elasticsearch variant and not recognised in opensearch. This PR removes the use of "flattened" and adds the "FlatObject" property type.

This is only supported from OpenSearch version 2.7.0 onwards
https://opensearch.org/docs/latest/field-types/supported-field-types/flat-object/

### Issues Resolved
https://github.com/opensearch-project/opensearch-java/issues/720

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
