### PR TITLE
[Backport] [2.x] Bump org.owasp.dependencycheck from 9.0.9 to 9.0.10 (#898)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `io.github.classgraph:classgraph` from 4.8.161 to 4.8.165
-- Bumps `org.owasp.dependencycheck` from 9.0.8 to 9.0.9
+- Bumps `org.owasp.dependencycheck` from 9.0.8 to 9.0.10
 - Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.3.0 to 5.3.1
 
 ### Changed

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -48,9 +48,9 @@ plugins {
     java
     `java-library`
     `maven-publish`
-    id("com.github.jk1.dependency-license-report") version "2.5"
+    id("com.github.jk1.dependency-license-report") version "2.6"
     id("com.diffplug.spotless") version "6.25.0"
-    id("org.owasp.dependencycheck") version "9.0.9"
+    id("org.owasp.dependencycheck") version "9.0.10"
 }
 
 apply(plugin = "org.owasp.dependencycheck")


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/898 to `2.x`