### PR TITLE
[Backpor] [2.x] Bump org.owasp.dependencycheck from 9.0.7 to 9.0.8 (#803)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bumps `com.diffplug.spotless` from 6.22.0 to 6.23.3
 - Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.2.1 to 5.3
+- Bumps `org.owasp.dependencycheck` from 8.4.2 to 9.0.8
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -48,7 +48,7 @@ plugins {
     `java-library`
     `maven-publish`
     id("com.github.jk1.dependency-license-report") version "2.5"
-    id("org.owasp.dependencycheck") version "8.4.0"
+    id("org.owasp.dependencycheck") version "9.0.8"
     id("com.diffplug.spotless") version "6.23.3"
 }
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/803 to `2.x`