### PR TITLE
[Backport] [2.x] Bumps jackson from 2.15.2 to 2.17.0 (#909)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `org.owasp.dependencycheck` from 9.0.8 to 9.1.0
 - Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.3.0 to 5.3.1
 - Bumps `io.github.classgraph:classgraph` from 4.8.165 to 4.8.168
+- Bumps `jackson` from 2.15.2 to 2.17.0
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -162,8 +162,8 @@ val opensearchVersion = "2.12.0"
 
 dependencies {
 
-    val jacksonVersion = "2.16.1"
-    val jacksonDatabindVersion = "2.16.1"
+    val jacksonVersion = "2.17.0"
+    val jacksonDatabindVersion = "2.17.0"
 
     // Apache 2.0
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/909 to `2.x`