### PR TITLE
Adding version check for hybrid query integ tests

### DIFF
--- a/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/AbstractSearchRequestIT.java
+++ b/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/AbstractSearchRequestIT.java
@@ -12,12 +12,14 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import org.junit.Test;
+import org.opensearch.Version;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.mapping.Property;
 import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
+import org.opensearch.client.opensearch.core.InfoResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
@@ -61,6 +63,12 @@ public abstract class AbstractSearchRequestIT extends OpenSearchJavaClientTestCa
 
     @Test
     public void hybridSearchShouldReturnSearchResults() throws Exception {
+        InfoResponse info = javaClient().info();
+        String version = info.version().number();
+        if (version.contains("SNAPSHOT")) {
+            version = version.split("-")[0];
+        }
+        assumeTrue("Hybrid search is supported from 2.10.0", Version.fromString(version).onOrAfter(Version.fromString("2.10.0")));
         final String index = "hybrid_search_request";
         try {
             createIndex(index);


### PR DESCRIPTION
### Description
In this PR the version check to run integ tests of hybrid query >=2.10 is added.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
