### PR TITLE
[Backport] [2.x]  Bump org.apache.httpcomponents.client5:httpclient5 from 5.2.3 to 5.3 in /java-client (#791)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `com.diffplug.spotless` from 6.22.0 to 6.23.3
+- Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.2.1 to 5.3
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -176,8 +176,8 @@ dependencies {
     testImplementation("com.fasterxml.jackson.datatype", "jackson-datatype-jakarta-jsonp", jacksonVersion)
 
     // ApacheHttpClient5Transport dependencies (optional)
-    implementation("org.apache.httpcomponents.client5", "httpclient5", "5.1.4")
-    implementation("org.apache.httpcomponents.core5", "httpcore5", "5.1.5")
+    implementation("org.apache.httpcomponents.client5", "httpclient5", "5.3")
+    implementation("org.apache.httpcomponents.core5", "httpcore5", "5.2.4")
 
     // For AwsSdk2Transport
     "awsSdk2SupportCompileOnly"("software.amazon.awssdk","sdk-core","[2.15,3.0)")


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/792 and https://github.com/opensearch-project/opensearch-java/pull/791 to `2.x`