### PR TITLE
Set 'id' field when deserializing a PutPipelineRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 - Fix PutTemplateRequest field deserialization ([#723](https://github.com/opensearch-project/opensearch-java/pull/723))
 - Fix PutIndexTemplateRequest field deserialization ([#765](https://github.com/opensearch-project/opensearch-java/pull/765))
 - Fix InnerHits storedFields deserialization/serialization ([#781](https://github.com/opensearch-project/opensearch-java/pull/781)
+- Fix PutPipelineRequest field deserialization ([#789](https://github.com/opensearch-project/opensearch-java/issues/789)
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/ingest/PutPipelineRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/ingest/PutPipelineRequest.java
@@ -481,6 +481,7 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 
         op.add(Builder::meta, JsonpDeserializer.stringMapDeserializer(JsonData._DESERIALIZER), "_meta");
         op.add(Builder::description, JsonpDeserializer.stringDeserializer(), "description");
+        op.add(Builder::id, JsonpDeserializer.stringDeserializer(), "id");
         op.add(Builder::onFailure, JsonpDeserializer.arrayDeserializer(Processor._DESERIALIZER), "on_failure");
         op.add(Builder::processors, JsonpDeserializer.arrayDeserializer(Processor._DESERIALIZER), "processors");
         op.add(Builder::version, JsonpDeserializer.longDeserializer(), "version");


### PR DESCRIPTION
### Description
Currently deserializing a PutPipelineRequest it not possible due to the `id` field not being set but also being required during deserialization.
This PR adds support for the `id` field. 

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-java/issues/789

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
