### PR TITLE
[Backport] [2.x] rename _toQuery() to toQuery() (#760)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added support for flat_object field property ([#735](https://github.com/opensearch-project/opensearch-java/pull/735))
 - Expose HTTP status code through `ResponseException#status` ([#756](https://github.com/opensearch-project/opensearch-java/pull/756))
 - Added toBuilder method to all request model in core package & _types.query_dsl package ([#766](https://github.com/opensearch-project/opensearch-java/pull/766))
+- Added toQuery method in Query and QueryVariant ([#760](https://github.com/opensearch-project/opensearch-java/pull/760)
 
 ### Dependencies
 - Bumps `com.diffplug.spotless` from 6.22.0 to 6.23.3
@@ -15,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 ### Deprecated
+- Deprecated "_toQuery()" in Query and QueryVariant ([#760](https://github.com/opensearch-project/opensearch-java/pull/760)
 
 ### Removed
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/QueryVariant.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/QueryVariant.java
@@ -39,8 +39,12 @@ public interface QueryVariant {
 
     Query.Kind _queryKind();
 
+    @Deprecated
     default Query _toQuery() {
         return new Query(this);
     }
 
+    default Query toQuery() {
+        return new Query(this);
+    }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/experiments/api/query2/Query.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/experiments/api/query2/Query.java
@@ -50,7 +50,12 @@ import org.opensearch.client.util.TaggedUnionUtils;
 public class Query implements TaggedUnion<Query.Kind, Query.Variant>, JsonpSerializable {
 
     public interface Variant extends UnionVariant<Kind>, JsonpSerializable {
+        @Deprecated
         default Query _toQuery() {
+            return new Query(this);
+        }
+
+        default Query toQuery() {
             return new Query(this);
         }
     }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/experiments/api/query2/QueryTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/experiments/api/query2/QueryTest.java
@@ -48,7 +48,7 @@ public class QueryTest extends Assert {
         Query.Variant v = q._get();
         assertEquals(Query.Kind.Bool, v._variantType());
 
-        Query q1 = v._toQuery();
+        Query q1 = v.toQuery();
 
         Collection<Query> must = q.bool().must();
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractRequestIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractRequestIT.java
@@ -495,9 +495,9 @@ public abstract class AbstractRequestIT extends OpenSearchJavaClientTestCase {
                         .filter(
                             BoolQuery.of(
                                 _5 -> _5.filter(
-                                    List.of(TermsQuery.of(_6 -> _6.field("color.keyword").terms(_7 -> _7.value(fieldValues)))._toQuery())
+                                    List.of(TermsQuery.of(_6 -> _6.field("color.keyword").terms(_7 -> _7.value(fieldValues))).toQuery())
                                 )
-                            )._toQuery()
+                            ).toQuery()
                         )
                 )
         );


### PR DESCRIPTION
(cherry picked from commit b50fdb84d801a1260ccc3e818e2c69b6f890c4e1)

### Description
- backport of https://github.com/opensearch-project/opensearch-java/pull/760
