### PR TITLE
[Backport] [2.x] Bump com.diffplug.spotless from 6.23.3 to 6.24.0 (#808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added toQuery method in Query and QueryVariant ([#760](https://github.com/opensearch-project/opensearch-java/pull/760)
 
 ### Dependencies
-- Bumps `com.diffplug.spotless` from 6.22.0 to 6.23.3
+- Bumps `com.diffplug.spotless` from 6.22.0 to 6.24.0
 - Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.2.1 to 5.3
 - Bumps `org.owasp.dependencycheck` from 8.4.2 to 9.0.8
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -49,7 +49,7 @@ plugins {
     `maven-publish`
     id("com.github.jk1.dependency-license-report") version "2.5"
     id("org.owasp.dependencycheck") version "9.0.8"
-    id("com.diffplug.spotless") version "6.23.3"
+    id("com.diffplug.spotless") version "6.24.0"
 }
 
 apply(plugin = "org.owasp.dependencycheck")

--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -9,7 +9,7 @@
 plugins {
     java
     application
-    id("com.diffplug.spotless") version "6.23.3"
+    id("com.diffplug.spotless") version "6.24.0"
 }
 
 java {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/808 to `2.x`