### PR TITLE
Changed SearchAfter field type to FieldValue instead of String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Changed
 - Migrate client transports to Apache HttpClient / Core 5.x ([#246](https://github.com/opensearch-project/opensearch-java/pull/246))
+- Changed SearchAfter of SearchRequest type to FieldValue instead of String ([#769](https://github.com/opensearch-project/opensearch-java/pull/769))
 
 ### Deprecated
 - Deprecate RestClientTransport ([#536](https://github.com/opensearch-project/opensearch-java/pull/536))
@@ -42,7 +43,6 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Dependencies
 
 ### Changed
-- Changed SearchAfter of SearchRequest type to FieldValue instead of String
 
 ### Deprecated
 - Deprecated "_toQuery()" in Query and QueryVariant ([#760](https://github.com/opensearch-project/opensearch-java/pull/760)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Dependencies
 
 ### Changed
+- Changed SearchAfter of SearchRequest type to FieldValue instead of String
 
 ### Deprecated
 - Deprecated "_toQuery()" in Query and QueryVariant ([#760](https://github.com/opensearch-project/opensearch-java/pull/760)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,5 +2,19 @@
 
 ## [UPGRADING 2.x to 3.0]
 ### SearchAfter of SearchRequest type
-- Changed SearchAfter of SearchRequest type to FieldValue instead of String
-- Consider using `FieldValue.of("")` to make string type values compatible.
+- Changed SearchAfter of SearchRequest type to FieldValue instead of String ([#769](https://github.com/opensearch-project/opensearch-java/pull/769))
+- Consider using `FieldValue.of` to make string type values compatible.
+
+Before:
+```
+.searchAfter("string")
+.searchAfter("string1", "string2")
+.searchAfter(List.of("String"))
+```
+
+After:
+```
+.searchAfter(FieldValue.of("string"))
+.searchAfter(FieldValue.of("string1"), FieldValue.of("string2"))
+.searchAfter(List.of(FieldValue.of("String")))
+```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,6 @@
+# UPGRADING
+
+## [UPGRADING 2.x to 3.0]
+### SearchAfter of SearchRequest type
+- Changed SearchAfter of SearchRequest type to FieldValue instead of String
+- Consider using `FieldValue.of("")` to make string type values compatible.

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
@@ -47,6 +47,7 @@ import org.opensearch.client.json.ObjectBuilderDeserializer;
 import org.opensearch.client.json.ObjectDeserializer;
 import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch._types.ExpandWildcard;
+import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.RequestBase;
 import org.opensearch.client.opensearch._types.ScriptField;
 import org.opensearch.client.opensearch._types.SearchType;
@@ -184,7 +185,7 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
     @Nullable
     private final Time scroll;
 
-    private final List<String> searchAfter;
+    private final List<FieldValue> searchAfter;
 
     @Nullable
     private final SearchType searchType;
@@ -678,7 +679,7 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
     /**
      * API name: {@code search_after}
      */
-    public final List<String> searchAfter() {
+    public final List<FieldValue> searchAfter() {
         return this.searchAfter;
     }
 
@@ -966,8 +967,8 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
         if (ApiTypeHelper.isDefined(this.searchAfter)) {
             generator.writeKey("search_after");
             generator.writeStartArray();
-            for (String item0 : this.searchAfter) {
-                generator.write(item0);
+            for (FieldValue item0 : this.searchAfter) {
+                item0.serialize(generator, mapper);
 
             }
             generator.writeEnd();
@@ -1173,7 +1174,7 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
         private Time scroll;
 
         @Nullable
-        private List<String> searchAfter;
+        private List<FieldValue> searchAfter;
 
         @Nullable
         private SearchType searchType;
@@ -1860,7 +1861,7 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
          * <p>
          * Adds all elements of <code>list</code> to <code>searchAfter</code>.
          */
-        public final Builder searchAfter(List<String> list) {
+        public final Builder searchAfter(List<FieldValue> list) {
             this.searchAfter = _listAddAll(this.searchAfter, list);
             return this;
         }
@@ -1870,7 +1871,7 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
          * <p>
          * Adds one or more values to <code>searchAfter</code>.
          */
-        public final Builder searchAfter(String value, String... values) {
+        public final Builder searchAfter(FieldValue value, FieldValue... values) {
             this.searchAfter = _listAdd(this.searchAfter, value, values);
             return this;
         }
@@ -2142,7 +2143,7 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
         op.add(Builder::rescore, JsonpDeserializer.arrayDeserializer(Rescore._DESERIALIZER), "rescore");
         op.add(Builder::runtimeMappings, JsonpDeserializer.stringMapDeserializer(RuntimeField._DESERIALIZER), "runtime_mappings");
         op.add(Builder::scriptFields, JsonpDeserializer.stringMapDeserializer(ScriptField._DESERIALIZER), "script_fields");
-        op.add(Builder::searchAfter, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "search_after");
+        op.add(Builder::searchAfter, JsonpDeserializer.arrayDeserializer(FieldValue._DESERIALIZER), "search_after");
         op.add(Builder::seqNoPrimaryTerm, JsonpDeserializer.booleanDeserializer(), "seq_no_primary_term");
         op.add(Builder::size, JsonpDeserializer.integerDeserializer(), "size");
         op.add(Builder::slice, SlicedScroll._DESERIALIZER, "slice");

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
@@ -7,11 +7,7 @@ import org.opensearch.client.opensearch.model.ModelTestCase;
 public class SearchRequestTest extends ModelTestCase {
     @Test
     public void afterSearch() {
-        SearchRequest request = new SearchRequest.Builder()
-            .searchAfter(
-                FieldValue.of(1),
-                FieldValue.of("string")
-            ).build();
+        SearchRequest request = new SearchRequest.Builder().searchAfter(FieldValue.of(1), FieldValue.of("string")).build();
 
         assertEquals("{\"search_after\":[1,\"string\"]}", toJson(request));
     }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
@@ -1,0 +1,18 @@
+package org.opensearch.client.opensearch.core;
+
+import org.junit.Test;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch.model.ModelTestCase;
+
+public class SearchRequestTest extends ModelTestCase {
+    @Test
+    public void afterSearch() {
+        SearchRequest request = new SearchRequest.Builder()
+            .searchAfter(
+                FieldValue.of(1),
+                FieldValue.of("string")
+            ).build();
+
+        assertEquals("{\"search_after\":[1,\"string\"]}", toJson(request));
+    }
+}


### PR DESCRIPTION

### Description
- Changed SearchAfter of SearchRequest type to FieldValue instead of String
- Written in the same way as other models receive various types

### Issues Resolved
https://github.com/opensearch-project/opensearch-java/issues/755

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
