### PR TITLE
Fix KNNQuery Precision

### DIFF
--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQuery.java
@@ -9,6 +9,7 @@
 package org.opensearch.client.opensearch._types.query_dsl;
 
 import jakarta.json.stream.JsonGenerator;
+import java.math.BigDecimal;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.opensearch.client.json.JsonpDeserializable;
@@ -18,6 +19,8 @@ import org.opensearch.client.json.ObjectBuilderDeserializer;
 import org.opensearch.client.json.ObjectDeserializer;
 import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.ObjectBuilder;
+
+import static java.math.RoundingMode.HALF_UP;
 
 @JsonpDeserializable
 public class KnnQuery extends QueryBase implements QueryVariant {
@@ -93,7 +96,9 @@ public class KnnQuery extends QueryBase implements QueryVariant {
         generator.writeKey("vector");
         generator.writeStartArray();
         for (float value : this.vector) {
-            generator.write(value);
+            BigDecimal b = new BigDecimal(value);
+            double T = b.setScale(6, HALF_UP).doubleValue();
+            generator.write(T);
         }
         generator.writeEnd();
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQueryTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQueryTest.java
@@ -11,4 +11,11 @@ public class KnnQueryTest extends ModelTestCase {
 
         assertEquals(toJson(copied), toJson(origin));
     }
+
+    @Test
+    public void toBuilderPrecision() {
+        KnnQuery origin = new KnnQuery.Builder().field("field").vector(new float[] { 0.1f, 0.4f }).k(1).build();
+
+        assertEquals(toJson(origin), "{\"field\":{\"vector\":[0.1,0.4],\"k\":1}}");
+    }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/model/RequestEncodingTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/model/RequestEncodingTest.java
@@ -33,6 +33,7 @@
 package org.opensearch.client.opensearch.model;
 
 import org.junit.Test;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch.core.SearchRequest;
 
@@ -60,5 +61,23 @@ public class RequestEncodingTest extends ModelTestCase {
         assertEquals("foo", request.query().type().value());
         assertNull(request.q());
 
+    }
+
+    @Test
+    public void testKnnVectorPrecision() {
+
+        float[] vector = {0.4f, 0.3f};
+        SearchRequest request = new SearchRequest.Builder().q("knn")
+                .query(q -> q.knn(k -> k.field("values").vector(vector).k(1)))
+                .build();
+
+        JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        String str = toJson(request, mapper);
+        assertEquals("{\"query\":{\"knn\":{\"values\":{\"vector\":[0.4,0.3],\"k\":1}}}}", str);
+
+        request = fromJson(str, SearchRequest.class, mapper);
+
+        assertTrue(request.query().isKnn());
+        assertNull(request.q());
     }
 }


### PR DESCRIPTION
### Description
There is a knn query like

```
KnnQuery origin = new KnnQuery.Builder().field("field").vector(new float[] { 0.1f, 0.4f }).k(1).build();
```

When it serialize to json string, the result would be:

```
{"field":{"vector":[0.10000000149011612,0.4000000059604645],"k":1}}
```

like the test code shows:

https://github.com/luyuncheng/opensearch-java/blob/4436e89a0f48d54e47c2c33689e0b828cbb31149/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQueryTest.java#L16-L19

### Proposal
I think it because in `KnnQuery#serializeInternal` call `generator.write(value);` but `jakarta.json.stream.JsonGenerator` write numeric only support double. when `KnnQuery#vector` is float type, it would make precision not correctly.

https://github.com/opensearch-project/opensearch-java/blob/045c805eb58a166f55888d27a0358d184f117761/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQuery.java#L86-L97

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
