### PR TITLE
Backporting missed dependency updates to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
+- Bumps `io.github.classgraph:classgraph` from 4.8.161 to 4.8.165
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bumps `io.github.classgraph:classgraph` from 4.8.161 to 4.8.165
 - Bumps `org.owasp.dependencycheck` from 9.0.8 to 9.0.9
+- Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.3.0 to 5.3.1
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `io.github.classgraph:classgraph` from 4.8.161 to 4.8.165
+- Bumps `org.owasp.dependencycheck` from 9.0.8 to 9.0.9
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -211,7 +211,7 @@ dependencies {
     implementation("org.eclipse", "yasson", "2.0.2")
 
     // https://github.com/classgraph/classgraph
-    testImplementation("io.github.classgraph:classgraph:4.8.161")
+    testImplementation("io.github.classgraph:classgraph:4.8.165")
 
     // Eclipse 1.0
     testImplementation("junit", "junit" , "4.13.2") {

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -49,8 +49,8 @@ plugins {
     `java-library`
     `maven-publish`
     id("com.github.jk1.dependency-license-report") version "2.5"
-    id("org.owasp.dependencycheck") version "9.0.8"
     id("com.diffplug.spotless") version "6.25.0"
+    id("org.owasp.dependencycheck") version "9.0.9"
 }
 
 apply(plugin = "org.owasp.dependencycheck")

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -192,7 +192,9 @@ dependencies {
     testImplementation("com.fasterxml.jackson.datatype", "jackson-datatype-jakarta-jsonp", jacksonVersion)
 
     // ApacheHttpClient5Transport dependencies (optional)
-    implementation("org.apache.httpcomponents.client5", "httpclient5", "5.3")
+    implementation("org.apache.httpcomponents.client5", "httpclient5", "5.3.1") {
+      exclude(group = "org.apache.httpcomponents.core5")
+    }
     implementation("org.apache.httpcomponents.core5", "httpcore5", "5.2.4")
 
     // For AwsSdk2Transport


### PR DESCRIPTION
### Description
While cleaning up the changelogs, I found some missing backports. Backport #762, #817 and #822 to 2.x

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
