### PR TITLE
Removed required index for Hit.java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ This section is for maintaining a changelog for all breaking changes for the cli
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
 - Fix PutTemplateRequest field deserialization ([#723](https://github.com/opensearch-project/opensearch-java/pull/723))
 - Fix PutIndexTemplateRequest field deserialization ([#765](https://github.com/opensearch-project/opensearch-java/pull/765))
-- Fix InnerHits storedFields deserialization/serialization ([#781](https://github.com/opensearch-project/opensearch-java/pull/781)
+- Fix InnerHits storedFields deserialization/serialization ([#781](https://github.com/opensearch-project/opensearch-java/pull/781))
+- Fix InnerHits to no longer enforce the nullable Index field when converting to Hit. ([#825](https://github.com/opensearch-project/opensearch-java/issues/825))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/search/Hit.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/search/Hit.java
@@ -107,7 +107,7 @@ public class Hit<TDocument> implements JsonpSerializable {
 
     private Hit(Builder<TDocument> builder) {
 
-        this.index = ApiTypeHelper.requireNonNull(builder.index, this, "index");
+        this.index = builder.index;
         this.id = builder.id;
         this.score = builder.score;
         this.explanation = builder.explanation;
@@ -134,7 +134,7 @@ public class Hit<TDocument> implements JsonpSerializable {
     }
 
     /**
-     * Required - API name: {@code _index}
+     * API name: {@code _index}
      */
     public final String index() {
         return this.index;
@@ -281,8 +281,10 @@ public class Hit<TDocument> implements JsonpSerializable {
 
     protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
-        generator.writeKey("_index");
-        generator.write(this.index);
+        if (this.index != null) {
+            generator.writeKey("_index");
+            generator.write(this.index);
+        }
 
         if (this.id != null) {
             generator.writeKey("_id");
@@ -419,6 +421,8 @@ public class Hit<TDocument> implements JsonpSerializable {
      */
 
     public static class Builder<TDocument> extends ObjectBuilderBase implements ObjectBuilder<Hit<TDocument>> {
+
+        @Nullable
         private String index;
 
         @Nullable
@@ -478,7 +482,7 @@ public class Hit<TDocument> implements JsonpSerializable {
         /**
          * Required - API name: {@code _index}
          */
-        public final Builder<TDocument> index(String value) {
+        public final Builder<TDocument> index(@Nullable String value) {
             this.index = value;
             return this;
         }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/search/InnerHitsResultTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/search/InnerHitsResultTest.java
@@ -1,0 +1,86 @@
+package org.opensearch.client.opensearch.core.search;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.StringReader;
+import org.junit.Test;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+
+public class InnerHitsResultTest {
+    private final JsonpMapper mapper = new JsonbJsonpMapper();
+    private final String storedSalary = "details.salary";
+    private final String storedJobId = "details.jobId";
+
+    /**
+     * test if the InnerHitsResult will build the Hit<JsonData>
+     */
+    @Test
+    public void testInnerHits() {
+
+        String classString = String.valueOf(hitResultWithIdIndex.innerHits().get("test_child").getClass());
+        assertEquals(classString, InnerHitsResult.class.toString());
+        // take hitResult and get the InnerHit
+        InnerHitsResult innerHitsResult = hitResultWithIdIndex.innerHits().get("test_child");
+        Hit<JsonData> innerHitResult = innerHitsResult.hits().hits().get(0);
+        assertNotNull(innerHitResult.index());
+        assertEquals(innerHitResult.index(), "_index");
+        assertNotNull(innerHitResult.id());
+        assertEquals(innerHitResult.id(), "child_id");
+    }
+
+    /**
+     * test if the InnerHitsResult will still build the Hit<JsonData> even if id and index is not specified
+     */
+    @Test
+    public void testInnerHitWithoutIdIndex() {
+
+        String classString = String.valueOf(hitResultNoIdIndex.innerHits().get("test_child").getClass());
+        assertEquals(classString, InnerHitsResult.class.toString());
+        // take hitResult and get the InnerHit
+        InnerHitsResult innerHitsResult = hitResultNoIdIndex.innerHits().get("test_child");
+        Hit<JsonData> innerHitResult = innerHitsResult.hits().hits().get(0);
+        // Id and index are now nullable.
+        assertNull(innerHitResult.index());
+        assertNull(innerHitResult.id());
+    }
+
+    private final String innerHitJsonWithNoIdOrIndex = "{\"key\":\"value\"}";
+    private final String innerHitJsonWithIdOrIndex = "{\"id\":\"value\",\"index\":\"value\"}";
+
+    private final Hit<JsonData> hitResultNoIdIndex = Hit.of(
+        it -> it.id("test_parent")
+            .index("_index")
+            .innerHits(
+                "test_child",
+                innerHitsResultBuilder -> innerHitsResultBuilder.hits(
+                    innerHitsMetadataBuilder -> innerHitsMetadataBuilder.total(total -> total.value(1).relation(TotalHitsRelation.Eq))
+                        .hits(
+                            innerHitsListMemberBuilder -> innerHitsListMemberBuilder.source(
+                                JsonData.from(mapper.jsonProvider().createParser(new StringReader(innerHitJsonWithNoIdOrIndex)), mapper)
+                            )
+                        )
+                )
+            )
+    );
+    private final Hit<JsonData> hitResultWithIdIndex = Hit.of(
+        it -> it.id("test_parent")
+            .index("_index")
+            .innerHits(
+                "test_child",
+                innerHitsResultBuilder -> innerHitsResultBuilder.hits(
+                    innerHitsMetadataBuilder -> innerHitsMetadataBuilder.total(total -> total.value(1).relation(TotalHitsRelation.Eq))
+                        .hits(
+                            innerHitsListMemberBuilder -> innerHitsListMemberBuilder.id("child_id")
+                                .index("_index")
+                                .source(
+                                    JsonData.from(mapper.jsonProvider().createParser(new StringReader(innerHitJsonWithIdOrIndex)), mapper)
+                                )
+                        )
+                )
+            )
+    );
+}


### PR DESCRIPTION
For InnerHits, since the index and id is assumed to be the same as parent, they were not included in the InnerHit object, but when converting it into a Hit object in the java sdk, it would throw an exception, saying index is required. Removed it, and also added unit tests.

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
