### PR TITLE
[Backport] [2.x] Bump io.github.classgraph:classgraph from 4.8.165 to 4.8.168 in /java-client (#897) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `io.github.classgraph:classgraph` from 4.8.161 to 4.8.165
 - Bumps `org.owasp.dependencycheck` from 9.0.8 to 9.0.10
 - Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.3.0 to 5.3.1
+- Bumps `io.github.classgraph:classgraph` from 4.8.165 to 4.8.168
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -213,7 +213,7 @@ dependencies {
     implementation("org.eclipse", "yasson", "2.0.2")
 
     // https://github.com/classgraph/classgraph
-    testImplementation("io.github.classgraph:classgraph:4.8.165")
+    testImplementation("io.github.classgraph:classgraph:4.8.168")
 
     // Eclipse 1.0
     testImplementation("junit", "junit" , "4.13.2") {


### PR DESCRIPTION
Backport of #897 to `2.x`