### PR TITLE
Fixing cluster stats response for role types and adding search role type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ## [Unreleased 2.x]
 
 ### Added
+- Add search role type for nodes in cluster stats ([#848](https://github.com/opensearch-project/opensearch-java/pull/848))
 
 ### Dependencies
 
@@ -48,6 +49,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Removed
 
 ### Fixed
+- Fix ClusterStatsResponse field deserialization ([#848](https://github.com/opensearch-project/opensearch-java/pull/848))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/stats/ClusterNodeCount.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/stats/ClusterNodeCount.java
@@ -59,24 +59,10 @@ public class ClusterNodeCount implements JsonpSerializable {
 
     private final int total;
 
-    private final int votingOnly;
-
-    private final int dataCold;
-
-    @Nullable
-    private final Integer dataFrozen;
-
-    private final int dataContent;
-
-    private final int dataWarm;
-
-    private final int dataHot;
-
-    private final int ml;
-
     private final int remoteClusterClient;
 
-    private final int transform;
+    @Nullable
+    private final Integer search;
 
     // ---------------------------------------------------------------------------------------------
 
@@ -87,16 +73,8 @@ public class ClusterNodeCount implements JsonpSerializable {
         this.ingest = ApiTypeHelper.requireNonNull(builder.ingest, this, "ingest");
         this.clusterManager = ApiTypeHelper.requireNonNull(builder.clusterManager, this, "clusterManager");
         this.total = ApiTypeHelper.requireNonNull(builder.total, this, "total");
-        this.votingOnly = ApiTypeHelper.requireNonNull(builder.votingOnly, this, "votingOnly");
-        this.dataCold = ApiTypeHelper.requireNonNull(builder.dataCold, this, "dataCold");
-        this.dataFrozen = builder.dataFrozen;
-        this.dataContent = ApiTypeHelper.requireNonNull(builder.dataContent, this, "dataContent");
-        this.dataWarm = ApiTypeHelper.requireNonNull(builder.dataWarm, this, "dataWarm");
-        this.dataHot = ApiTypeHelper.requireNonNull(builder.dataHot, this, "dataHot");
-        this.ml = ApiTypeHelper.requireNonNull(builder.ml, this, "ml");
         this.remoteClusterClient = ApiTypeHelper.requireNonNull(builder.remoteClusterClient, this, "remoteClusterClient");
-        this.transform = ApiTypeHelper.requireNonNull(builder.transform, this, "transform");
-
+        this.search = builder.search;
     }
 
     public static ClusterNodeCount of(Function<Builder, ObjectBuilder<ClusterNodeCount>> fn) {
@@ -139,56 +117,6 @@ public class ClusterNodeCount implements JsonpSerializable {
     }
 
     /**
-     * Required - API name: {@code voting_only}
-     */
-    public final int votingOnly() {
-        return this.votingOnly;
-    }
-
-    /**
-     * Required - API name: {@code data_cold}
-     */
-    public final int dataCold() {
-        return this.dataCold;
-    }
-
-    /**
-     * API name: {@code data_frozen}
-     */
-    @Nullable
-    public final Integer dataFrozen() {
-        return this.dataFrozen;
-    }
-
-    /**
-     * Required - API name: {@code data_content}
-     */
-    public final int dataContent() {
-        return this.dataContent;
-    }
-
-    /**
-     * Required - API name: {@code data_warm}
-     */
-    public final int dataWarm() {
-        return this.dataWarm;
-    }
-
-    /**
-     * Required - API name: {@code data_hot}
-     */
-    public final int dataHot() {
-        return this.dataHot;
-    }
-
-    /**
-     * Required - API name: {@code ml}
-     */
-    public final int ml() {
-        return this.ml;
-    }
-
-    /**
      * Required - API name: {@code remote_cluster_client}
      */
     public final int remoteClusterClient() {
@@ -196,10 +124,11 @@ public class ClusterNodeCount implements JsonpSerializable {
     }
 
     /**
-     * Required - API name: {@code transform}
+     * API name: {@code search}
      */
-    public final int transform() {
-        return this.transform;
+    @Nullable
+    public final Integer search() {
+        return this.search;
     }
 
     /**
@@ -228,34 +157,13 @@ public class ClusterNodeCount implements JsonpSerializable {
         generator.writeKey("total");
         generator.write(this.total);
 
-        generator.writeKey("voting_only");
-        generator.write(this.votingOnly);
-
-        generator.writeKey("data_cold");
-        generator.write(this.dataCold);
-
-        if (this.dataFrozen != null) {
-            generator.writeKey("data_frozen");
-            generator.write(this.dataFrozen);
-
-        }
-        generator.writeKey("data_content");
-        generator.write(this.dataContent);
-
-        generator.writeKey("data_warm");
-        generator.write(this.dataWarm);
-
-        generator.writeKey("data_hot");
-        generator.write(this.dataHot);
-
-        generator.writeKey("ml");
-        generator.write(this.ml);
-
         generator.writeKey("remote_cluster_client");
         generator.write(this.remoteClusterClient);
 
-        generator.writeKey("transform");
-        generator.write(this.transform);
+        if (this.search != null) {
+            generator.writeKey("search");
+            generator.write(this.search);
+        }
 
     }
 
@@ -276,24 +184,9 @@ public class ClusterNodeCount implements JsonpSerializable {
 
         private Integer total;
 
-        private Integer votingOnly;
-
-        private Integer dataCold;
-
-        @Nullable
-        private Integer dataFrozen;
-
-        private Integer dataContent;
-
-        private Integer dataWarm;
-
-        private Integer dataHot;
-
-        private Integer ml;
-
         private Integer remoteClusterClient;
 
-        private Integer transform;
+        private Integer search;
 
         /**
          * Required - API name: {@code coordinating_only}
@@ -336,62 +229,6 @@ public class ClusterNodeCount implements JsonpSerializable {
         }
 
         /**
-         * Required - API name: {@code voting_only}
-         */
-        public final Builder votingOnly(int value) {
-            this.votingOnly = value;
-            return this;
-        }
-
-        /**
-         * Required - API name: {@code data_cold}
-         */
-        public final Builder dataCold(int value) {
-            this.dataCold = value;
-            return this;
-        }
-
-        /**
-         * API name: {@code data_frozen}
-         */
-        public final Builder dataFrozen(@Nullable Integer value) {
-            this.dataFrozen = value;
-            return this;
-        }
-
-        /**
-         * Required - API name: {@code data_content}
-         */
-        public final Builder dataContent(int value) {
-            this.dataContent = value;
-            return this;
-        }
-
-        /**
-         * Required - API name: {@code data_warm}
-         */
-        public final Builder dataWarm(int value) {
-            this.dataWarm = value;
-            return this;
-        }
-
-        /**
-         * Required - API name: {@code data_hot}
-         */
-        public final Builder dataHot(int value) {
-            this.dataHot = value;
-            return this;
-        }
-
-        /**
-         * Required - API name: {@code ml}
-         */
-        public final Builder ml(int value) {
-            this.ml = value;
-            return this;
-        }
-
-        /**
          * Required - API name: {@code remote_cluster_client}
          */
         public final Builder remoteClusterClient(int value) {
@@ -400,10 +237,11 @@ public class ClusterNodeCount implements JsonpSerializable {
         }
 
         /**
-         * Required - API name: {@code transform}
+         * API name: {@code search}
          */
-        public final Builder transform(int value) {
-            this.transform = value;
+        @Nullable
+        public final Builder search(int value) {
+            this.search = value;
             return this;
         }
 
@@ -437,15 +275,8 @@ public class ClusterNodeCount implements JsonpSerializable {
         op.add(Builder::ingest, JsonpDeserializer.integerDeserializer(), "ingest");
         op.add(Builder::clusterManager, JsonpDeserializer.integerDeserializer(), "cluster_manager");
         op.add(Builder::total, JsonpDeserializer.integerDeserializer(), "total");
-        op.add(Builder::votingOnly, JsonpDeserializer.integerDeserializer(), "voting_only");
-        op.add(Builder::dataCold, JsonpDeserializer.integerDeserializer(), "data_cold");
-        op.add(Builder::dataFrozen, JsonpDeserializer.integerDeserializer(), "data_frozen");
-        op.add(Builder::dataContent, JsonpDeserializer.integerDeserializer(), "data_content");
-        op.add(Builder::dataWarm, JsonpDeserializer.integerDeserializer(), "data_warm");
-        op.add(Builder::dataHot, JsonpDeserializer.integerDeserializer(), "data_hot");
-        op.add(Builder::ml, JsonpDeserializer.integerDeserializer(), "ml");
         op.add(Builder::remoteClusterClient, JsonpDeserializer.integerDeserializer(), "remote_cluster_client");
-        op.add(Builder::transform, JsonpDeserializer.integerDeserializer(), "transform");
+        op.add(Builder::search, JsonpDeserializer.integerDeserializer(), "search");
 
     }
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/cluster/stats/NodePackagingType.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/cluster/stats/NodePackagingType.java
@@ -50,8 +50,6 @@ import org.opensearch.client.util.ObjectBuilderBase;
 public class NodePackagingType implements JsonpSerializable {
     private final int count;
 
-    private final String flavor;
-
     private final String type;
 
     // ---------------------------------------------------------------------------------------------
@@ -59,7 +57,6 @@ public class NodePackagingType implements JsonpSerializable {
     private NodePackagingType(Builder builder) {
 
         this.count = ApiTypeHelper.requireNonNull(builder.count, this, "count");
-        this.flavor = ApiTypeHelper.requireNonNull(builder.flavor, this, "flavor");
         this.type = ApiTypeHelper.requireNonNull(builder.type, this, "type");
 
     }
@@ -73,13 +70,6 @@ public class NodePackagingType implements JsonpSerializable {
      */
     public final int count() {
         return this.count;
-    }
-
-    /**
-     * Required - API name: {@code flavor}
-     */
-    public final String flavor() {
-        return this.flavor;
     }
 
     /**
@@ -103,9 +93,6 @@ public class NodePackagingType implements JsonpSerializable {
         generator.writeKey("count");
         generator.write(this.count);
 
-        generator.writeKey("flavor");
-        generator.write(this.flavor);
-
         generator.writeKey("type");
         generator.write(this.type);
 
@@ -120,8 +107,6 @@ public class NodePackagingType implements JsonpSerializable {
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<NodePackagingType> {
         private Integer count;
 
-        private String flavor;
-
         private String type;
 
         /**
@@ -129,14 +114,6 @@ public class NodePackagingType implements JsonpSerializable {
          */
         public final Builder count(int value) {
             this.count = value;
-            return this;
-        }
-
-        /**
-         * Required - API name: {@code flavor}
-         */
-        public final Builder flavor(String value) {
-            this.flavor = value;
             return this;
         }
 
@@ -174,7 +151,6 @@ public class NodePackagingType implements JsonpSerializable {
     protected static void setupNodePackagingTypeDeserializer(ObjectDeserializer<NodePackagingType.Builder> op) {
 
         op.add(Builder::count, JsonpDeserializer.integerDeserializer(), "count");
-        op.add(Builder::flavor, JsonpDeserializer.stringDeserializer(), "flavor");
         op.add(Builder::type, JsonpDeserializer.stringDeserializer(), "type");
 
     }

--- a/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/AbstractClusterClientIT.java
+++ b/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/AbstractClusterClientIT.java
@@ -22,6 +22,8 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.HealthStatus;
 import org.opensearch.client.opensearch._types.Level;
 import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch.cluster.ClusterStatsRequest;
+import org.opensearch.client.opensearch.cluster.ClusterStatsResponse;
 import org.opensearch.client.opensearch.cluster.GetClusterSettingsRequest;
 import org.opensearch.client.opensearch.cluster.GetClusterSettingsResponse;
 import org.opensearch.client.opensearch.cluster.HealthRequest;
@@ -299,5 +301,16 @@ public abstract class AbstractClusterClientIT extends OpenSearchJavaClientTestCa
         } catch (ResponseException e) {
             assertNotNull(e);
         }
+    }
+
+    public void testClusterStats() throws IOException {
+        OpenSearchClient openSearchClient = javaClient();
+        javaClient().indices().create(b -> b.index("index"));
+        ClusterStatsRequest request = new ClusterStatsRequest.Builder().build();
+        ClusterStatsResponse response = openSearchClient.cluster().stats(request);
+        assertNotNull(response);
+        assertNotNull(response.clusterName());
+        assertNotEquals(response.nodes().count().total(), 0);
+        assertNotEquals(response.indices().count(), 0);
     }
 }


### PR DESCRIPTION
### Description
When calling the cluster stats api from the client, the call fails with the following error: 

```
org.opensearch.client.util.MissingRequiredPropertyException: Missing required property 'ClusterNodeCount.votingOnly'
```

Upon further debugging, I found other role types as well in the client which are not supported by OpenSearch. Fixing the cluster stats API call in this PR. I also added the `search` role type which was added in OpenSearch 2.4.0.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
