### PR TITLE
Added support for 33 language analyzers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Added
 - Document HTTP/2 support ([#330](https://github.com/opensearch-project/opensearch-java/pull/330))
 - Expose HTTP status code through `ResponseException#status` ([#756](https://github.com/opensearch-project/opensearch-java/pull/756))
+- Added support for 33 new language analyzers (only Dutch existed previously) ([#000](https://github.com/opensearch-project/opensearch-java/pull/ooo))
 
 ### Dependencies
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/Analyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/Analyzer.java
@@ -62,8 +62,6 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
     public enum Kind implements JsonEnum {
         Custom("custom"),
 
-        Dutch("dutch"),
-
         Fingerprint("fingerprint"),
 
         IcuAnalyzer("icu_analyzer"),
@@ -91,6 +89,74 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
         Smartcn("smartcn"),
 
         Cjk("cjk"),
+
+        Arabic("arabic"),
+
+        Armenian("armenian"),
+
+        Basque("basque"),
+
+        Bengali("bengali"),
+
+        Brazilian("brazilian"),
+
+        Bulgarian("bulgarian"),
+
+        Catalan("catalan"),
+
+        Czech("czech"),
+
+        Danish("danish"),
+
+        Dutch("dutch"),
+
+        English("english"),
+
+        Estonian("estonian"),
+
+        Finnish("finnish"),
+
+        French("french"),
+
+        Galician("galician"),
+
+        German("german"),
+
+        Greek("greek"),
+
+        Hindi("hindi"),
+
+        Hungarian("hungarian"),
+
+        Indonesian("indonesian"),
+
+        Irish("irish"),
+
+        Italian("italian"),
+
+        Latvian("latvian"),
+
+        Lithuanian("lithuanian"),
+
+        Norwegian("norwegian"),
+
+        Persian("persian"),
+
+        Portuguese("portuguese"),
+
+        Romanian("romanian"),
+
+        Russian("russian"),
+
+        Sorani("sorani"),
+
+        Spanish("spanish"),
+
+        Swedish("swedish"),
+
+        Turkish("turkish"),
+
+        Thai("thai"),
 
         ;
 
@@ -170,6 +236,601 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
     public DutchAnalyzer dutch() {
         return TaggedUnionUtils.get(this, Kind.Dutch);
     }
+
+
+
+    /**
+     * Is this variant instance of kind {@code arabic}?
+     */
+    public boolean isArabic() {
+        return _kind == Kind.Arabic;
+    }
+
+    /**
+     * Get the {@code arabic} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code arabic} kind.
+     */
+    public ArabicAnalyzer arabic() {
+        return TaggedUnionUtils.get(this, Kind.Arabic);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code armenian}?
+     */
+    public boolean isArmenian() {
+        return _kind == Kind.Armenian;
+    }
+
+    /**
+     * Get the {@code armenian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code armenian} kind.
+     */
+    public ArmenianAnalyzer armenian() {
+        return TaggedUnionUtils.get(this, Kind.Armenian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code basque}?
+     */
+    public boolean isBasque() {
+        return _kind == Kind.Basque;
+    }
+
+    /**
+     * Get the {@code basque} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code basque} kind.
+     */
+    public BasqueAnalyzer basque() {
+        return TaggedUnionUtils.get(this, Kind.Basque);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code bengali}?
+     */
+    public boolean isBengali() {
+        return _kind == Kind.Bengali;
+    }
+
+    /**
+     * Get the {@code bengali} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code bengali} kind.
+     */
+    public BengaliAnalyzer bengali() {
+        return TaggedUnionUtils.get(this, Kind.Bengali);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code brazilian}?
+     */
+    public boolean isBrazilian() {
+        return _kind == Kind.Brazilian;
+    }
+
+    /**
+     * Get the {@code brazilian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code brazilian} kind.
+     */
+    public BrazilianAnalyzer brazilian() {
+        return TaggedUnionUtils.get(this, Kind.Brazilian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code bulgarian}?
+     */
+    public boolean isBulgarian() {
+        return _kind == Kind.Bulgarian;
+    }
+
+    /**
+     * Get the {@code bulgarian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code bulgarian} kind.
+     */
+    public BulgarianAnalyzer bulgarian() {
+        return TaggedUnionUtils.get(this, Kind.Bulgarian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code catalan}?
+     */
+    public boolean isCatalan() {
+        return _kind == Kind.Catalan;
+    }
+
+    /**
+     * Get the {@code catalan} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code catalan} kind.
+     */
+    public CatalanAnalyzer catalan() {
+        return TaggedUnionUtils.get(this, Kind.Catalan);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code czech}?
+     */
+    public boolean isCzech() {
+        return _kind == Kind.Czech;
+    }
+
+    /**
+     * Get the {@code czech} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code czech} kind.
+     */
+    public CzechAnalyzer czech() {
+        return TaggedUnionUtils.get(this, Kind.Czech);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code danish}?
+     */
+    public boolean isDanish() {
+        return _kind == Kind.Danish;
+    }
+
+    /**
+     * Get the {@code danish} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code danish} kind.
+     */
+    public DanishAnalyzer danish() {
+        return TaggedUnionUtils.get(this, Kind.Danish);
+    }
+
+    /**
+     * Is this variant instance of kind {@code english}?
+     */
+    public boolean isEnglish() {
+        return _kind == Kind.English;
+    }
+
+    /**
+     * Get the {@code english} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code english} kind.
+     */
+    public EnglishAnalyzer english() {
+        return TaggedUnionUtils.get(this, Kind.English);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code estonian}?
+     */
+    public boolean isEstonian() {
+        return _kind == Kind.Estonian;
+    }
+
+    /**
+     * Get the {@code estonian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code estonian} kind.
+     */
+    public EstonianAnalyzer estonian() {
+        return TaggedUnionUtils.get(this, Kind.Estonian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code finnish}?
+     */
+    public boolean isFinnish() {
+        return _kind == Kind.Finnish;
+    }
+
+    /**
+     * Get the {@code finnish} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code finnish} kind.
+     */
+    public FinnishAnalyzer finnish() {
+        return TaggedUnionUtils.get(this, Kind.Finnish);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code french}?
+     */
+    public boolean isFrench() {
+        return _kind == Kind.French;
+    }
+
+    /**
+     * Get the {@code french} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code french} kind.
+     */
+    public FrenchAnalyzer french() {
+        return TaggedUnionUtils.get(this, Kind.French);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code galician}?
+     */
+    public boolean isGalician() {
+        return _kind == Kind.Galician;
+    }
+
+    /**
+     * Get the {@code galician} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code galician} kind.
+     */
+    public GalicianAnalyzer galician() {
+        return TaggedUnionUtils.get(this, Kind.Galician);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code german}?
+     */
+    public boolean isGerman() {
+        return _kind == Kind.German;
+    }
+
+    /**
+     * Get the {@code german} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code german} kind.
+     */
+    public GermanAnalyzer german() {
+        return TaggedUnionUtils.get(this, Kind.German);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code greek}?
+     */
+    public boolean isGreek() {
+        return _kind == Kind.Greek;
+    }
+
+    /**
+     * Get the {@code greek} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code greek} kind.
+     */
+    public GreekAnalyzer greek() {
+        return TaggedUnionUtils.get(this, Kind.Greek);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code hindi}?
+     */
+    public boolean isHindi() {
+        return _kind == Kind.Hindi;
+    }
+
+    /**
+     * Get the {@code hindi} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code hindi} kind.
+     */
+    public HindiAnalyzer hindi() {
+        return TaggedUnionUtils.get(this, Kind.Hindi);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code hungarian}?
+     */
+    public boolean isHungarian() {
+        return _kind == Kind.Hungarian;
+    }
+
+    /**
+     * Get the {@code hungarian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code hungarian} kind.
+     */
+    public HungarianAnalyzer hungarian() {
+        return TaggedUnionUtils.get(this, Kind.Hungarian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code indonesian}?
+     */
+    public boolean isIndonesian() {
+        return _kind == Kind.Indonesian;
+    }
+
+    /**
+     * Get the {@code indonesian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code indonesian} kind.
+     */
+    public IndonesianAnalyzer indonesian() {
+        return TaggedUnionUtils.get(this, Kind.Indonesian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code irish}?
+     */
+    public boolean isIrish() {
+        return _kind == Kind.Irish;
+    }
+
+    /**
+     * Get the {@code irish} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code irish} kind.
+     */
+    public IrishAnalyzer irish() {
+        return TaggedUnionUtils.get(this, Kind.Irish);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code italian}?
+     */
+    public boolean isItalian() {
+        return _kind == Kind.Italian;
+    }
+
+    /**
+     * Get the {@code italian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code italian} kind.
+     */
+    public ItalianAnalyzer italian() {
+        return TaggedUnionUtils.get(this, Kind.Italian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code latvian}?
+     */
+    public boolean isLatvian() {
+        return _kind == Kind.Latvian;
+    }
+
+    /**
+     * Get the {@code latvian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code latvian} kind.
+     */
+    public LatvianAnalyzer latvian() {
+        return TaggedUnionUtils.get(this, Kind.Latvian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code lithuanian}?
+     */
+    public boolean isLithuanian() {
+        return _kind == Kind.Lithuanian;
+    }
+
+    /**
+     * Get the {@code lithuanian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code lithuanian} kind.
+     */
+    public LithuanianAnalyzer lithuanian() {
+        return TaggedUnionUtils.get(this, Kind.Lithuanian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code norwegian}?
+     */
+    public boolean isNorwegian() {
+        return _kind == Kind.Norwegian;
+    }
+
+    /**
+     * Get the {@code norwegian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code norwegian} kind.
+     */
+    public NorwegianAnalyzer norwegian() {
+        return TaggedUnionUtils.get(this, Kind.Norwegian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code persian}?
+     */
+    public boolean isPersian() {
+        return _kind == Kind.Persian;
+    }
+
+    /**
+     * Get the {@code persian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code persian} kind.
+     */
+    public PersianAnalyzer persian() {
+        return TaggedUnionUtils.get(this, Kind.Persian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code portuguese}?
+     */
+    public boolean isPortuguese() {
+        return _kind == Kind.Portuguese;
+    }
+
+    /**
+     * Get the {@code portuguese} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code portuguese} kind.
+     */
+    public PortugueseAnalyzer portuguese() {
+        return TaggedUnionUtils.get(this, Kind.Portuguese);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code romanian}?
+     */
+    public boolean isRomanian() {
+        return _kind == Kind.Romanian;
+    }
+
+    /**
+     * Get the {@code romanian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code romanian} kind.
+     */
+    public RomanianAnalyzer romanian() {
+        return TaggedUnionUtils.get(this, Kind.Romanian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code russian}?
+     */
+    public boolean isRussian() {
+        return _kind == Kind.Russian;
+    }
+
+    /**
+     * Get the {@code russian} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code russian} kind.
+     */
+    public RussianAnalyzer russian() {
+        return TaggedUnionUtils.get(this, Kind.Russian);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code sorani}?
+     */
+    public boolean isSorani() {
+        return _kind == Kind.Sorani;
+    }
+
+    /**
+     * Get the {@code sorani} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code sorani} kind.
+     */
+    public SoraniAnalyzer sorani() {
+        return TaggedUnionUtils.get(this, Kind.Sorani);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code spanish}?
+     */
+    public boolean isSpanish() {
+        return _kind == Kind.Spanish;
+    }
+
+    /**
+     * Get the {@code spanish} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code spanish} kind.
+     */
+    public SpanishAnalyzer spanish() {
+        return TaggedUnionUtils.get(this, Kind.Spanish);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code swedish}?
+     */
+    public boolean isSwedish() {
+        return _kind == Kind.Swedish;
+    }
+
+    /**
+     * Get the {@code swedish} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code swedish} kind.
+     */
+    public SwedishAnalyzer swedish() {
+        return TaggedUnionUtils.get(this, Kind.Swedish);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code turkish}?
+     */
+    public boolean isTurkish() {
+        return _kind == Kind.Turkish;
+    }
+
+    /**
+     * Get the {@code turkish} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code turkish} kind.
+     */
+    public TurkishAnalyzer turkish() {
+        return TaggedUnionUtils.get(this, Kind.Turkish);
+    }
+
+
+    /**
+     * Is this variant instance of kind {@code thai}?
+     */
+    public boolean isThai() {
+        return _kind == Kind.Thai;
+    }
+
+    /**
+     * Get the {@code thai} variant value.
+     *
+     * @throws IllegalStateException
+     *      if the current variant is not of the {@code thai} kind.
+     */
+    public ThaiAnalyzer thai() {
+        return TaggedUnionUtils.get(this, Kind.Thai);
+    }
+
 
     /**
      * Is this variant instance of kind {@code fingerprint}?
@@ -440,6 +1101,336 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
             return this.dutch(fn.apply(new DutchAnalyzer.Builder()).build());
         }
 
+        public ObjectBuilder<Analyzer> arabic(ArabicAnalyzer v) {
+            this._kind = Kind.Arabic;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> arabic(Function<ArabicAnalyzer.Builder, ObjectBuilder<ArabicAnalyzer>> fn) {
+            return this.arabic(fn.apply(new ArabicAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> armenian(ArmenianAnalyzer v) {
+            this._kind = Kind.Armenian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> armenian(Function<ArmenianAnalyzer.Builder, ObjectBuilder<ArmenianAnalyzer>> fn) {
+            return this.armenian(fn.apply(new ArmenianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> basque(BasqueAnalyzer v) {
+            this._kind = Kind.Basque;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> basque(Function<BasqueAnalyzer.Builder, ObjectBuilder<BasqueAnalyzer>> fn) {
+            return this.basque(fn.apply(new BasqueAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> bengali(BengaliAnalyzer v) {
+            this._kind = Kind.Bengali;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> bengali(Function<BengaliAnalyzer.Builder, ObjectBuilder<BengaliAnalyzer>> fn) {
+            return this.bengali(fn.apply(new BengaliAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> brazilian(BrazilianAnalyzer v) {
+            this._kind = Kind.Brazilian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> brazilian(Function<BrazilianAnalyzer.Builder, ObjectBuilder<BrazilianAnalyzer>> fn) {
+            return this.brazilian(fn.apply(new BrazilianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> bulgarian(BulgarianAnalyzer v) {
+            this._kind = Kind.Bulgarian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> bulgarian(Function<BulgarianAnalyzer.Builder, ObjectBuilder<BulgarianAnalyzer>> fn) {
+            return this.bulgarian(fn.apply(new BulgarianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> catalan(CatalanAnalyzer v) {
+            this._kind = Kind.Catalan;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> catalan(Function<CatalanAnalyzer.Builder, ObjectBuilder<CatalanAnalyzer>> fn) {
+            return this.catalan(fn.apply(new CatalanAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> czech(CzechAnalyzer v) {
+            this._kind = Kind.Czech;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> czech(Function<CzechAnalyzer.Builder, ObjectBuilder<CzechAnalyzer>> fn) {
+            return this.czech(fn.apply(new CzechAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> danish(DanishAnalyzer v) {
+            this._kind = Kind.Danish;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> danish(Function<DanishAnalyzer.Builder, ObjectBuilder<DanishAnalyzer>> fn) {
+            return this.danish(fn.apply(new DanishAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> english(EnglishAnalyzer v) {
+            this._kind = Kind.English;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> english(Function<EnglishAnalyzer.Builder, ObjectBuilder<EnglishAnalyzer>> fn) {
+            return this.english(fn.apply(new EnglishAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> estonian(EstonianAnalyzer v) {
+            this._kind = Kind.Estonian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> estonian(Function<EstonianAnalyzer.Builder, ObjectBuilder<EstonianAnalyzer>> fn) {
+            return this.estonian(fn.apply(new EstonianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> finnish(FinnishAnalyzer v) {
+            this._kind = Kind.Finnish;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> finnish(Function<FinnishAnalyzer.Builder, ObjectBuilder<FinnishAnalyzer>> fn) {
+            return this.finnish(fn.apply(new FinnishAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> french(FrenchAnalyzer v) {
+            this._kind = Kind.French;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> french(Function<FrenchAnalyzer.Builder, ObjectBuilder<FrenchAnalyzer>> fn) {
+            return this.french(fn.apply(new FrenchAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> galician(GalicianAnalyzer v) {
+            this._kind = Kind.Galician;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> galician(Function<GalicianAnalyzer.Builder, ObjectBuilder<GalicianAnalyzer>> fn) {
+            return this.galician(fn.apply(new GalicianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> german(GermanAnalyzer v) {
+            this._kind = Kind.German;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> german(Function<GermanAnalyzer.Builder, ObjectBuilder<GermanAnalyzer>> fn) {
+            return this.german(fn.apply(new GermanAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> greek(GreekAnalyzer v) {
+            this._kind = Kind.Greek;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> greek(Function<GreekAnalyzer.Builder, ObjectBuilder<GreekAnalyzer>> fn) {
+            return this.greek(fn.apply(new GreekAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> hindi(HindiAnalyzer v) {
+            this._kind = Kind.Hindi;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> hindi(Function<HindiAnalyzer.Builder, ObjectBuilder<HindiAnalyzer>> fn) {
+            return this.hindi(fn.apply(new HindiAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> hungarian(HungarianAnalyzer v) {
+            this._kind = Kind.Hungarian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> hungarian(Function<HungarianAnalyzer.Builder, ObjectBuilder<HungarianAnalyzer>> fn) {
+            return this.hungarian(fn.apply(new HungarianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> indonesian(IndonesianAnalyzer v) {
+            this._kind = Kind.Indonesian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> indonesian(Function<IndonesianAnalyzer.Builder, ObjectBuilder<IndonesianAnalyzer>> fn) {
+            return this.indonesian(fn.apply(new IndonesianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> irish(IrishAnalyzer v) {
+            this._kind = Kind.Irish;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> irish(Function<IrishAnalyzer.Builder, ObjectBuilder<IrishAnalyzer>> fn) {
+            return this.irish(fn.apply(new IrishAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> italian(ItalianAnalyzer v) {
+            this._kind = Kind.Italian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> italian(Function<ItalianAnalyzer.Builder, ObjectBuilder<ItalianAnalyzer>> fn) {
+            return this.italian(fn.apply(new ItalianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> latvian(LatvianAnalyzer v) {
+            this._kind = Kind.Latvian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> latvian(Function<LatvianAnalyzer.Builder, ObjectBuilder<LatvianAnalyzer>> fn) {
+            return this.latvian(fn.apply(new LatvianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> lithuanian(LithuanianAnalyzer v) {
+            this._kind = Kind.Lithuanian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> lithuanian(Function<LithuanianAnalyzer.Builder, ObjectBuilder<LithuanianAnalyzer>> fn) {
+            return this.lithuanian(fn.apply(new LithuanianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> norwegian(NorwegianAnalyzer v) {
+            this._kind = Kind.Norwegian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> norwegian(Function<NorwegianAnalyzer.Builder, ObjectBuilder<NorwegianAnalyzer>> fn) {
+            return this.norwegian(fn.apply(new NorwegianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> persian(PersianAnalyzer v) {
+            this._kind = Kind.Persian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> persian(Function<PersianAnalyzer.Builder, ObjectBuilder<PersianAnalyzer>> fn) {
+            return this.persian(fn.apply(new PersianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> portuguese(PortugueseAnalyzer v) {
+            this._kind = Kind.Portuguese;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> portuguese(Function<PortugueseAnalyzer.Builder, ObjectBuilder<PortugueseAnalyzer>> fn) {
+            return this.portuguese(fn.apply(new PortugueseAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> romanian(RomanianAnalyzer v) {
+            this._kind = Kind.Romanian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> romanian(Function<RomanianAnalyzer.Builder, ObjectBuilder<RomanianAnalyzer>> fn) {
+            return this.romanian(fn.apply(new RomanianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> russian(RussianAnalyzer v) {
+            this._kind = Kind.Russian;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> russian(Function<RussianAnalyzer.Builder, ObjectBuilder<RussianAnalyzer>> fn) {
+            return this.russian(fn.apply(new RussianAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> sorani(SoraniAnalyzer v) {
+            this._kind = Kind.Sorani;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> sorani(Function<SoraniAnalyzer.Builder, ObjectBuilder<SoraniAnalyzer>> fn) {
+            return this.sorani(fn.apply(new SoraniAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> spanish(SpanishAnalyzer v) {
+            this._kind = Kind.Spanish;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> spanish(Function<SpanishAnalyzer.Builder, ObjectBuilder<SpanishAnalyzer>> fn) {
+            return this.spanish(fn.apply(new SpanishAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> swedish(SwedishAnalyzer v) {
+            this._kind = Kind.Swedish;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> swedish(Function<SwedishAnalyzer.Builder, ObjectBuilder<SwedishAnalyzer>> fn) {
+            return this.swedish(fn.apply(new SwedishAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> turkish(TurkishAnalyzer v) {
+            this._kind = Kind.Turkish;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> turkish(Function<TurkishAnalyzer.Builder, ObjectBuilder<TurkishAnalyzer>> fn) {
+            return this.turkish(fn.apply(new TurkishAnalyzer.Builder()).build());
+        }
+
+        public ObjectBuilder<Analyzer> thai(ThaiAnalyzer v) {
+            this._kind = Kind.Thai;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Analyzer> thai(Function<ThaiAnalyzer.Builder, ObjectBuilder<ThaiAnalyzer>> fn) {
+            return this.thai(fn.apply(new ThaiAnalyzer.Builder()).build());
+        }
+
         public ObjectBuilder<Analyzer> fingerprint(FingerprintAnalyzer v) {
             this._kind = Kind.Fingerprint;
             this._value = v;
@@ -591,6 +1582,39 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
 
         op.add(Builder::custom, CustomAnalyzer._DESERIALIZER, "custom");
         op.add(Builder::dutch, DutchAnalyzer._DESERIALIZER, "dutch");
+        op.add(Builder::arabic, ArabicAnalyzer._DESERIALIZER, "arabic");
+        op.add(Builder::armenian, ArmenianAnalyzer._DESERIALIZER, "armenian");
+        op.add(Builder::basque, BasqueAnalyzer._DESERIALIZER, "basque");
+        op.add(Builder::bengali, BengaliAnalyzer._DESERIALIZER, "bengali");
+        op.add(Builder::brazilian, BrazilianAnalyzer._DESERIALIZER, "brazilian");
+        op.add(Builder::bulgarian, BulgarianAnalyzer._DESERIALIZER, "bulgarian");
+        op.add(Builder::catalan, CatalanAnalyzer._DESERIALIZER, "catalan");
+        op.add(Builder::czech, CzechAnalyzer._DESERIALIZER, "czech");
+        op.add(Builder::danish, DanishAnalyzer._DESERIALIZER, "danish");
+        op.add(Builder::english, EnglishAnalyzer._DESERIALIZER, "english");
+        op.add(Builder::estonian, EstonianAnalyzer._DESERIALIZER, "estonian");
+        op.add(Builder::finnish, FinnishAnalyzer._DESERIALIZER, "finnish");
+        op.add(Builder::french, FrenchAnalyzer._DESERIALIZER, "french");
+        op.add(Builder::galician, GalicianAnalyzer._DESERIALIZER, "galician");
+        op.add(Builder::german, GermanAnalyzer._DESERIALIZER, "german");
+        op.add(Builder::greek, GreekAnalyzer._DESERIALIZER, "greek");
+        op.add(Builder::hindi, HindiAnalyzer._DESERIALIZER, "hindi");
+        op.add(Builder::hungarian, HungarianAnalyzer._DESERIALIZER, "hungarian");
+        op.add(Builder::indonesian, IndonesianAnalyzer._DESERIALIZER, "indonesian");
+        op.add(Builder::irish, IrishAnalyzer._DESERIALIZER, "irish");
+        op.add(Builder::italian, ItalianAnalyzer._DESERIALIZER, "italian");
+        op.add(Builder::latvian, LatvianAnalyzer._DESERIALIZER, "latvian");
+        op.add(Builder::lithuanian, LithuanianAnalyzer._DESERIALIZER, "lithuanian");
+        op.add(Builder::norwegian, NorwegianAnalyzer._DESERIALIZER, "norwegian");
+        op.add(Builder::persian, PersianAnalyzer._DESERIALIZER, "persian");
+        op.add(Builder::portuguese, PortugueseAnalyzer._DESERIALIZER, "portuguese");
+        op.add(Builder::romanian, RomanianAnalyzer._DESERIALIZER, "romanian");
+        op.add(Builder::russian, RussianAnalyzer._DESERIALIZER, "russian");
+        op.add(Builder::sorani, SoraniAnalyzer._DESERIALIZER, "sorani");
+        op.add(Builder::spanish, SpanishAnalyzer._DESERIALIZER, "spanish");
+        op.add(Builder::swedish, SwedishAnalyzer._DESERIALIZER, "swedish");
+        op.add(Builder::turkish, TurkishAnalyzer._DESERIALIZER, "turkish");
+        op.add(Builder::thai, ThaiAnalyzer._DESERIALIZER, "thai");
         op.add(Builder::fingerprint, FingerprintAnalyzer._DESERIALIZER, "fingerprint");
         op.add(Builder::icuAnalyzer, IcuAnalyzer._DESERIALIZER, "icu_analyzer");
         op.add(Builder::keyword, KeywordAnalyzer._DESERIALIZER, "keyword");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/ArabicAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/ArabicAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.ArabicAnalyzer
+
+@JsonpDeserializable
+public class ArabicAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private ArabicAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static ArabicAnalyzer of(Function<Builder, ObjectBuilder<ArabicAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Arabic;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "arabic");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link ArabicAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ArabicAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link ArabicAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public ArabicAnalyzer build() {
+            _checkSingleUse();
+
+            return new ArabicAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link ArabicAnalyzer}
+     */
+    public static final JsonpDeserializer<ArabicAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        ArabicAnalyzer::setupArabicAnalyzerDeserializer
+    );
+
+    protected static void setupArabicAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/ArmenianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/ArmenianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.ArmenianAnalyzer
+
+@JsonpDeserializable
+public class ArmenianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private ArmenianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static ArmenianAnalyzer of(Function<Builder, ObjectBuilder<ArmenianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Armenian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "armenian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link ArmenianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ArmenianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link ArmenianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public ArmenianAnalyzer build() {
+            _checkSingleUse();
+
+            return new ArmenianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link ArmenianAnalyzer}
+     */
+    public static final JsonpDeserializer<ArmenianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        ArmenianAnalyzer::setupArmenianAnalyzerDeserializer
+    );
+
+    protected static void setupArmenianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/BasqueAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/BasqueAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.BasqueAnalyzer
+
+@JsonpDeserializable
+public class BasqueAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private BasqueAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static BasqueAnalyzer of(Function<Builder, ObjectBuilder<BasqueAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Basque;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "basque");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link BasqueAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<BasqueAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link BasqueAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public BasqueAnalyzer build() {
+            _checkSingleUse();
+
+            return new BasqueAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link BasqueAnalyzer}
+     */
+    public static final JsonpDeserializer<BasqueAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        BasqueAnalyzer::setupBasqueAnalyzerDeserializer
+    );
+
+    protected static void setupBasqueAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/BengaliAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/BengaliAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.BengaliAnalyzer
+
+@JsonpDeserializable
+public class BengaliAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private BengaliAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static BengaliAnalyzer of(Function<Builder, ObjectBuilder<BengaliAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Bengali;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "bengali");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link BengaliAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<BengaliAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link BengaliAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public BengaliAnalyzer build() {
+            _checkSingleUse();
+
+            return new BengaliAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link BengaliAnalyzer}
+     */
+    public static final JsonpDeserializer<BengaliAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        BengaliAnalyzer::setupBengaliAnalyzerDeserializer
+    );
+
+    protected static void setupBengaliAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/BrazilianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/BrazilianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.BrazilianAnalyzer
+
+@JsonpDeserializable
+public class BrazilianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private BrazilianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static BrazilianAnalyzer of(Function<Builder, ObjectBuilder<BrazilianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Brazilian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "brazilian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link BrazilianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<BrazilianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link BrazilianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public BrazilianAnalyzer build() {
+            _checkSingleUse();
+
+            return new BrazilianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link BrazilianAnalyzer}
+     */
+    public static final JsonpDeserializer<BrazilianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        BrazilianAnalyzer::setupBrazilianAnalyzerDeserializer
+    );
+
+    protected static void setupBrazilianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/BulgarianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/BulgarianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.BulgarianAnalyzer
+
+@JsonpDeserializable
+public class BulgarianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private BulgarianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static BulgarianAnalyzer of(Function<Builder, ObjectBuilder<BulgarianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Bulgarian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "bulgarian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link BulgarianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<BulgarianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link BulgarianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public BulgarianAnalyzer build() {
+            _checkSingleUse();
+
+            return new BulgarianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link BulgarianAnalyzer}
+     */
+    public static final JsonpDeserializer<BulgarianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        BulgarianAnalyzer::setupBulgarianAnalyzerDeserializer
+    );
+
+    protected static void setupBulgarianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/CatalanAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/CatalanAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.CatalanAnalyzer
+
+@JsonpDeserializable
+public class CatalanAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private CatalanAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static CatalanAnalyzer of(Function<Builder, ObjectBuilder<CatalanAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Catalan;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "catalan");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link CatalanAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CatalanAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link CatalanAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public CatalanAnalyzer build() {
+            _checkSingleUse();
+
+            return new CatalanAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link CatalanAnalyzer}
+     */
+    public static final JsonpDeserializer<CatalanAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        CatalanAnalyzer::setupCatalanAnalyzerDeserializer
+    );
+
+    protected static void setupCatalanAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/CzechAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/CzechAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.CzechAnalyzer
+
+@JsonpDeserializable
+public class CzechAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private CzechAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static CzechAnalyzer of(Function<Builder, ObjectBuilder<CzechAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Czech;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "czech");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link CzechAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CzechAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link CzechAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public CzechAnalyzer build() {
+            _checkSingleUse();
+
+            return new CzechAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link CzechAnalyzer}
+     */
+    public static final JsonpDeserializer<CzechAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        CzechAnalyzer::setupCzechAnalyzerDeserializer
+    );
+
+    protected static void setupCzechAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/DanishAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/DanishAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.DanishAnalyzer
+
+@JsonpDeserializable
+public class DanishAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private DanishAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static DanishAnalyzer of(Function<Builder, ObjectBuilder<DanishAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Danish;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "danish");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link DanishAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DanishAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link DanishAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public DanishAnalyzer build() {
+            _checkSingleUse();
+
+            return new DanishAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link DanishAnalyzer}
+     */
+    public static final JsonpDeserializer<DanishAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        DanishAnalyzer::setupDanishAnalyzerDeserializer
+    );
+
+    protected static void setupDanishAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/EnglishAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/EnglishAnalyzer.java
@@ -1,0 +1,164 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import org.opensearch.client.json.*;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.function.Function;
+
+// typedef: _types.analysis.EnglishAnalyzer
+
+@JsonpDeserializable
+public class EnglishAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private EnglishAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static EnglishAnalyzer of(Function<Builder, ObjectBuilder<EnglishAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.English;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "english");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link EnglishAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<EnglishAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link EnglishAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public EnglishAnalyzer build() {
+            _checkSingleUse();
+
+            return new EnglishAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link EnglishAnalyzer}
+     */
+    public static final JsonpDeserializer<EnglishAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        EnglishAnalyzer::setupEnglishAnalyzerDeserializer
+    );
+
+    protected static void setupEnglishAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/EstonianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/EstonianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.EstonianAnalyzer
+
+@JsonpDeserializable
+public class EstonianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private EstonianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static EstonianAnalyzer of(Function<Builder, ObjectBuilder<EstonianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Estonian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "estonian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link EstonianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<EstonianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link EstonianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public EstonianAnalyzer build() {
+            _checkSingleUse();
+
+            return new EstonianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link EstonianAnalyzer}
+     */
+    public static final JsonpDeserializer<EstonianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        EstonianAnalyzer::setupEstonianAnalyzerDeserializer
+    );
+
+    protected static void setupEstonianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/FinnishAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/FinnishAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.FinnishAnalyzer
+
+@JsonpDeserializable
+public class FinnishAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private FinnishAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static FinnishAnalyzer of(Function<Builder, ObjectBuilder<FinnishAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Finnish;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "finnish");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link FinnishAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<FinnishAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link FinnishAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public FinnishAnalyzer build() {
+            _checkSingleUse();
+
+            return new FinnishAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link FinnishAnalyzer}
+     */
+    public static final JsonpDeserializer<FinnishAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        FinnishAnalyzer::setupFinnishAnalyzerDeserializer
+    );
+
+    protected static void setupFinnishAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/FrenchAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/FrenchAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.FrenchAnalyzer
+
+@JsonpDeserializable
+public class FrenchAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private FrenchAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static FrenchAnalyzer of(Function<Builder, ObjectBuilder<FrenchAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.French;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "french");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link FrenchAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<FrenchAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link FrenchAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public FrenchAnalyzer build() {
+            _checkSingleUse();
+
+            return new FrenchAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link FrenchAnalyzer}
+     */
+    public static final JsonpDeserializer<FrenchAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        FrenchAnalyzer::setupFrenchAnalyzerDeserializer
+    );
+
+    protected static void setupFrenchAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/GalicianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/GalicianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.GalicianAnalyzer
+
+@JsonpDeserializable
+public class GalicianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private GalicianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static GalicianAnalyzer of(Function<Builder, ObjectBuilder<GalicianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Galician;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "galician");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link GalicianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GalicianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link GalicianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public GalicianAnalyzer build() {
+            _checkSingleUse();
+
+            return new GalicianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link GalicianAnalyzer}
+     */
+    public static final JsonpDeserializer<GalicianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        GalicianAnalyzer::setupGalicianAnalyzerDeserializer
+    );
+
+    protected static void setupGalicianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/GermanAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/GermanAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.GermanAnalyzer
+
+@JsonpDeserializable
+public class GermanAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private GermanAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static GermanAnalyzer of(Function<Builder, ObjectBuilder<GermanAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.German;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "german");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link GermanAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GermanAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link GermanAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public GermanAnalyzer build() {
+            _checkSingleUse();
+
+            return new GermanAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link GermanAnalyzer}
+     */
+    public static final JsonpDeserializer<GermanAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        GermanAnalyzer::setupGermanAnalyzerDeserializer
+    );
+
+    protected static void setupGermanAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/GreekAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/GreekAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.GreekAnalyzer
+
+@JsonpDeserializable
+public class GreekAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private GreekAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static GreekAnalyzer of(Function<Builder, ObjectBuilder<GreekAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Greek;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "greek");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link GreekAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GreekAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link GreekAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public GreekAnalyzer build() {
+            _checkSingleUse();
+
+            return new GreekAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link GreekAnalyzer}
+     */
+    public static final JsonpDeserializer<GreekAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        GreekAnalyzer::setupGreekAnalyzerDeserializer
+    );
+
+    protected static void setupGreekAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/HindiAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/HindiAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.HindiAnalyzer
+
+@JsonpDeserializable
+public class HindiAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private HindiAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static HindiAnalyzer of(Function<Builder, ObjectBuilder<HindiAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Hindi;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "hindi");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link HindiAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<HindiAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link HindiAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public HindiAnalyzer build() {
+            _checkSingleUse();
+
+            return new HindiAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link HindiAnalyzer}
+     */
+    public static final JsonpDeserializer<HindiAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        HindiAnalyzer::setupHindiAnalyzerDeserializer
+    );
+
+    protected static void setupHindiAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/HungarianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/HungarianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.HungarianAnalyzer
+
+@JsonpDeserializable
+public class HungarianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private HungarianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static HungarianAnalyzer of(Function<Builder, ObjectBuilder<HungarianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Hungarian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "hungarian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link HungarianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<HungarianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link HungarianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public HungarianAnalyzer build() {
+            _checkSingleUse();
+
+            return new HungarianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link HungarianAnalyzer}
+     */
+    public static final JsonpDeserializer<HungarianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        HungarianAnalyzer::setupHungarianAnalyzerDeserializer
+    );
+
+    protected static void setupHungarianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/IndonesianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/IndonesianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.IndonesianAnalyzer
+
+@JsonpDeserializable
+public class IndonesianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private IndonesianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static IndonesianAnalyzer of(Function<Builder, ObjectBuilder<IndonesianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Indonesian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "indonesian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link IndonesianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<IndonesianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link IndonesianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public IndonesianAnalyzer build() {
+            _checkSingleUse();
+
+            return new IndonesianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link IndonesianAnalyzer}
+     */
+    public static final JsonpDeserializer<IndonesianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        IndonesianAnalyzer::setupIndonesianAnalyzerDeserializer
+    );
+
+    protected static void setupIndonesianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/IrishAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/IrishAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.IrishAnalyzer
+
+@JsonpDeserializable
+public class IrishAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private IrishAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static IrishAnalyzer of(Function<Builder, ObjectBuilder<IrishAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Irish;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "irish");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link IrishAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<IrishAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link IrishAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public IrishAnalyzer build() {
+            _checkSingleUse();
+
+            return new IrishAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link IrishAnalyzer}
+     */
+    public static final JsonpDeserializer<IrishAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        IrishAnalyzer::setupIrishAnalyzerDeserializer
+    );
+
+    protected static void setupIrishAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/ItalianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/ItalianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.ItalianAnalyzer
+
+@JsonpDeserializable
+public class ItalianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private ItalianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static ItalianAnalyzer of(Function<Builder, ObjectBuilder<ItalianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Italian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "italian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link ItalianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ItalianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link ItalianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public ItalianAnalyzer build() {
+            _checkSingleUse();
+
+            return new ItalianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link ItalianAnalyzer}
+     */
+    public static final JsonpDeserializer<ItalianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        ItalianAnalyzer::setupItalianAnalyzerDeserializer
+    );
+
+    protected static void setupItalianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/LatvianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/LatvianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.LatvianAnalyzer
+
+@JsonpDeserializable
+public class LatvianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private LatvianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static LatvianAnalyzer of(Function<Builder, ObjectBuilder<LatvianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Latvian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "latvian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link LatvianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<LatvianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link LatvianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public LatvianAnalyzer build() {
+            _checkSingleUse();
+
+            return new LatvianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link LatvianAnalyzer}
+     */
+    public static final JsonpDeserializer<LatvianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        LatvianAnalyzer::setupLatvianAnalyzerDeserializer
+    );
+
+    protected static void setupLatvianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/LithuanianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/LithuanianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.LithuanianAnalyzer
+
+@JsonpDeserializable
+public class LithuanianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private LithuanianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static LithuanianAnalyzer of(Function<Builder, ObjectBuilder<LithuanianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Lithuanian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "lithuanian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link LithuanianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<LithuanianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link LithuanianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public LithuanianAnalyzer build() {
+            _checkSingleUse();
+
+            return new LithuanianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link LithuanianAnalyzer}
+     */
+    public static final JsonpDeserializer<LithuanianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        LithuanianAnalyzer::setupLithuanianAnalyzerDeserializer
+    );
+
+    protected static void setupLithuanianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/NorwegianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/NorwegianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.NorwegianAnalyzer
+
+@JsonpDeserializable
+public class NorwegianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private NorwegianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static NorwegianAnalyzer of(Function<Builder, ObjectBuilder<NorwegianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Norwegian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "norwegian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link NorwegianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<NorwegianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link NorwegianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public NorwegianAnalyzer build() {
+            _checkSingleUse();
+
+            return new NorwegianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link NorwegianAnalyzer}
+     */
+    public static final JsonpDeserializer<NorwegianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        NorwegianAnalyzer::setupNorwegianAnalyzerDeserializer
+    );
+
+    protected static void setupNorwegianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/PersianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/PersianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.PersianAnalyzer
+
+@JsonpDeserializable
+public class PersianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private PersianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static PersianAnalyzer of(Function<Builder, ObjectBuilder<PersianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Persian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "persian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link PersianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<PersianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link PersianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public PersianAnalyzer build() {
+            _checkSingleUse();
+
+            return new PersianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link PersianAnalyzer}
+     */
+    public static final JsonpDeserializer<PersianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        PersianAnalyzer::setupPersianAnalyzerDeserializer
+    );
+
+    protected static void setupPersianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/PortugueseAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/PortugueseAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.PortugueseAnalyzer
+
+@JsonpDeserializable
+public class PortugueseAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private PortugueseAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static PortugueseAnalyzer of(Function<Builder, ObjectBuilder<PortugueseAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Portuguese;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "portuguese");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link PortugueseAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<PortugueseAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link PortugueseAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public PortugueseAnalyzer build() {
+            _checkSingleUse();
+
+            return new PortugueseAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link PortugueseAnalyzer}
+     */
+    public static final JsonpDeserializer<PortugueseAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        PortugueseAnalyzer::setupPortugueseAnalyzerDeserializer
+    );
+
+    protected static void setupPortugueseAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/RomanianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/RomanianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.RomanianAnalyzer
+
+@JsonpDeserializable
+public class RomanianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private RomanianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static RomanianAnalyzer of(Function<Builder, ObjectBuilder<RomanianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Romanian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "romanian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link RomanianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<RomanianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link RomanianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public RomanianAnalyzer build() {
+            _checkSingleUse();
+
+            return new RomanianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link RomanianAnalyzer}
+     */
+    public static final JsonpDeserializer<RomanianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        RomanianAnalyzer::setupRomanianAnalyzerDeserializer
+    );
+
+    protected static void setupRomanianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/RussianAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/RussianAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.RussianAnalyzer
+
+@JsonpDeserializable
+public class RussianAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private RussianAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static RussianAnalyzer of(Function<Builder, ObjectBuilder<RussianAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Russian;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "russian");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link RussianAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<RussianAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link RussianAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public RussianAnalyzer build() {
+            _checkSingleUse();
+
+            return new RussianAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link RussianAnalyzer}
+     */
+    public static final JsonpDeserializer<RussianAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        RussianAnalyzer::setupRussianAnalyzerDeserializer
+    );
+
+    protected static void setupRussianAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/SoraniAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/SoraniAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.SoraniAnalyzer
+
+@JsonpDeserializable
+public class SoraniAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private SoraniAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static SoraniAnalyzer of(Function<Builder, ObjectBuilder<SoraniAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Sorani;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "sorani");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link SoraniAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SoraniAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link SoraniAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public SoraniAnalyzer build() {
+            _checkSingleUse();
+
+            return new SoraniAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link SoraniAnalyzer}
+     */
+    public static final JsonpDeserializer<SoraniAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        SoraniAnalyzer::setupSoraniAnalyzerDeserializer
+    );
+
+    protected static void setupSoraniAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/SpanishAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/SpanishAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.SpanishAnalyzer
+
+@JsonpDeserializable
+public class SpanishAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private SpanishAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static SpanishAnalyzer of(Function<Builder, ObjectBuilder<SpanishAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Spanish;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "spanish");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link SpanishAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SpanishAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link SpanishAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public SpanishAnalyzer build() {
+            _checkSingleUse();
+
+            return new SpanishAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link SpanishAnalyzer}
+     */
+    public static final JsonpDeserializer<SpanishAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        SpanishAnalyzer::setupSpanishAnalyzerDeserializer
+    );
+
+    protected static void setupSpanishAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/SwedishAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/SwedishAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.SwedishAnalyzer
+
+@JsonpDeserializable
+public class SwedishAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private SwedishAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static SwedishAnalyzer of(Function<Builder, ObjectBuilder<SwedishAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Swedish;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "swedish");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link SwedishAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SwedishAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link SwedishAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public SwedishAnalyzer build() {
+            _checkSingleUse();
+
+            return new SwedishAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link SwedishAnalyzer}
+     */
+    public static final JsonpDeserializer<SwedishAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        SwedishAnalyzer::setupSwedishAnalyzerDeserializer
+    );
+
+    protected static void setupSwedishAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/ThaiAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/ThaiAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.ThaiAnalyzer
+
+@JsonpDeserializable
+public class ThaiAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private ThaiAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static ThaiAnalyzer of(Function<Builder, ObjectBuilder<ThaiAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Thai;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "thai");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link ThaiAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ThaiAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link ThaiAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public ThaiAnalyzer build() {
+            _checkSingleUse();
+
+            return new ThaiAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link ThaiAnalyzer}
+     */
+    public static final JsonpDeserializer<ThaiAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        ThaiAnalyzer::setupThaiAnalyzerDeserializer
+    );
+
+    protected static void setupThaiAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/TurkishAnalyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/TurkishAnalyzer.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+// typedef: _types.analysis.TurkishAnalyzer
+
+@JsonpDeserializable
+public class TurkishAnalyzer implements AnalyzerVariant, JsonpSerializable {
+    private final List<String> stopwords;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private TurkishAnalyzer(Builder builder) {
+
+        this.stopwords = ApiTypeHelper.unmodifiable(builder.stopwords);
+
+    }
+
+    public static TurkishAnalyzer of(Function<Builder, ObjectBuilder<TurkishAnalyzer>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Analyzer variant kind.
+     */
+    @Override
+    public Analyzer.Kind _analyzerKind() {
+        return Analyzer.Kind.Turkish;
+    }
+
+    /**
+     * API name: {@code stopwords}
+     */
+    public final List<String> stopwords() {
+        return this.stopwords;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.write("type", "turkish");
+
+        if (ApiTypeHelper.isDefined(this.stopwords)) {
+            generator.writeKey("stopwords");
+            generator.writeStartArray();
+            for (String item0 : this.stopwords) {
+                generator.write(item0);
+
+            }
+            generator.writeEnd();
+
+        }
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link TurkishAnalyzer}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TurkishAnalyzer> {
+        @Nullable
+        private List<String> stopwords;
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>stopwords</code>.
+         */
+        public final Builder stopwords(List<String> list) {
+            this.stopwords = _listAddAll(this.stopwords, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code stopwords}
+         * <p>
+         * Adds one or more values to <code>stopwords</code>.
+         */
+        public final Builder stopwords(String value, String... values) {
+            this.stopwords = _listAdd(this.stopwords, value, values);
+            return this;
+        }
+
+        /**
+         * Builds a {@link TurkishAnalyzer}.
+         *
+         * @throws NullPointerException
+         *             if some of the required fields are null.
+         */
+        public TurkishAnalyzer build() {
+            _checkSingleUse();
+
+            return new TurkishAnalyzer(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link TurkishAnalyzer}
+     */
+    public static final JsonpDeserializer<TurkishAnalyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+        Builder::new,
+        TurkishAnalyzer::setupTurkishAnalyzerDeserializer
+    );
+
+    protected static void setupTurkishAnalyzerDeserializer(ObjectDeserializer<Builder> op) {
+
+        op.add(Builder::stopwords, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stopwords");
+
+        op.ignore("type");
+    }
+
+}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/analysis/AnalyzerKindTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/analysis/AnalyzerKindTest.java
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import jakarta.json.stream.JsonParser;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+import org.opensearch.client.opensearch.indices.IndexSettings;
+
+import java.io.StringReader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+public class AnalyzerKindTest extends Assert {
+
+    /**
+     *  Test if we can deserialize the language analyzers
+     *  it uses reflection to avoid having to duplicate tests for all 34 currently supported languages
+     *
+     * @throws NoSuchMethodException
+     * @throws InvocationTargetException
+     * @throws IllegalAccessException
+     * @throws ClassNotFoundException
+     */
+    @Test
+    public void testParsingAnalyzersForLanguages() throws NoSuchMethodException, InvocationTargetException,
+            IllegalAccessException, ClassNotFoundException, NullPointerException {
+        JsonpMapper mapper = new JsonbJsonpMapper();
+
+        for (Analyzer.Kind theKind : onlyLanguageAnalyzers) {
+            String type = theKind.jsonValue();
+            String typeCapitalized = type.substring(0, 1).toUpperCase() + type.substring(1);
+            String json = String.format("{ \"index\": { \"analysis\": { \"analyzer\": { \"some_analyzer\": { \"type\": \"%s\"," +
+                    " \"char_filter\": [ \"html_strip\" ], \"tokenizer\": \"standard\" } } } } } ", type);
+
+            JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
+            IndexSettings indexSettings = IndexSettings._DESERIALIZER.deserialize(parser, mapper);
+            Analyzer someAnalyzer = indexSettings.index().analysis().analyzer().get("some_analyzer");
+
+            // Use reflection to generically check analyzer type
+            Method isMethod = someAnalyzer.getClass().getMethod("is" + typeCapitalized);
+            assertTrue((boolean) isMethod.invoke(someAnalyzer));
+
+
+            String analyzerClassName = typeCapitalized + "Analyzer";
+
+            // Use reflection to generically check analyzer class
+            Method getAnalyzerMethod = someAnalyzer.getClass().getMethod(type);
+            Object analyzerInstance = getAnalyzerMethod.invoke(someAnalyzer);
+            Package pk = analyzerInstance.getClass().getPackage();
+            assertEquals(analyzerInstance.getClass(), Class.forName(pk.getName() + "." + analyzerClassName));
+        }
+    }
+
+    private final List<Analyzer.Kind> onlyLanguageAnalyzers = List.of(
+            Analyzer.Kind.Arabic,
+            Analyzer.Kind.Armenian,
+            Analyzer.Kind.Basque,
+            Analyzer.Kind.Bengali,
+            Analyzer.Kind.Brazilian,
+            Analyzer.Kind.Bulgarian,
+            Analyzer.Kind.Catalan,
+            Analyzer.Kind.Czech,
+            Analyzer.Kind.Danish,
+            Analyzer.Kind.Dutch,
+            Analyzer.Kind.English,
+            Analyzer.Kind.Estonian,
+            Analyzer.Kind.Finnish,
+            Analyzer.Kind.French,
+            Analyzer.Kind.Galician,
+            Analyzer.Kind.German,
+            Analyzer.Kind.Greek,
+            Analyzer.Kind.Hindi,
+            Analyzer.Kind.Hungarian,
+            Analyzer.Kind.Indonesian,
+            Analyzer.Kind.Irish,
+            Analyzer.Kind.Italian,
+            Analyzer.Kind.Latvian,
+            Analyzer.Kind.Lithuanian,
+            Analyzer.Kind.Norwegian,
+            Analyzer.Kind.Persian,
+            Analyzer.Kind.Portuguese,
+            Analyzer.Kind.Romanian,
+            Analyzer.Kind.Russian,
+            Analyzer.Kind.Sorani,
+            Analyzer.Kind.Spanish,
+            Analyzer.Kind.Swedish,
+            Analyzer.Kind.Turkish,
+            Analyzer.Kind.Thai
+    );
+
+}


### PR DESCRIPTION
### Description
_Describe what this change achieves._
When trying to build `IndexSettings`. There is no way to build default analyzers for languages supported in opensearch.
The only supported language is Dutch at the moment.
This is also a problem when deserializing `IndexSettings` from json. It will fail for any language other than Dutch.
See this issue [684](https://github.com/opensearch-project/opensearch-java/issues/684)

In this PR, support for creating language Analyzers was added for these languages:
_arabic, armenian, basque, bengali, brazilian, bulgarian, catalan, czech, danish, english, estonian, finnish, french, galician, german, greek, hindi, hungarian, indonesian, irish, italian, latvian, lithuanian, norwegian, persian, portuguese, romanian, russian, sorani, spanish, swedish, turkish, and thai_

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 
Will close this issue: [684](https://github.com/opensearch-project/opensearch-java/issues/684)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
