### PR TITLE
[Backport 2.x] Adding version check for hybrid query integ tests (#863)

### DIFF
--- a/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractSearchRequestIT.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/integTest/AbstractSearchRequestIT.java
@@ -12,12 +12,14 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import org.junit.Test;
+import org.opensearch.Version;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.mapping.Property;
 import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
+import org.opensearch.client.opensearch.core.InfoResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
@@ -61,6 +63,12 @@ public abstract class AbstractSearchRequestIT extends OpenSearchJavaClientTestCa
 
     @Test
     public void hybridSearchShouldReturnSearchResults() throws Exception {
+        InfoResponse info = javaClient().info();
+        String version = info.version().number();
+        if (version.contains("SNAPSHOT")) {
+            version = version.split("-")[0];
+        }
+        assumeTrue("Hybrid search is supported from 2.10.0", Version.fromString(version).onOrAfter(Version.fromString("2.10.0")));
         final String index = "hybrid_search_request";
         try {
             createIndex(index);


### PR DESCRIPTION
### Description
In this PR the version check to run integ tests of hybrid query >=2.10 is added.


