### PR TITLE
Revert support for JDK8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.2.1 to 5.3
 
 ### Changed
-- Restore support for Java 8 ([#767](https://github.com/opensearch-project/opensearch-java/pull/767))
 
 ### Deprecated
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -19,7 +19,7 @@ The below matrix shows the compatibility of the [`opensearch-java-client`](https
 | Client Version | JDK                |
 |----------------|--------------------|
 | 1.0.0          | 8                  |
-| 2.x.0          | 8 / 11 / 17 / 21   |
+| 2.x.0          | 11 / 17 / 21       |
 
 ## Upgrading
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -61,8 +61,8 @@ configurations {
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_1_8
-    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_11
 
     withJavadocJar()
     withSourcesJar()
@@ -146,7 +146,8 @@ val integrationTest = task<Test>("integrationTest") {
             System.getProperty("tests.awsSdk2support.domainRegion", "us-east-1"))
 }
 
-val opensearchVersion = "2.12.0-SNAPSHOT"
+// TODO: Revert https://github.com/opensearch-project/opensearch-java/pull/799 when OpenSearch 2.12 ships.
+val opensearchVersion = "2.7.0"
 
 dependencies {
 


### PR DESCRIPTION
### Description

Supersedes https://github.com/opensearch-project/opensearch-java/pull/796 for 2.x.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
