### PR TITLE
[Backport] [2.x] Bump com.diffplug.spotless from 6.24.0 to 6.25.0 in /java-client (#828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added missing WrapperQuery accessors and builder methods ([#806](https://github.com/opensearch-project/opensearch-java/pull/806))
 
 ### Dependencies
-- Bumps `com.diffplug.spotless` from 6.22.0 to 6.24.0
+- Bumps `com.diffplug.spotless` from 6.22.0 to 6.25.0
 - Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.2.1 to 5.3
 - Bumps `org.owasp.dependencycheck` from 8.4.2 to 9.0.8
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -49,7 +49,7 @@ plugins {
     `maven-publish`
     id("com.github.jk1.dependency-license-report") version "2.5"
     id("org.owasp.dependencycheck") version "9.0.8"
-    id("com.diffplug.spotless") version "6.24.0"
+    id("com.diffplug.spotless") version "6.25.0"
 }
 
 apply(plugin = "org.owasp.dependencycheck")


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/828 to `2.x`