### PR TITLE
Fix PutIndexTemplateRequest deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Fixed
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
 - Fix PutTemplateRequest field deserialization ([#723](https://github.com/opensearch-project/opensearch-java/pull/723))
-- Fix PutIndexTemplateRequest field deserialization (...)
+- Fix PutIndexTemplateRequest field deserialization ([#765](https://github.com/opensearch-project/opensearch-java/pull/765))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Fixed
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
 - Fix PutTemplateRequest field deserialization ([#723](https://github.com/opensearch-project/opensearch-java/pull/723))
+- Fix PutIndexTemplateRequest field deserialization (...)
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/PutIndexTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/PutIndexTemplateRequest.java
@@ -406,6 +406,7 @@ public class PutIndexTemplateRequest extends RequestBase implements JsonpSeriali
         op.add(Builder::priority, JsonpDeserializer.integerDeserializer(), "priority");
         op.add(Builder::template, IndexTemplateMapping._DESERIALIZER, "template");
         op.add(Builder::version, JsonpDeserializer.longDeserializer(), "version");
+        op.add(Builder::name, JsonpDeserializer.stringDeserializer(), "name");
 
     }
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/PutIndexTemplateRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/PutIndexTemplateRequestTest.java
@@ -1,0 +1,32 @@
+package org.opensearch.client.opensearch.core;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
+
+import java.io.StringReader;
+import java.util.List;
+import java.util.Map;
+
+public class PutIndexTemplateRequestTest extends Assert {
+
+    @Test
+    public void deserialize_validFieldsIncluded_RequestIsBuilt() throws JsonProcessingException {
+        final JsonpMapper mapper = new JsonbJsonpMapper();
+        final Map<String, Object> indexTemplateMap = Map.of("name", "test", "index_patterns", "*", "create", true, "priority", 1);
+
+        final String indexTemplate = new ObjectMapper().writeValueAsString(indexTemplateMap);
+        final var parser = mapper.jsonProvider().createParser(new StringReader(indexTemplate));
+
+        final PutIndexTemplateRequest putIndexTemplateRequest = PutIndexTemplateRequest._DESERIALIZER.deserialize(parser, mapper);
+
+        assertEquals(putIndexTemplateRequest.name(), "test");
+        assertEquals(putIndexTemplateRequest.indexPatterns(), List.of("*"));
+        assertEquals((int) putIndexTemplateRequest.priority(), 1);
+    }
+
+}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/PutIndexTemplateRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/PutIndexTemplateRequestTest.java
@@ -2,15 +2,14 @@ package org.opensearch.client.opensearch.core;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.StringReader;
+import java.util.List;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
-
-import java.io.StringReader;
-import java.util.List;
-import java.util.Map;
 
 public class PutIndexTemplateRequestTest extends Assert {
 


### PR DESCRIPTION
### Description
This PR adds in the missing deserialization steps to the PutIndexTemplateRequest _DESERIALIZER which would result in the error
Missing required property 'PutIndexTemplateRequest.name' if you tried to deserialize a request object.

### Issues Resolved
Relates to issues https://github.com/opensearch-project/opensearch-java/issues/417, https://github.com/opensearch-project/opensearch-java/issues/618 and PR #723 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
