### PR TITLE
[Backport] [2.x] Bump com.diffplug.spotless from 6.23.0 to 6.23.3 (#772)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Expose HTTP status code through `ResponseException#status` ([#756](https://github.com/opensearch-project/opensearch-java/pull/756))
 
 ### Dependencies
+- Bumps `com.diffplug.spotless` from 6.22.0 to 6.23.3
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -49,7 +49,7 @@ plugins {
     `maven-publish`
     id("com.github.jk1.dependency-license-report") version "2.5"
     id("org.owasp.dependencycheck") version "8.4.0"
-    id("com.diffplug.spotless") version "6.22.0"
+    id("com.diffplug.spotless") version "6.23.3"
 }
 
 apply(plugin = "org.owasp.dependencycheck")

--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -9,7 +9,7 @@
 plugins {
     java
     application
-    id("com.diffplug.spotless") version "6.22.0"
+    id("com.diffplug.spotless") version "6.23.3"
 }
 
 java {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/772 to `2.x`