### PR TITLE
Support optional function score variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
+- Support weight function in function score query ([#880](https://github.com/opensearch-project/opensearch-java/pull/880))
 
 ### Security
 
@@ -43,6 +44,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix integer overflow for variables in indices stats response ([#877](https://github.com/opensearch-project/opensearch-java/pull/877))
+- Support weight function in function score query ([#880](https://github.com/opensearch-project/opensearch-java/pull/880))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
-- Support weight function in function score query ([#880](https://github.com/opensearch-project/opensearch-java/pull/880))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/FunctionScore.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/FunctionScore.java
@@ -106,10 +106,14 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, Object>, J
     @Nullable
     private final Double weight;
 
-    public FunctionScore(FunctionScoreVariant value) {
-
-        this._kind = ApiTypeHelper.requireNonNull(value._functionScoreKind(), this, "<variant kind>");
-        this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+    public FunctionScore(@Nullable FunctionScoreVariant value) {
+        if (value != null) {
+            this._kind = ApiTypeHelper.requireNonNull(value._functionScoreKind(), this, "<variant kind>");
+            this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        } else {
+            this._kind = null;
+            this._value = null;
+        }
 
         this.filter = null;
         this.weight = null;
@@ -117,9 +121,13 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, Object>, J
     }
 
     private FunctionScore(Builder builder) {
-
-        this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
-        this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        if (builder._value != null) {
+            this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
+            this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        } else {
+            this._kind = null;
+            this._value = null;
+        }
 
         this.filter = builder.filter;
         this.weight = builder.weight;
@@ -266,9 +274,11 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, Object>, J
 
         }
 
-        generator.writeKey(_kind.jsonValue());
-        if (_value instanceof JsonpSerializable) {
-            ((JsonpSerializable) _value).serialize(generator, mapper);
+        if (_value != null) {
+            generator.writeKey(_kind.jsonValue());
+            if (_value instanceof JsonpSerializable) {
+                ((JsonpSerializable) _value).serialize(generator, mapper);
+            }
         }
 
         generator.writeEnd();
@@ -279,8 +289,10 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, Object>, J
         return new Builder()._kind(_kind)._value(_value).filter(filter).weight(weight);
     }
 
-    public static class Builder extends ObjectBuilderBase {
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<FunctionScore> {
+        @Nullable
         private Kind _kind;
+        @Nullable
         private Object _value;
 
         @Nullable
@@ -289,12 +301,12 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, Object>, J
         @Nullable
         private Double weight;
 
-        protected final Builder _kind(Kind v) {
+        protected final Builder _kind(@Nullable Kind v) {
             this._kind = v;
             return this;
         }
 
-        protected final Builder _value(Object v) {
+        protected final Builder _value(@Nullable Object v) {
             this._value = v;
             return this;
         }
@@ -384,7 +396,7 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, Object>, J
             return this.scriptScore(fn.apply(new ScriptScoreFunction.Builder()).build());
         }
 
-        protected FunctionScore build() {
+        public FunctionScore build() {
             _checkSingleUse();
             return new FunctionScore(this);
         }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/FunctionScoreQueryTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/FunctionScoreQueryTest.java
@@ -14,9 +14,7 @@ public class FunctionScoreQueryTest extends ModelTestCase {
 
     @Test
     public void canSupportWeightFunction() {
-        Query functionScoreQuery = FunctionScoreQuery.of(fs -> fs
-                .functions(f -> f.weight(5d))
-        )._toQuery();
+        Query functionScoreQuery = FunctionScoreQuery.of(fs -> fs.functions(f -> f.weight(5d)))._toQuery();
 
         String json = "{\"function_score\":{\"functions\":[{\"weight\":5.0}]}}";
 
@@ -30,8 +28,8 @@ public class FunctionScoreQueryTest extends ModelTestCase {
 
     @Test
     public void canSupportFunctionVariant() {
-        Query functionScoreQuery = FunctionScoreQuery.of(fs -> fs
-                .functions(f -> f.weight(3d).linear(l -> l.field("field").placement(p -> p.decay(8.0))))
+        Query functionScoreQuery = FunctionScoreQuery.of(
+            fs -> fs.functions(f -> f.weight(3d).linear(l -> l.field("field").placement(p -> p.decay(8.0))))
         )._toQuery();
 
         String json = "{\"function_score\":{\"functions\":[{\"weight\":3.0,\"linear\":{\"field\":{\"decay\":8.0}}}]}}";

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/FunctionScoreQueryTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/FunctionScoreQueryTest.java
@@ -11,4 +11,37 @@ public class FunctionScoreQueryTest extends ModelTestCase {
 
         assertEquals(toJson(copied), toJson(origin));
     }
+
+    @Test
+    public void canSupportWeightFunction() {
+        Query functionScoreQuery = FunctionScoreQuery.of(fs -> fs
+                .functions(f -> f.weight(5d))
+        )._toQuery();
+
+        String json = "{\"function_score\":{\"functions\":[{\"weight\":5.0}]}}";
+
+        assertEquals(json, toJson(functionScoreQuery));
+
+        Query roundtripQuery = checkJsonRoundtrip(functionScoreQuery, json);
+
+        assertNull(roundtripQuery.functionScore().functions().get(0)._kind());
+        assertEquals(5.0, roundtripQuery.functionScore().functions().get(0).weight(), 0.001);
+    }
+
+    @Test
+    public void canSupportFunctionVariant() {
+        Query functionScoreQuery = FunctionScoreQuery.of(fs -> fs
+                .functions(f -> f.weight(3d).linear(l -> l.field("field").placement(p -> p.decay(8.0))))
+        )._toQuery();
+
+        String json = "{\"function_score\":{\"functions\":[{\"weight\":3.0,\"linear\":{\"field\":{\"decay\":8.0}}}]}}";
+
+        assertEquals(json, toJson(functionScoreQuery));
+
+        Query roundtripQuery = checkJsonRoundtrip(functionScoreQuery, json);
+
+        assertEquals(FunctionScore.Kind.Linear, roundtripQuery.functionScore().functions().get(0)._kind());
+        assertEquals(3.0, roundtripQuery.functionScore().functions().get(0).weight(), 0.001);
+        assertEquals(8.0, roundtripQuery.functionScore().functions().get(0).linear().placement().decay(), 0.001);
+    }
 }


### PR DESCRIPTION
### Description
This PR supports function score functions with an optional function variant. The function is optional as it is perfectly valid to have a function with only a weight e.g. a function score query with multiple functions and a score mode of "first", where the last weight function acts as some default value.

https://github.com/opensearch-project/opensearch-java/pull/786 also addresses this issue but contains quite a few other unrelated changes e.g. `DelegatingJsonpMapper`.

### Issues Resolved
Closes #820 
Closes #752

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
