### PR TITLE
Fix missing properties on UpdateOperation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fix missing properties on UpdateOperation ([#744](https://github.com/opensearch-project/opensearch-java/pull/744))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperation.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperation.java
@@ -153,6 +153,9 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
         private Boolean scriptedUpsert;
 
         @Nullable
+        private Boolean detectNoop;
+
+        @Nullable
         private TDocument upsert;
 
         @Nullable
@@ -179,6 +182,14 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
          */
         public final Builder<TDocument> scriptedUpsert(@Nullable Boolean value) {
             this.scriptedUpsert = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code detect_noop}
+         */
+        public final Builder<TDocument> detectNoop(@Nullable Boolean value) {
+            this.detectNoop = value;
             return this;
         }
 
@@ -241,6 +252,7 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
             data = new UpdateOperationData.Builder<TDocument>().document(document)
                 .docAsUpsert(docAsUpsert)
                 .scriptedUpsert(scriptedUpsert)
+                .detectNoop(detectNoop)
                 .script(script)
                 .upsert(upsert)
                 .tDocumentSerializer(tDocumentSerializer)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperation.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperation.java
@@ -32,17 +32,20 @@
 
 package org.opensearch.client.opensearch.core.bulk;
 
-import jakarta.json.stream.JsonGenerator;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.function.Function;
+
 import javax.annotation.Nullable;
+
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.JsonpSerializer;
 import org.opensearch.client.json.NdJsonpSerializable;
 import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.ObjectBuilder;
+
+import jakarta.json.stream.JsonGenerator;
 
 // typedef: _global.bulk.UpdateOperation
 
@@ -69,7 +72,8 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
 
     }
 
-    public static <TDocument> UpdateOperation<TDocument> of(Function<Builder<TDocument>, ObjectBuilder<UpdateOperation<TDocument>>> fn) {
+    public static <TDocument> UpdateOperation<TDocument>
+        of(Function<Builder<TDocument>, ObjectBuilder<UpdateOperation<TDocument>>> fn) {
         return fn.apply(new Builder<>()).build();
     }
 
@@ -102,6 +106,7 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
         return this.retryOnConflict;
     }
 
+    @Override
     protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
         super.serializeInternal(generator, mapper);
@@ -125,7 +130,7 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
 
     public static class Builder<TDocument> extends BulkOperationBase.AbstractBuilder<Builder<TDocument>>
         implements
-            ObjectBuilder<UpdateOperation<TDocument>> {
+        ObjectBuilder<UpdateOperation<TDocument>> {
 
         private UpdateOperationData<TDocument> data;
 
@@ -143,6 +148,9 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
 
         @Nullable
         private Boolean docAsUpsert;
+
+        @Nullable
+        private Boolean scriptedUpsert;
 
         @Nullable
         private TDocument upsert;
@@ -163,6 +171,14 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
          */
         public final Builder<TDocument> docAsUpsert(@Nullable Boolean value) {
             this.docAsUpsert = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code scripted_upsert}
+         */
+        public final Builder<TDocument> scriptedUpsert(@Nullable Boolean value) {
+            this.scriptedUpsert = value;
             return this;
         }
 
@@ -218,17 +234,19 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
          * @throws NullPointerException
          *			 if some of the required fields are null.
          */
+        @Override
         public UpdateOperation<TDocument> build() {
             _checkSingleUse();
 
             data = new UpdateOperationData.Builder<TDocument>().document(document)
                 .docAsUpsert(docAsUpsert)
+                .scriptedUpsert(scriptedUpsert)
                 .script(script)
                 .upsert(upsert)
                 .tDocumentSerializer(tDocumentSerializer)
                 .build();
 
-            return new UpdateOperation<TDocument>(this);
+            return new UpdateOperation<>(this);
         }
     }
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperation.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperation.java
@@ -32,20 +32,17 @@
 
 package org.opensearch.client.opensearch.core.bulk;
 
+import jakarta.json.stream.JsonGenerator;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.function.Function;
-
 import javax.annotation.Nullable;
-
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.JsonpSerializer;
 import org.opensearch.client.json.NdJsonpSerializable;
 import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.ObjectBuilder;
-
-import jakarta.json.stream.JsonGenerator;
 
 // typedef: _global.bulk.UpdateOperation
 
@@ -72,8 +69,7 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
 
     }
 
-    public static <TDocument> UpdateOperation<TDocument>
-        of(Function<Builder<TDocument>, ObjectBuilder<UpdateOperation<TDocument>>> fn) {
+    public static <TDocument> UpdateOperation<TDocument> of(Function<Builder<TDocument>, ObjectBuilder<UpdateOperation<TDocument>>> fn) {
         return fn.apply(new Builder<>()).build();
     }
 
@@ -130,7 +126,7 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
 
     public static class Builder<TDocument> extends BulkOperationBase.AbstractBuilder<Builder<TDocument>>
         implements
-        ObjectBuilder<UpdateOperation<TDocument>> {
+            ObjectBuilder<UpdateOperation<TDocument>> {
 
         private UpdateOperationData<TDocument> data;
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperationData.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperationData.java
@@ -72,7 +72,7 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
 
         if (this.detectNoop != null) {
             generator.writeKey("detect_noop");
-            generator.write(scriptedUpsert);
+            generator.write(detectNoop);
         }
 
         if (this.document != null) {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperationData.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperationData.java
@@ -25,6 +25,9 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
     private final Boolean docAsUpsert;
 
     @Nullable
+    private final Boolean scriptedUpsert;
+
+    @Nullable
     private final TDocument upsert;
 
     @Nullable
@@ -36,6 +39,7 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
     private UpdateOperationData(Builder<TDocument> builder) {
         this.document = builder.document;
         this.docAsUpsert = builder.docAsUpsert;
+        this.scriptedUpsert = builder.scriptedUpsert;
         this.script = builder.script;
         this.upsert = builder.upsert;
         this.tDocumentSerializer = builder.tDocumentSerializer;
@@ -53,6 +57,11 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
         if (this.docAsUpsert != null) {
             generator.writeKey("doc_as_upsert");
             generator.write(this.docAsUpsert);
+        }
+
+        if (this.scriptedUpsert != null) {
+            generator.writeKey("scripted_upsert");
+            generator.write(scriptedUpsert);
         }
 
         if (this.document != null) {
@@ -88,6 +97,9 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
         private Boolean docAsUpsert;
 
         @Nullable
+        private Boolean scriptedUpsert;
+
+        @Nullable
         private TDocument upsert;
 
         @Nullable
@@ -109,6 +121,14 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
             return this;
         }
 
+        /**
+         * API name: {@code scripted_upsert}
+         */
+        public final Builder<TDocument> scriptedUpsert(@Nullable Boolean value) {
+            this.scriptedUpsert = value;
+            return this;
+        }
+        
         /**
          * API name: {@code upsert}
          */

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperationData.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperationData.java
@@ -8,16 +8,14 @@
 
 package org.opensearch.client.opensearch.core.bulk;
 
+import jakarta.json.stream.JsonGenerator;
 import javax.annotation.Nullable;
-
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.JsonpSerializable;
 import org.opensearch.client.json.JsonpSerializer;
 import org.opensearch.client.json.JsonpUtils;
 import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.util.ObjectBuilder;
-
-import jakarta.json.stream.JsonGenerator;
 
 public class UpdateOperationData<TDocument> implements JsonpSerializable {
     @Nullable
@@ -96,7 +94,7 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
      */
     public static class Builder<TDocument> extends BulkOperationBase.AbstractBuilder<Builder<TDocument>>
         implements
-        ObjectBuilder<UpdateOperationData<TDocument>> {
+            ObjectBuilder<UpdateOperationData<TDocument>> {
 
         @Nullable
         private TDocument document;

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperationData.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperationData.java
@@ -8,14 +8,16 @@
 
 package org.opensearch.client.opensearch.core.bulk;
 
-import jakarta.json.stream.JsonGenerator;
 import javax.annotation.Nullable;
+
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.JsonpSerializable;
 import org.opensearch.client.json.JsonpSerializer;
 import org.opensearch.client.json.JsonpUtils;
 import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.util.ObjectBuilder;
+
+import jakarta.json.stream.JsonGenerator;
 
 public class UpdateOperationData<TDocument> implements JsonpSerializable {
     @Nullable
@@ -26,6 +28,9 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
 
     @Nullable
     private final Boolean scriptedUpsert;
+
+    @Nullable
+    private final Boolean detectNoop;
 
     @Nullable
     private final TDocument upsert;
@@ -40,6 +45,7 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
         this.document = builder.document;
         this.docAsUpsert = builder.docAsUpsert;
         this.scriptedUpsert = builder.scriptedUpsert;
+        this.detectNoop = builder.detectNoop;
         this.script = builder.script;
         this.upsert = builder.upsert;
         this.tDocumentSerializer = builder.tDocumentSerializer;
@@ -64,6 +70,11 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
             generator.write(scriptedUpsert);
         }
 
+        if (this.detectNoop != null) {
+            generator.writeKey("detect_noop");
+            generator.write(scriptedUpsert);
+        }
+
         if (this.document != null) {
             generator.writeKey("doc");
             JsonpUtils.serialize(document, generator, tDocumentSerializer, mapper);
@@ -85,7 +96,7 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
      */
     public static class Builder<TDocument> extends BulkOperationBase.AbstractBuilder<Builder<TDocument>>
         implements
-            ObjectBuilder<UpdateOperationData<TDocument>> {
+        ObjectBuilder<UpdateOperationData<TDocument>> {
 
         @Nullable
         private TDocument document;
@@ -98,6 +109,9 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
 
         @Nullable
         private Boolean scriptedUpsert;
+
+        @Nullable
+        private Boolean detectNoop;
 
         @Nullable
         private TDocument upsert;
@@ -128,7 +142,15 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
             this.scriptedUpsert = value;
             return this;
         }
-        
+
+        /**
+         * API name: {@code detect_noop}
+         */
+        public final Builder<TDocument> detectNoop(@Nullable Boolean value) {
+            this.detectNoop = value;
+            return this;
+        }
+
         /**
          * API name: {@code upsert}
          */
@@ -165,10 +187,11 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
          * @throws NullPointerException
          *             if some of the required fields are null.
          */
+        @Override
         public UpdateOperationData<TDocument> build() {
             _checkSingleUse();
 
-            return new UpdateOperationData<TDocument>(this);
+            return new UpdateOperationData<>(this);
         }
     }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractCrudIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractCrudIT.java
@@ -392,6 +392,104 @@ public abstract class AbstractCrudIT extends OpenSearchJavaClientTestCase {
         assertTrue(getResponse.found());
         assertEquals(1337, getResponse.source().getIntValue());
     }
+    
+    public void testBulkUpdateScriptedUpsertUpdate() throws IOException {
+        final String id = "777";
+
+        final AppData appData = new AppData();
+        appData.setIntValue(1337);
+        appData.setMsg("foo");
+
+        assertEquals(Result.Created, javaClient().index(b -> b.index("index").id(id).document(appData)).result());
+
+        final BulkOperation op = new BulkOperation.Builder().update(
+            o -> o.index("index")
+                .id(id)
+                .scriptedUpsert(true)
+                .upsert(Collections.emptyMap())
+                .script(
+                    Script.of(
+                        s -> s.inline(
+                            new InlineScript.Builder().lang("painless")
+                                .source("ctx._source.intValue = ctx?._source?.intValue == null ? 7777 : 9999")
+                                .build()))))
+            .build();
+
+        BulkRequest bulkRequest = new BulkRequest.Builder().operations(op).build();
+        BulkResponse bulkResponse = javaClient().bulk(bulkRequest);
+
+        assertTrue(bulkResponse.took() > 0);
+        assertEquals(1, bulkResponse.items().size());
+
+        final GetResponse<AppData> getResponse = javaClient().get(b -> b.index("index").id(id), AppData.class);
+        assertTrue(getResponse.found());
+        assertEquals(9999, getResponse.source().getIntValue());
+    }
+
+    public void testBulkUpdateScriptedUpsertInsert() throws IOException {
+        final String id = "778";
+
+        final BulkOperation op = new BulkOperation.Builder().update(
+            o -> o.index("index")
+                .id(id)
+                .scriptedUpsert(true)
+                .upsert(Collections.emptyMap())
+                .script(
+                    Script.of(
+                        s -> s.inline(
+                            new InlineScript.Builder().lang("painless")
+                                .source("ctx._source.intValue = ctx?._source?.intValue == null ? 7777 : 9999")
+                                .build()))))
+            .build();
+
+        BulkRequest bulkRequest = new BulkRequest.Builder().operations(op).build();
+        BulkResponse bulkResponse = javaClient().bulk(bulkRequest);
+
+        assertTrue(bulkResponse.took() > 0);
+        assertEquals(1, bulkResponse.items().size());
+
+        final GetResponse<AppData> getResponse = javaClient().get(b -> b.index("index").id(id), AppData.class);
+        assertTrue(getResponse.found());
+        assertEquals(7777, getResponse.source().getIntValue());
+    }
+
+    public void testBulkUpdateDetectNoop() throws IOException {
+        final String id = "779";
+
+        final AppData appData = new AppData();
+        appData.setIntValue(1337);
+        appData.setMsg("foo");
+
+        assertEquals(Result.Created, javaClient().index(b -> b.index("index").id(id).document(appData)).result());
+
+        BulkOperation op = new BulkOperation.Builder().update(
+            o -> o.index("index")
+                .id(id)
+                .detectNoop(true)
+                .document(appData))
+            .build();
+
+        BulkRequest bulkRequest = new BulkRequest.Builder().operations(op).build();
+        BulkResponse bulkResponse = javaClient().bulk(bulkRequest);
+
+        assertTrue(bulkResponse.took() > 0);
+        assertEquals(1, bulkResponse.items().size());
+        assertEquals(Result.NoOp.jsonValue(), bulkResponse.items().get(0).result());
+
+        op = new BulkOperation.Builder().update(
+            o -> o.index("index")
+                .id(id)
+                .detectNoop(false)
+                .document(appData))
+            .build();
+
+        bulkRequest = new BulkRequest.Builder().operations(op).build();
+        bulkResponse = javaClient().bulk(bulkRequest);
+        assertTrue(bulkResponse.took() > 0);
+        assertEquals(1, bulkResponse.items().size());
+        assertEquals(Result.Updated.jsonValue(), bulkResponse.items().get(0).result());
+
+    }
 
     public void testBulkUpdateUpsert() throws IOException {
         final String id = "100";

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractCrudIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractCrudIT.java
@@ -392,7 +392,7 @@ public abstract class AbstractCrudIT extends OpenSearchJavaClientTestCase {
         assertTrue(getResponse.found());
         assertEquals(1337, getResponse.source().getIntValue());
     }
-    
+
     public void testBulkUpdateScriptedUpsertUpdate() throws IOException {
         final String id = "777";
 
@@ -412,8 +412,11 @@ public abstract class AbstractCrudIT extends OpenSearchJavaClientTestCase {
                         s -> s.inline(
                             new InlineScript.Builder().lang("painless")
                                 .source("ctx._source.intValue = ctx?._source?.intValue == null ? 7777 : 9999")
-                                .build()))))
-            .build();
+                                .build()
+                        )
+                    )
+                )
+        ).build();
 
         BulkRequest bulkRequest = new BulkRequest.Builder().operations(op).build();
         BulkResponse bulkResponse = javaClient().bulk(bulkRequest);
@@ -439,8 +442,11 @@ public abstract class AbstractCrudIT extends OpenSearchJavaClientTestCase {
                         s -> s.inline(
                             new InlineScript.Builder().lang("painless")
                                 .source("ctx._source.intValue = ctx?._source?.intValue == null ? 7777 : 9999")
-                                .build()))))
-            .build();
+                                .build()
+                        )
+                    )
+                )
+        ).build();
 
         BulkRequest bulkRequest = new BulkRequest.Builder().operations(op).build();
         BulkResponse bulkResponse = javaClient().bulk(bulkRequest);
