### PR TITLE
Bumps jackson from 2.15.2 to 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 - Bumps `io.github.classgraph:classgraph` from 4.8.161 to 4.8.165
 - Bumps `org.owasp.dependencycheck` from 9.0.8 to 9.0.9
 - Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.3.0 to 5.3.1
+- Bumps `jackson` from 2.15.2 to 2.17.0
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -165,8 +165,8 @@ val opensearchVersion = "3.0.0-SNAPSHOT"
 
 dependencies {
 
-    val jacksonVersion = "2.15.2"
-    val jacksonDatabindVersion = "2.15.2"
+    val jacksonVersion = "2.17.0"
+    val jacksonDatabindVersion = "2.17.0"
 
     // Apache 2.0
     compileOnly("org.opensearch.client", "opensearch-rest-client", opensearchVersion)


### PR DESCRIPTION
### Description
Bumps jackson from 2.15.2 to 2.17.0

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
