### PR TITLE
Removing unsupported prefix field from CompletionSuggester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,10 @@ This section is for maintaining a changelog for all breaking changes for the cli
 - Add an integration test that runs on JDK-8 ([#795](https://github.com/opensearch-project/opensearch-java/pull/795))
 
 ### Deprecated
-- Deprecated "_toQuery()" in Query and QueryVariant ([#760](https://github.com/opensearch-project/opensearch-java/pull/760)
+- Deprecated "_toQuery()" in Query and QueryVariant ([#760](https://github.com/opensearch-project/opensearch-java/pull/760))
 
 ### Removed
+- Removed unsupported `prefix` field from CompletionSuggester ([#812](https://github.com/opensearch-project/opensearch-java/pull/812))
 
 ### Fixed
 - Fix partial success results for msearch_template ([#709](https://github.com/opensearch-project/opensearch-java/pull/709))

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/search/CompletionSuggester.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/search/CompletionSuggester.java
@@ -55,9 +55,6 @@ public class CompletionSuggester extends SuggesterBase implements FieldSuggester
     private final SuggestFuzziness fuzzy;
 
     @Nullable
-    private final String prefix;
-
-    @Nullable
     private final String regex;
 
     @Nullable
@@ -70,7 +67,6 @@ public class CompletionSuggester extends SuggesterBase implements FieldSuggester
 
         this.contexts = ApiTypeHelper.unmodifiable(builder.contexts);
         this.fuzzy = builder.fuzzy;
-        this.prefix = builder.prefix;
         this.regex = builder.regex;
         this.skipDuplicates = builder.skipDuplicates;
 
@@ -101,14 +97,6 @@ public class CompletionSuggester extends SuggesterBase implements FieldSuggester
     @Nullable
     public final SuggestFuzziness fuzzy() {
         return this.fuzzy;
-    }
-
-    /**
-     * API name: {@code prefix}
-     */
-    @Nullable
-    public final String prefix() {
-        return this.prefix;
     }
 
     /**
@@ -153,11 +141,6 @@ public class CompletionSuggester extends SuggesterBase implements FieldSuggester
             this.fuzzy.serialize(generator, mapper);
 
         }
-        if (this.prefix != null) {
-            generator.writeKey("prefix");
-            generator.write(this.prefix);
-
-        }
         if (this.regex != null) {
             generator.writeKey("regex");
             generator.write(this.regex);
@@ -183,9 +166,6 @@ public class CompletionSuggester extends SuggesterBase implements FieldSuggester
 
         @Nullable
         private SuggestFuzziness fuzzy;
-
-        @Nullable
-        private String prefix;
 
         @Nullable
         private String regex;
@@ -226,14 +206,6 @@ public class CompletionSuggester extends SuggesterBase implements FieldSuggester
          */
         public final Builder fuzzy(Function<SuggestFuzziness.Builder, ObjectBuilder<SuggestFuzziness>> fn) {
             return this.fuzzy(fn.apply(new SuggestFuzziness.Builder()).build());
-        }
-
-        /**
-         * API name: {@code prefix}
-         */
-        public final Builder prefix(@Nullable String value) {
-            this.prefix = value;
-            return this;
         }
 
         /**
@@ -288,7 +260,6 @@ public class CompletionSuggester extends SuggesterBase implements FieldSuggester
             "contexts"
         );
         op.add(Builder::fuzzy, SuggestFuzziness._DESERIALIZER, "fuzzy");
-        op.add(Builder::prefix, JsonpDeserializer.stringDeserializer(), "prefix");
         op.add(Builder::regex, JsonpDeserializer.stringDeserializer(), "regex");
         op.add(Builder::skipDuplicates, JsonpDeserializer.booleanDeserializer(), "skip_duplicates");
 


### PR DESCRIPTION
### Description
CompletionSuggester does not support `prefix` field. `prefix` can be added to `FieldSuggester` of which `CompletionSuggester` is a part. An example: https://github.com/opensearch-project/opensearch-java/blob/main/samples/src/main/java/org/opensearch/client/samples/Search.java#L140-L143

### Issues Resolved
Resolve #771 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
