### PR TITLE
Fixing InnerHits storedFields ("stored_fields") generated Json name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
 - Fix PutTemplateRequest field deserialization ([#723](https://github.com/opensearch-project/opensearch-java/pull/723))
 - Fix PutIndexTemplateRequest field deserialization ([#765](https://github.com/opensearch-project/opensearch-java/pull/765))
+- Fix InnerHits storedFields deserialization/serialization ([ooo](https://github.com/opensearch-project/opensearch-java/pull/ooo))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
 - Fix PutTemplateRequest field deserialization ([#723](https://github.com/opensearch-project/opensearch-java/pull/723))
 - Fix PutIndexTemplateRequest field deserialization ([#765](https://github.com/opensearch-project/opensearch-java/pull/765))
-- Fix InnerHits storedFields deserialization/serialization ([ooo](https://github.com/opensearch-project/opensearch-java/pull/ooo))
+- Fix InnerHits storedFields deserialization/serialization ([#781](https://github.com/opensearch-project/opensearch-java/pull/781)
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/search/InnerHits.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/search/InnerHits.java
@@ -89,7 +89,7 @@ public class InnerHits implements JsonpSerializable {
     @Nullable
     private final SourceConfig source;
 
-    private final List<String> storedField;
+    private final List<String> storedFields;
 
     @Nullable
     private final Boolean trackScores;
@@ -114,7 +114,7 @@ public class InnerHits implements JsonpSerializable {
         this.fields = ApiTypeHelper.unmodifiable(builder.fields);
         this.sort = ApiTypeHelper.unmodifiable(builder.sort);
         this.source = builder.source;
-        this.storedField = ApiTypeHelper.unmodifiable(builder.storedField);
+        this.storedFields = ApiTypeHelper.unmodifiable(builder.storedFields);
         this.trackScores = builder.trackScores;
         this.version = builder.version;
 
@@ -225,10 +225,10 @@ public class InnerHits implements JsonpSerializable {
     }
 
     /**
-     * API name: {@code stored_field}
+     * API name: {@code stored_fields}
      */
-    public final List<String> storedField() {
-        return this.storedField;
+    public final List<String> storedFields() {
+        return this.storedFields;
     }
 
     /**
@@ -344,10 +344,10 @@ public class InnerHits implements JsonpSerializable {
             this.source.serialize(generator, mapper);
 
         }
-        if (ApiTypeHelper.isDefined(this.storedField)) {
-            generator.writeKey("stored_field");
+        if (ApiTypeHelper.isDefined(this.storedFields)) {
+            generator.writeKey("stored_fields");
             generator.writeStartArray();
-            for (String item0 : this.storedField) {
+            for (String item0 : this.storedFields) {
                 generator.write(item0);
 
             }
@@ -414,7 +414,7 @@ public class InnerHits implements JsonpSerializable {
         private SourceConfig source;
 
         @Nullable
-        private List<String> storedField;
+        private List<String> storedFields;
 
         @Nullable
         private Boolean trackScores;
@@ -623,22 +623,22 @@ public class InnerHits implements JsonpSerializable {
         }
 
         /**
-         * API name: {@code stored_field}
+         * API name: {@code stored_fields}
          * <p>
-         * Adds all elements of <code>list</code> to <code>storedField</code>.
+         * Adds all elements of <code>list</code> to <code>storedFields</code>.
          */
-        public final Builder storedField(List<String> list) {
-            this.storedField = _listAddAll(this.storedField, list);
+        public final Builder storedFields(List<String> list) {
+            this.storedFields = _listAddAll(this.storedFields, list);
             return this;
         }
 
         /**
-         * API name: {@code stored_field}
+         * API name: {@code stored_fields}
          * <p>
-         * Adds one or more values to <code>storedField</code>.
+         * Adds one or more values to <code>storedFields</code>.
          */
-        public final Builder storedField(String value, String... values) {
-            this.storedField = _listAdd(this.storedField, value, values);
+        public final Builder storedFields(String value, String... values) {
+            this.storedFields = _listAdd(this.storedFields, value, values);
             return this;
         }
 
@@ -696,7 +696,7 @@ public class InnerHits implements JsonpSerializable {
         op.add(Builder::fields, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "fields");
         op.add(Builder::sort, JsonpDeserializer.arrayDeserializer(SortOptions._DESERIALIZER), "sort");
         op.add(Builder::source, SourceConfig._DESERIALIZER, "_source");
-        op.add(Builder::storedField, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stored_field");
+        op.add(Builder::storedFields, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "stored_fields");
         op.add(Builder::trackScores, JsonpDeserializer.booleanDeserializer(), "track_scores");
         op.add(Builder::version, JsonpDeserializer.booleanDeserializer(), "version");
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/search/InnerHitsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/search/InnerHitsTest.java
@@ -1,0 +1,80 @@
+package org.opensearch.client.opensearch.core.search;
+
+import jakarta.json.spi.JsonProvider;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonParser;
+import org.junit.Test;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class InnerHitsTest {
+    private JsonpMapper mapper = new JsonbJsonpMapper();
+    private String storedSalary = "details.salary";
+    private String storedJobId = "details.jobId";
+
+    /**
+     * test if the json field for storedFields is generated with the correct name "stored_fields"
+     */
+    @Test
+    public void testInnerHitStoredFields() {
+        InnerHits hits = InnerHits.of((it) -> it.storedFields(List.of("field1", "field2")));
+        assertTrue(toJson(hits).contains("stored_fields"));
+    }
+
+    /**
+     * test if the field "stored_fields" is present after deserialization/serialization
+     * of InnerHits
+     */
+    @Test
+    public void testInnerHitFromParsed() {
+        JsonParser parser = mapper.jsonProvider().createParser(new StringReader(innerHitsJson));
+        InnerHits innerHits = InnerHits._DESERIALIZER.deserialize(parser, mapper);
+        assertThat(innerHits.storedFields(), containsInAnyOrder(storedJobId, storedSalary));
+        String actualJson = toJson(innerHits);
+        assertEquals(innerHitsJson, actualJson);
+
+
+    }
+
+    /**
+     * We test if the field "stored_fields" is present in the InnerHits after deserialization/serialization
+     * of a SearchRequest
+     */
+    @Test
+    public void testRequestWithInnerHitFromParsed() {
+        JsonParser parser = mapper.jsonProvider().createParser(new StringReader(searchRequestJson));
+        SearchRequest searchRequest = SearchRequest._DESERIALIZER.deserialize(parser, mapper);
+        InnerHits innerHits = searchRequest.query().bool().must().get(1).nested().innerHits();
+        assertThat(innerHits.storedFields(), containsInAnyOrder(storedJobId, storedSalary));
+        String actualJson = toJson(searchRequest);
+        assertEquals(searchRequestJson, actualJson);
+    }
+
+    private String toJson(JsonpSerializable obj) {
+        StringWriter stringWriter = new StringWriter();
+        try (JsonGenerator generator = mapper.jsonProvider().createGenerator(stringWriter)) {
+            mapper.serialize(obj, generator);
+        }
+        return stringWriter.toString();
+    }
+    private String innerHitsJson = String.format(
+            "{\"_source\":false,\"stored_fields\":[\"%s\",\"%s\"]}",
+            storedJobId,
+            storedSalary
+    );
+    private String searchRequestJson = String.format(
+            "{\"_source\":false,\"query\":{\"bool\":{\"must\":[{\"match_all\":{}},{\"nested\":{\"inner_hits\":%s,\"path\":\"details\","
+                    + "\"query\":{\"match_all\":{}}}}]}},\"stored_fields\":[\"title\",\"companyName\"]}",
+            innerHitsJson);
+}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/search/InnerHitsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/search/InnerHitsTest.java
@@ -1,27 +1,25 @@
 package org.opensearch.client.opensearch.core.search;
 
-import jakarta.json.spi.JsonProvider;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.List;
 import org.junit.Test;
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.JsonpSerializable;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch.core.SearchRequest;
 
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.util.List;
-
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 public class InnerHitsTest {
-    private JsonpMapper mapper = new JsonbJsonpMapper();
-    private String storedSalary = "details.salary";
-    private String storedJobId = "details.jobId";
+    private final JsonpMapper mapper = new JsonbJsonpMapper();
+    private final String storedSalary = "details.salary";
+    private final String storedJobId = "details.jobId";
 
     /**
      * test if the json field for storedFields is generated with the correct name "stored_fields"
@@ -43,7 +41,6 @@ public class InnerHitsTest {
         assertThat(innerHits.storedFields(), containsInAnyOrder(storedJobId, storedSalary));
         String actualJson = toJson(innerHits);
         assertEquals(innerHitsJson, actualJson);
-
 
     }
 
@@ -68,13 +65,11 @@ public class InnerHitsTest {
         }
         return stringWriter.toString();
     }
-    private String innerHitsJson = String.format(
-            "{\"_source\":false,\"stored_fields\":[\"%s\",\"%s\"]}",
-            storedJobId,
-            storedSalary
+
+    private final String innerHitsJson = String.format("{\"_source\":false,\"stored_fields\":[\"%s\",\"%s\"]}", storedJobId, storedSalary);
+    private final String searchRequestJson = String.format(
+        "{\"_source\":false,\"query\":{\"bool\":{\"must\":[{\"match_all\":{}},{\"nested\":{\"inner_hits\":%s,\"path\":\"details\","
+            + "\"query\":{\"match_all\":{}}}}]}},\"stored_fields\":[\"title\",\"companyName\"]}",
+        innerHitsJson
     );
-    private String searchRequestJson = String.format(
-            "{\"_source\":false,\"query\":{\"bool\":{\"must\":[{\"match_all\":{}},{\"nested\":{\"inner_hits\":%s,\"path\":\"details\","
-                    + "\"query\":{\"match_all\":{}}}}]}},\"stored_fields\":[\"title\",\"companyName\"]}",
-            innerHitsJson);
 }


### PR DESCRIPTION
### Description
This will fix the InnerHits storedFields serialization/deserialization.

At the moment, InnerHits is generating/expecting the wrong json field name for "stored_fields".
It is actually using "stored_field" (singular).

Thus, Is not possible to create correct search requests that uses InnerHits with storedFields.


### Issues Resolved

Will close [#780](https://github.com/opensearch-project/opensearch-java/issues/780) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