@@ -462,12 +468,7 @@ public abstract class AbstractCrudIT extends OpenSearchJavaClientTestCase {
 
         assertEquals(Result.Created, javaClient().index(b -> b.index("index").id(id).document(appData)).result());
 
-        BulkOperation op = new BulkOperation.Builder().update(
-            o -> o.index("index")
-                .id(id)
-                .detectNoop(true)
-                .document(appData))
-            .build();
+        BulkOperation op = new BulkOperation.Builder().update(o -> o.index("index").id(id).detectNoop(true).document(appData)).build();
 
         BulkRequest bulkRequest = new BulkRequest.Builder().operations(op).build();
         BulkResponse bulkResponse = javaClient().bulk(bulkRequest);
@@ -476,12 +477,7 @@ public abstract class AbstractCrudIT extends OpenSearchJavaClientTestCase {
         assertEquals(1, bulkResponse.items().size());
         assertEquals(Result.NoOp.jsonValue(), bulkResponse.items().get(0).result());
 
-        op = new BulkOperation.Builder().update(
-            o -> o.index("index")
-                .id(id)
-                .detectNoop(false)
-                .document(appData))
-            .build();
+        op = new BulkOperation.Builder().update(o -> o.index("index").id(id).detectNoop(false).document(appData)).build();
 
         bulkRequest = new BulkRequest.Builder().operations(op).build();
         bulkResponse = javaClient().bulk(bulkRequest);


### PR DESCRIPTION
### Description
Adds missing properties `scriptedUpsert` and `detectNoop` to `UpdateOperation`

### Issues Resolved
Fixes #744 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
