### PR TITLE
Added scriptedUpsert and detectNoop options to UpdateOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
+- Fix missing properties on UpdateOperation ([#744](https://github.com/opensearch-project/opensearch-java/pull/744))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperation.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperation.java
@@ -145,6 +145,12 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
         private Boolean docAsUpsert;
 
         @Nullable
+        private Boolean scriptedUpsert;
+
+        @Nullable
+        private Boolean detectNoop;
+
+        @Nullable
         private TDocument upsert;
 
         @Nullable
@@ -163,6 +169,22 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
          */
         public final Builder<TDocument> docAsUpsert(@Nullable Boolean value) {
             this.docAsUpsert = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code scripted_upsert}
+         */
+        public final Builder<TDocument> scriptedUpsert(@Nullable Boolean value) {
+            this.scriptedUpsert = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code detect_noop}
+         */
+        public final Builder<TDocument> detectNoop(@Nullable Boolean value) {
+            this.detectNoop = value;
             return this;
         }
 
@@ -223,6 +245,8 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
 
             data = new UpdateOperationData.Builder<TDocument>().document(document)
                 .docAsUpsert(docAsUpsert)
+                .scriptedUpsert(scriptedUpsert)
+                .detectNoop(detectNoop)
                 .script(script)
                 .upsert(upsert)
                 .tDocumentSerializer(tDocumentSerializer)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperationData.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperationData.java
@@ -25,6 +25,12 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
     private final Boolean docAsUpsert;
 
     @Nullable
+    private final Boolean scriptedUpsert;
+
+    @Nullable
+    private final Boolean detectNoop;
+
+    @Nullable
     private final TDocument upsert;
 
     @Nullable
@@ -36,6 +42,8 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
     private UpdateOperationData(Builder<TDocument> builder) {
         this.document = builder.document;
         this.docAsUpsert = builder.docAsUpsert;
+        this.scriptedUpsert = builder.scriptedUpsert;
+        this.detectNoop = builder.detectNoop;
         this.script = builder.script;
         this.upsert = builder.upsert;
         this.tDocumentSerializer = builder.tDocumentSerializer;
@@ -53,6 +61,16 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
         if (this.docAsUpsert != null) {
             generator.writeKey("doc_as_upsert");
             generator.write(this.docAsUpsert);
+        }
+
+        if (this.scriptedUpsert != null) {
+            generator.writeKey("scripted_upsert");
+            generator.write(scriptedUpsert);
+        }
+
+        if (this.detectNoop != null) {
+            generator.writeKey("detect_noop");
+            generator.write(detectNoop);
         }
 
         if (this.document != null) {
@@ -88,6 +106,12 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
         private Boolean docAsUpsert;
 
         @Nullable
+        private Boolean scriptedUpsert;
+
+        @Nullable
+        private Boolean detectNoop;
+
+        @Nullable
         private TDocument upsert;
 
         @Nullable
@@ -106,6 +130,22 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
          */
         public final Builder<TDocument> docAsUpsert(@Nullable Boolean value) {
             this.docAsUpsert = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code scripted_upsert}
+         */
+        public final Builder<TDocument> scriptedUpsert(@Nullable Boolean value) {
+            this.scriptedUpsert = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code detect_noop}
+         */
+        public final Builder<TDocument> detectNoop(@Nullable Boolean value) {
+            this.detectNoop = value;
             return this;
         }
 


### PR DESCRIPTION
### Description
Adds missing properties `scriptedUpsert` and `detectNoop` to `UpdateOperation`

This is the same as https://github.com/opensearch-project/opensearch-java/pull/748 and https://github.com/opensearch-project/opensearch-java/pull/750
*** **Please backport to 2.8** ***

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-java/issues/744


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
