### PR TITLE
[Backport] [2.x] Bump org.ajoberstar.grgit:grgit-gradle from 5.2.1 to 5.2.2 (#854)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add search role type for nodes in cluster stats ([#848](https://github.com/opensearch-project/opensearch-java/pull/848))
 
 ### Dependencies
+- Bumps `org.ajoberstar.grgit:grgit-gradle` from 5.2.0 to 5.2.2
 
 ### Changed
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,7 +31,7 @@
  */
 
 dependencies {
-    implementation("org.ajoberstar.grgit:grgit-gradle:5.2.0")
+    implementation("org.ajoberstar.grgit:grgit-gradle:5.2.2")
 }
 
 repositories {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/854 to `2.x`