### PR TITLE
add `ResponseException#status` (#756)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # CHANGELOG
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
 ## [Unreleased 2.x]
 ### Added
 - Added support for icu_collation_keyword type ([#725](https://github.com/opensearch-project/opensearch-java/pull/725))
 - Added support for flat_object field property ([#735](https://github.com/opensearch-project/opensearch-java/pull/735))
+- Expose HTTP status code through `ResponseException#status` ([#756](https://github.com/opensearch-project/opensearch-java/pull/756))
 
 ### Dependencies
 

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ResponseException.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ResponseException.java
@@ -64,7 +64,7 @@ public final class ResponseException extends IOException {
             response.getRequestLine().getMethod(),
             response.getHost(),
             response.getRequestLine().getUri(),
-            response.getStatusLine().toString()
+            response.getStatusLine()
         );
 
         if (response.hasWarnings()) {
@@ -91,5 +91,12 @@ public final class ResponseException extends IOException {
      */
     public Response getResponse() {
         return response;
+    }
+
+    /**
+     * HTTP status code returned by OpenSearch.
+     */
+    public int status() {
+        return this.response.getStatusLine().getStatusCode();
     }
 }

--- a/java-client/src/test/java/org/opensearch/client/transport/httpclient5/ResponseExceptionTest.java
+++ b/java-client/src/test/java/org/opensearch/client/transport/httpclient5/ResponseExceptionTest.java
@@ -1,0 +1,34 @@
+package org.opensearch.client.transport.httpclient5;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
+import org.apache.hc.core5.http.message.RequestLine;
+import org.junit.Test;
+
+public class ResponseExceptionTest {
+
+    @Test
+    public void testStatus() throws IOException {
+        final var response = this.buildResponseException(HttpStatus.SC_BAD_REQUEST);
+        assertThat(response.status(), equalTo(HttpStatus.SC_BAD_REQUEST));
+    }
+
+    private ResponseException buildResponseException(final int statusCode) throws IOException {
+        return new ResponseException(this.buildTestResponse(statusCode));
+    }
+
+    private Response buildTestResponse(final int statusCode) {
+        return new Response(
+            new RequestLine("GET", "/", HttpVersion.HTTP_1_1),
+            new HttpHost("localhost"),
+            new BasicClassicHttpResponse(statusCode)
+        );
+    }
+
+}


### PR DESCRIPTION
this allows accessing the HTTP status code of the response when an API returns a `ResponseException`. this was not possible through `getResponse` since `Response` itself is package-private and thus its members (even though they are marked as `public`) are not accessible to external consumers.

solves #749

Signed-off-by: Ralph Ursprung <Ralph.Ursprung@avaloq.com>
(cherry picked from commit 863518c372629b70e986eb4f2ae23cdfa482c07e)

backport of #756 
