### PR TITLE
Fix integer overflow for remaining index stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Removed
 
 ### Fixed
+- Fix integer overflow for variables in indices stats response ([#877](https://github.com/opensearch-project/opensearch-java/pull/877))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/QueryCacheStats.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/QueryCacheStats.java
@@ -60,7 +60,7 @@ public class QueryCacheStats implements JsonpSerializable {
     @Nullable
     private final String memorySize;
 
-    private final int memorySizeInBytes;
+    private final long memorySizeInBytes;
 
     private final int missCount;
 
@@ -124,7 +124,7 @@ public class QueryCacheStats implements JsonpSerializable {
     /**
      * Required - API name: {@code memory_size_in_bytes}
      */
-    public final int memorySizeInBytes() {
+    public final long memorySizeInBytes() {
         return this.memorySizeInBytes;
     }
 
@@ -199,7 +199,7 @@ public class QueryCacheStats implements JsonpSerializable {
         @Nullable
         private String memorySize;
 
-        private Integer memorySizeInBytes;
+        private Long memorySizeInBytes;
 
         private Integer missCount;
 
@@ -248,7 +248,7 @@ public class QueryCacheStats implements JsonpSerializable {
         /**
          * Required - API name: {@code memory_size_in_bytes}
          */
-        public final Builder memorySizeInBytes(int value) {
+        public final Builder memorySizeInBytes(long value) {
             this.memorySizeInBytes = value;
             return this;
         }
@@ -299,7 +299,7 @@ public class QueryCacheStats implements JsonpSerializable {
         op.add(Builder::evictions, JsonpDeserializer.integerDeserializer(), "evictions");
         op.add(Builder::hitCount, JsonpDeserializer.integerDeserializer(), "hit_count");
         op.add(Builder::memorySize, JsonpDeserializer.stringDeserializer(), "memory_size");
-        op.add(Builder::memorySizeInBytes, JsonpDeserializer.integerDeserializer(), "memory_size_in_bytes");
+        op.add(Builder::memorySizeInBytes, JsonpDeserializer.longDeserializer(), "memory_size_in_bytes");
         op.add(Builder::missCount, JsonpDeserializer.integerDeserializer(), "miss_count");
         op.add(Builder::totalCount, JsonpDeserializer.integerDeserializer(), "total_count");
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/SegmentsStats.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/SegmentsStats.java
@@ -56,46 +56,46 @@ public class SegmentsStats implements JsonpSerializable {
     @Nullable
     private final String docValuesMemory;
 
-    private final int docValuesMemoryInBytes;
+    private final long docValuesMemoryInBytes;
 
     private final Map<String, ShardFileSizeInfo> fileSizes;
 
     @Nullable
     private final String fixedBitSet;
 
-    private final int fixedBitSetMemoryInBytes;
+    private final long fixedBitSetMemoryInBytes;
 
     @Nullable
     private final String indexWriterMemory;
 
     @Nullable
-    private final Integer indexWriterMaxMemoryInBytes;
+    private final Long indexWriterMaxMemoryInBytes;
 
-    private final int indexWriterMemoryInBytes;
+    private final long indexWriterMemoryInBytes;
 
     private final long maxUnsafeAutoIdTimestamp;
 
     @Nullable
     private final String memory;
 
-    private final int memoryInBytes;
+    private final long memoryInBytes;
 
     @Nullable
     private final String normsMemory;
 
-    private final int normsMemoryInBytes;
+    private final long normsMemoryInBytes;
 
     @Nullable
     private final String pointsMemory;
 
-    private final int pointsMemoryInBytes;
+    private final long pointsMemoryInBytes;
 
     @Nullable
     private final String storedMemory;
 
-    private final int storedFieldsMemoryInBytes;
+    private final long storedFieldsMemoryInBytes;
 
-    private final int termsMemoryInBytes;
+    private final long termsMemoryInBytes;
 
     @Nullable
     private final String termsMemory;
@@ -103,12 +103,12 @@ public class SegmentsStats implements JsonpSerializable {
     @Nullable
     private final String termVectoryMemory;
 
-    private final int termVectorsMemoryInBytes;
+    private final long termVectorsMemoryInBytes;
 
     @Nullable
     private final String versionMapMemory;
 
-    private final int versionMapMemoryInBytes;
+    private final long versionMapMemoryInBytes;
 
     // ---------------------------------------------------------------------------------------------
 
@@ -163,7 +163,7 @@ public class SegmentsStats implements JsonpSerializable {
     /**
      * Required - API name: {@code doc_values_memory_in_bytes}
      */
-    public final int docValuesMemoryInBytes() {
+    public final long docValuesMemoryInBytes() {
         return this.docValuesMemoryInBytes;
     }
 
@@ -185,7 +185,7 @@ public class SegmentsStats implements JsonpSerializable {
     /**
      * Required - API name: {@code fixed_bit_set_memory_in_bytes}
      */
-    public final int fixedBitSetMemoryInBytes() {
+    public final long fixedBitSetMemoryInBytes() {
         return this.fixedBitSetMemoryInBytes;
     }
 
@@ -201,14 +201,14 @@ public class SegmentsStats implements JsonpSerializable {
      * API name: {@code index_writer_max_memory_in_bytes}
      */
     @Nullable
-    public final Integer indexWriterMaxMemoryInBytes() {
+    public final Long indexWriterMaxMemoryInBytes() {
         return this.indexWriterMaxMemoryInBytes;
     }
 
     /**
      * Required - API name: {@code index_writer_memory_in_bytes}
      */
-    public final int indexWriterMemoryInBytes() {
+    public final long indexWriterMemoryInBytes() {
         return this.indexWriterMemoryInBytes;
     }
 
@@ -230,7 +230,7 @@ public class SegmentsStats implements JsonpSerializable {
     /**
      * Required - API name: {@code memory_in_bytes}
      */
-    public final int memoryInBytes() {
+    public final long memoryInBytes() {
         return this.memoryInBytes;
     }
 
@@ -245,7 +245,7 @@ public class SegmentsStats implements JsonpSerializable {
     /**
      * Required - API name: {@code norms_memory_in_bytes}
      */
-    public final int normsMemoryInBytes() {
+    public final long normsMemoryInBytes() {
         return this.normsMemoryInBytes;
     }
 
@@ -260,7 +260,7 @@ public class SegmentsStats implements JsonpSerializable {
     /**
      * Required - API name: {@code points_memory_in_bytes}
      */
-    public final int pointsMemoryInBytes() {
+    public final long pointsMemoryInBytes() {
         return this.pointsMemoryInBytes;
     }
 
@@ -275,14 +275,14 @@ public class SegmentsStats implements JsonpSerializable {
     /**
      * Required - API name: {@code stored_fields_memory_in_bytes}
      */
-    public final int storedFieldsMemoryInBytes() {
+    public final long storedFieldsMemoryInBytes() {
         return this.storedFieldsMemoryInBytes;
     }
 
     /**
      * Required - API name: {@code terms_memory_in_bytes}
      */
-    public final int termsMemoryInBytes() {
+    public final long termsMemoryInBytes() {
         return this.termsMemoryInBytes;
     }
 
@@ -305,7 +305,7 @@ public class SegmentsStats implements JsonpSerializable {
     /**
      * Required - API name: {@code term_vectors_memory_in_bytes}
      */
-    public final int termVectorsMemoryInBytes() {
+    public final long termVectorsMemoryInBytes() {
         return this.termVectorsMemoryInBytes;
     }
 
@@ -320,7 +320,7 @@ public class SegmentsStats implements JsonpSerializable {
     /**
      * Required - API name: {@code version_map_memory_in_bytes}
      */
-    public final int versionMapMemoryInBytes() {
+    public final long versionMapMemoryInBytes() {
         return this.versionMapMemoryInBytes;
     }
 
@@ -451,46 +451,46 @@ public class SegmentsStats implements JsonpSerializable {
         @Nullable
         private String docValuesMemory;
 
-        private Integer docValuesMemoryInBytes;
+        private Long docValuesMemoryInBytes;
 
         private Map<String, ShardFileSizeInfo> fileSizes;
 
         @Nullable
         private String fixedBitSet;
 
-        private Integer fixedBitSetMemoryInBytes;
+        private Long fixedBitSetMemoryInBytes;
 
         @Nullable
         private String indexWriterMemory;
 
         @Nullable
-        private Integer indexWriterMaxMemoryInBytes;
+        private Long indexWriterMaxMemoryInBytes;
 
-        private Integer indexWriterMemoryInBytes;
+        private Long indexWriterMemoryInBytes;
 
         private Long maxUnsafeAutoIdTimestamp;
 
         @Nullable
         private String memory;
 
-        private Integer memoryInBytes;
+        private Long memoryInBytes;
 
         @Nullable
         private String normsMemory;
 
-        private Integer normsMemoryInBytes;
+        private Long normsMemoryInBytes;
 
         @Nullable
         private String pointsMemory;
 
-        private Integer pointsMemoryInBytes;
+        private Long pointsMemoryInBytes;
 
         @Nullable
         private String storedMemory;
 
-        private Integer storedFieldsMemoryInBytes;
+        private Long storedFieldsMemoryInBytes;
 
-        private Integer termsMemoryInBytes;
+        private Long termsMemoryInBytes;
 
         @Nullable
         private String termsMemory;
@@ -498,12 +498,12 @@ public class SegmentsStats implements JsonpSerializable {
         @Nullable
         private String termVectoryMemory;
 
-        private Integer termVectorsMemoryInBytes;
+        private Long termVectorsMemoryInBytes;
 
         @Nullable
         private String versionMapMemory;
 
-        private Integer versionMapMemoryInBytes;
+        private Long versionMapMemoryInBytes;
 
         /**
          * Required - API name: {@code count}
@@ -524,7 +524,7 @@ public class SegmentsStats implements JsonpSerializable {
         /**
          * Required - API name: {@code doc_values_memory_in_bytes}
          */
-        public final Builder docValuesMemoryInBytes(int value) {
+        public final Builder docValuesMemoryInBytes(long value) {
             this.docValuesMemoryInBytes = value;
             return this;
         }
@@ -569,7 +569,7 @@ public class SegmentsStats implements JsonpSerializable {
         /**
          * Required - API name: {@code fixed_bit_set_memory_in_bytes}
          */
-        public final Builder fixedBitSetMemoryInBytes(int value) {
+        public final Builder fixedBitSetMemoryInBytes(long value) {
             this.fixedBitSetMemoryInBytes = value;
             return this;
         }
@@ -585,7 +585,7 @@ public class SegmentsStats implements JsonpSerializable {
         /**
          * API name: {@code index_writer_max_memory_in_bytes}
          */
-        public final Builder indexWriterMaxMemoryInBytes(@Nullable Integer value) {
+        public final Builder indexWriterMaxMemoryInBytes(@Nullable Long value) {
             this.indexWriterMaxMemoryInBytes = value;
             return this;
         }
@@ -593,7 +593,7 @@ public class SegmentsStats implements JsonpSerializable {
         /**
          * Required - API name: {@code index_writer_memory_in_bytes}
          */
-        public final Builder indexWriterMemoryInBytes(int value) {
+        public final Builder indexWriterMemoryInBytes(long value) {
             this.indexWriterMemoryInBytes = value;
             return this;
         }
@@ -617,7 +617,7 @@ public class SegmentsStats implements JsonpSerializable {
         /**
          * Required - API name: {@code memory_in_bytes}
          */
-        public final Builder memoryInBytes(int value) {
+        public final Builder memoryInBytes(long value) {
             this.memoryInBytes = value;
             return this;
         }
@@ -633,7 +633,7 @@ public class SegmentsStats implements JsonpSerializable {
         /**
          * Required - API name: {@code norms_memory_in_bytes}
          */
-        public final Builder normsMemoryInBytes(int value) {
+        public final Builder normsMemoryInBytes(long value) {
             this.normsMemoryInBytes = value;
             return this;
         }
@@ -649,7 +649,7 @@ public class SegmentsStats implements JsonpSerializable {
         /**
          * Required - API name: {@code points_memory_in_bytes}
          */
-        public final Builder pointsMemoryInBytes(int value) {
+        public final Builder pointsMemoryInBytes(long value) {
             this.pointsMemoryInBytes = value;
             return this;
         }
@@ -665,7 +665,7 @@ public class SegmentsStats implements JsonpSerializable {
         /**
          * Required - API name: {@code stored_fields_memory_in_bytes}
          */
-        public final Builder storedFieldsMemoryInBytes(int value) {
+        public final Builder storedFieldsMemoryInBytes(long value) {
             this.storedFieldsMemoryInBytes = value;
             return this;
         }
@@ -673,7 +673,7 @@ public class SegmentsStats implements JsonpSerializable {
         /**
          * Required - API name: {@code terms_memory_in_bytes}
          */
-        public final Builder termsMemoryInBytes(int value) {
+        public final Builder termsMemoryInBytes(long value) {
             this.termsMemoryInBytes = value;
             return this;
         }
@@ -697,7 +697,7 @@ public class SegmentsStats implements JsonpSerializable {
         /**
          * Required - API name: {@code term_vectors_memory_in_bytes}
          */
-        public final Builder termVectorsMemoryInBytes(int value) {
+        public final Builder termVectorsMemoryInBytes(long value) {
             this.termVectorsMemoryInBytes = value;
             return this;
         }
@@ -713,7 +713,7 @@ public class SegmentsStats implements JsonpSerializable {
         /**
          * Required - API name: {@code version_map_memory_in_bytes}
          */
-        public final Builder versionMapMemoryInBytes(int value) {
+        public final Builder versionMapMemoryInBytes(long value) {
             this.versionMapMemoryInBytes = value;
             return this;
         }
@@ -745,28 +745,28 @@ public class SegmentsStats implements JsonpSerializable {
 
         op.add(Builder::count, JsonpDeserializer.integerDeserializer(), "count");
         op.add(Builder::docValuesMemory, JsonpDeserializer.stringDeserializer(), "doc_values_memory");
-        op.add(Builder::docValuesMemoryInBytes, JsonpDeserializer.integerDeserializer(), "doc_values_memory_in_bytes");
+        op.add(Builder::docValuesMemoryInBytes, JsonpDeserializer.longDeserializer(), "doc_values_memory_in_bytes");
         op.add(Builder::fileSizes, JsonpDeserializer.stringMapDeserializer(ShardFileSizeInfo._DESERIALIZER), "file_sizes");
         op.add(Builder::fixedBitSet, JsonpDeserializer.stringDeserializer(), "fixed_bit_set");
-        op.add(Builder::fixedBitSetMemoryInBytes, JsonpDeserializer.integerDeserializer(), "fixed_bit_set_memory_in_bytes");
+        op.add(Builder::fixedBitSetMemoryInBytes, JsonpDeserializer.longDeserializer(), "fixed_bit_set_memory_in_bytes");
         op.add(Builder::indexWriterMemory, JsonpDeserializer.stringDeserializer(), "index_writer_memory");
-        op.add(Builder::indexWriterMaxMemoryInBytes, JsonpDeserializer.integerDeserializer(), "index_writer_max_memory_in_bytes");
-        op.add(Builder::indexWriterMemoryInBytes, JsonpDeserializer.integerDeserializer(), "index_writer_memory_in_bytes");
+        op.add(Builder::indexWriterMaxMemoryInBytes, JsonpDeserializer.longDeserializer(), "index_writer_max_memory_in_bytes");
+        op.add(Builder::indexWriterMemoryInBytes, JsonpDeserializer.longDeserializer(), "index_writer_memory_in_bytes");
         op.add(Builder::maxUnsafeAutoIdTimestamp, JsonpDeserializer.longDeserializer(), "max_unsafe_auto_id_timestamp");
         op.add(Builder::memory, JsonpDeserializer.stringDeserializer(), "memory");
-        op.add(Builder::memoryInBytes, JsonpDeserializer.integerDeserializer(), "memory_in_bytes");
+        op.add(Builder::memoryInBytes, JsonpDeserializer.longDeserializer(), "memory_in_bytes");
         op.add(Builder::normsMemory, JsonpDeserializer.stringDeserializer(), "norms_memory");
-        op.add(Builder::normsMemoryInBytes, JsonpDeserializer.integerDeserializer(), "norms_memory_in_bytes");
+        op.add(Builder::normsMemoryInBytes, JsonpDeserializer.longDeserializer(), "norms_memory_in_bytes");
         op.add(Builder::pointsMemory, JsonpDeserializer.stringDeserializer(), "points_memory");
-        op.add(Builder::pointsMemoryInBytes, JsonpDeserializer.integerDeserializer(), "points_memory_in_bytes");
+        op.add(Builder::pointsMemoryInBytes, JsonpDeserializer.longDeserializer(), "points_memory_in_bytes");
         op.add(Builder::storedMemory, JsonpDeserializer.stringDeserializer(), "stored_memory");
-        op.add(Builder::storedFieldsMemoryInBytes, JsonpDeserializer.integerDeserializer(), "stored_fields_memory_in_bytes");
-        op.add(Builder::termsMemoryInBytes, JsonpDeserializer.integerDeserializer(), "terms_memory_in_bytes");
+        op.add(Builder::storedFieldsMemoryInBytes, JsonpDeserializer.longDeserializer(), "stored_fields_memory_in_bytes");
+        op.add(Builder::termsMemoryInBytes, JsonpDeserializer.longDeserializer(), "terms_memory_in_bytes");
         op.add(Builder::termsMemory, JsonpDeserializer.stringDeserializer(), "terms_memory");
         op.add(Builder::termVectoryMemory, JsonpDeserializer.stringDeserializer(), "term_vectory_memory");
-        op.add(Builder::termVectorsMemoryInBytes, JsonpDeserializer.integerDeserializer(), "term_vectors_memory_in_bytes");
+        op.add(Builder::termVectorsMemoryInBytes, JsonpDeserializer.longDeserializer(), "term_vectors_memory_in_bytes");
         op.add(Builder::versionMapMemory, JsonpDeserializer.stringDeserializer(), "version_map_memory");
-        op.add(Builder::versionMapMemoryInBytes, JsonpDeserializer.integerDeserializer(), "version_map_memory_in_bytes");
+        op.add(Builder::versionMapMemoryInBytes, JsonpDeserializer.longDeserializer(), "version_map_memory_in_bytes");
 
     }
 


### PR DESCRIPTION
### Description
Some values in index stats still have an int which can overflow as reported in #875. Fixing in this PR. A similar fix was done some time back for some stats: https://github.com/opensearch-project/opensearch-java/pull/489. 

I also skimmed through other stats to verify that the variables related to bytes are converted to long.

### Issues Resolved
Fixes #875 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
