### PR TITLE
rename _toQuery() to toQuery()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,13 +36,13 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Added
 - Added support for icu_collation_keyword type ([#725](https://github.com/opensearch-project/opensearch-java/pull/725))
 - Added support for flat_object field property ([#735](https://github.com/opensearch-project/opensearch-java/pull/735))
-
+- Added toQuery method in Query and QueryVariant ([#760](https://github.com/opensearch-project/opensearch-java/pull/760)
 ### Dependencies
 
 ### Changed
 
 ### Deprecated
-
+- deprecated _toQuery() in Query and QueryVariant ([#760](https://github.com/opensearch-project/opensearch-java/pull/760)
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Changed
 
 ### Deprecated
-- deprecated _toQuery() in Query and QueryVariant ([#760](https://github.com/opensearch-project/opensearch-java/pull/760)
+- Deprecated "_toQuery()" in Query and QueryVariant ([#760](https://github.com/opensearch-project/opensearch-java/pull/760)
 ### Removed
 
 ### Fixed

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/QueryVariant.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/QueryVariant.java
@@ -39,8 +39,12 @@ public interface QueryVariant {
 
     Query.Kind _queryKind();
 
+    @Deprecated
     default Query _toQuery() {
         return new Query(this);
     }
 
+    default Query toQuery() {
+        return new Query(this);
+    }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/experiments/api/query2/Query.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/experiments/api/query2/Query.java
@@ -50,7 +50,12 @@ import org.opensearch.client.util.TaggedUnionUtils;
 public class Query implements TaggedUnion<Query.Kind, Query.Variant>, JsonpSerializable {
 
     public interface Variant extends UnionVariant<Kind>, JsonpSerializable {
+        @Deprecated
         default Query _toQuery() {
+            return new Query(this);
+        }
+
+        default Query toQuery() {
             return new Query(this);
         }
     }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/experiments/api/query2/QueryTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/experiments/api/query2/QueryTest.java
@@ -48,7 +48,7 @@ public class QueryTest extends Assert {
         Query.Variant v = q._get();
         assertEquals(Query.Kind.Bool, v._variantType());
 
-        Query q1 = v._toQuery();
+        Query q1 = v.toQuery();
 
         Collection<Query> must = q.bool().must();
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractRequestIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractRequestIT.java
@@ -495,9 +495,9 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
                         .filter(
                             BoolQuery.of(
                                 _5 -> _5.filter(
-                                    List.of(TermsQuery.of(_6 -> _6.field("color.keyword").terms(_7 -> _7.value(fieldValues)))._toQuery())
+                                    List.of(TermsQuery.of(_6 -> _6.field("color.keyword").terms(_7 -> _7.value(fieldValues))).toQuery())
                                 )
-                            )._toQuery()
+                            ).toQuery()
                         )
                 )
         );


### PR DESCRIPTION
### Description
- Add toQuery() method with the same logic as _toQuery() in Query and QueryVariant
- add deprecated annotation on _toQuery() method

### Issues Resolved
- https://github.com/opensearch-project/opensearch-java/issues/716

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
