### PR TITLE
Add wrapper to builder (#806)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Expose HTTP status code through `ResponseException#status` ([#756](https://github.com/opensearch-project/opensearch-java/pull/756))
 - Added toBuilder method to all request model in core package & _types.query_dsl package ([#766](https://github.com/opensearch-project/opensearch-java/pull/766))
 - Added toQuery method in Query and QueryVariant ([#760](https://github.com/opensearch-project/opensearch-java/pull/760)
+- Added missing WrapperQuery accessors and builder methods ([#806](https://github.com/opensearch-project/opensearch-java/pull/806))
 
 ### Dependencies
 - Bumps `com.diffplug.spotless` from 6.22.0 to 6.24.0

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/Query.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/Query.java
@@ -1154,6 +1154,23 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
     }
 
     /**
+     * Is this variant instance of kind {@code wrapper}?
+     */
+    public boolean isWrapper() {
+        return this._kind == Query.Kind.Wrapper;
+    }
+
+    /**
+     * Get the {@code wrapper} variant value.
+     *
+     * @throws IllegalStateException
+     *             if the current variant is not of the {@code wrapper} kind.
+     */
+    public WrapperQuery wrapper() {
+        return (WrapperQuery) TaggedUnionUtils.get(this, Query.Kind.Wrapper);
+    }
+
+    /**
      * Is this variant instance of kind {@code type}?
      */
     public boolean isType() {
@@ -1741,6 +1758,16 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 
         public ObjectBuilder<Query> wildcard(Function<WildcardQuery.Builder, ObjectBuilder<WildcardQuery>> fn) {
             return this.wildcard(fn.apply(new WildcardQuery.Builder()).build());
+        }
+
+        public ObjectBuilder<Query> wrapper(WrapperQuery v) {
+            this._kind = Query.Kind.Wrapper;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<Query> wrapper(Function<WrapperQuery.Builder, ObjectBuilder<WrapperQuery>> fn) {
+            return this.wrapper(fn.apply(new WrapperQuery.Builder()).build());
         }
 
         public ObjectBuilder<Query> type(TypeQuery v) {


### PR DESCRIPTION
### Description
Backport:  Add the missing builder and query function for the Kind.Wrapper
https://github.com/opensearch-project/opensearch-java/pull/806 

### Issues Resolved
Missing isWrapper, wrapper() and wrapper(...) in a downstream project

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).