### PR TITLE
Add missed fields to MultisearchBody: collapse, version, timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Added
 - Add missed fields to MultisearchBody: seqNoPrimaryTerm, storedFields, explain, fields, indicesBoost ([#914](https://github.com/opensearch-project/opensearch-java/pull/914))
+- Add missed fields to MultisearchBody: collapse, version, timeout ([#916](https://github.com/opensearch-project/opensearch-java/pull/916)
 
 ### Dependencies
 - Bumps `io.github.classgraph:classgraph` from 4.8.161 to 4.8.165

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/msearch/MultisearchBody.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/msearch/MultisearchBody.java
@@ -49,6 +49,7 @@ import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.query_dsl.FieldAndFormat;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.SearchRequest.Builder;
+import org.opensearch.client.opensearch.core.search.FieldCollapse;
 import org.opensearch.client.opensearch.core.search.Highlight;
 import org.opensearch.client.opensearch.core.search.SourceConfig;
 import org.opensearch.client.opensearch.core.search.Suggester;
@@ -111,6 +112,15 @@ public class MultisearchBody implements JsonpSerializable {
 
     private final List<Map<String, Double>> indicesBoost;
 
+    @Nullable
+    private final FieldCollapse collapse;
+
+    @Nullable
+    private final Boolean version;
+
+    @Nullable
+    private final String timeout;
+
     // ---------------------------------------------------------------------------------------------
 
     private MultisearchBody(Builder builder) {
@@ -134,6 +144,9 @@ public class MultisearchBody implements JsonpSerializable {
         this.explain = builder.explain;
         this.fields = ApiTypeHelper.unmodifiable(builder.fields);
         this.indicesBoost = ApiTypeHelper.unmodifiable(builder.indicesBoost);
+        this.collapse = builder.collapse;
+        this.version = builder.version;
+        this.timeout = builder.timeout;
     }
 
     public static MultisearchBody of(Function<Builder, ObjectBuilder<MultisearchBody>> fn) {
@@ -299,6 +312,36 @@ public class MultisearchBody implements JsonpSerializable {
     }
 
     /**
+     * API name: {@code collapse}
+     */
+    @Nullable
+    public final FieldCollapse collapse() {
+        return this.collapse;
+    }
+
+    /**
+     * If true, returns document version as part of a hit.
+     * <p>
+     * API name: {@code version}
+     */
+    @Nullable
+    public final Boolean version() {
+        return this.version;
+    }
+
+    /**
+     * Specifies the period of time to wait for a response from each shard. If no
+     * response is received before the timeout expires, the request fails and
+     * returns an error. Defaults to no timeout.
+     * <p>
+     * API name: {@code timeout}
+     */
+    @Nullable
+    public final String timeout() {
+        return this.timeout;
+    }
+
+    /**
      * Serialize this object to JSON.
      */
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
@@ -453,6 +496,21 @@ public class MultisearchBody implements JsonpSerializable {
             }
             generator.writeEnd();
         }
+
+        if (this.collapse != null) {
+            generator.writeKey("collapse");
+            this.collapse.serialize(generator, mapper);
+        }
+
+        if (this.version != null) {
+            generator.writeKey("version");
+            generator.write(this.version);
+        }
+
+        if (this.timeout != null) {
+            generator.writeKey("timeout");
+            generator.write(this.timeout);
+        }
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -517,6 +575,15 @@ public class MultisearchBody implements JsonpSerializable {
 
         @Nullable
         private List<Map<String, Double>> indicesBoost;
+
+        @Nullable
+        private FieldCollapse collapse;
+
+        @Nullable
+        private Boolean version;
+
+        @Nullable
+        private String timeout;
 
         /**
          * API name: {@code aggregations}
@@ -862,6 +929,43 @@ public class MultisearchBody implements JsonpSerializable {
         }
 
         /**
+         * API name: {@code collapse}
+         */
+        public final Builder collapse(@Nullable FieldCollapse value) {
+            this.collapse = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code collapse}
+         */
+        public final Builder collapse(Function<FieldCollapse.Builder, ObjectBuilder<FieldCollapse>> fn) {
+            return this.collapse(fn.apply(new FieldCollapse.Builder()).build());
+        }
+
+        /**
+         * If true, returns document version as part of a hit.
+         * <p>
+         * API name: {@code version}
+         */
+        public final Builder version(@Nullable Boolean value) {
+            this.version = value;
+            return this;
+        }
+
+        /**
+         * Specifies the period of time to wait for a response from each shard. If no
+         * response is received before the timeout expires, the request fails and
+         * returns an error. Defaults to no timeout.
+         * <p>
+         * API name: {@code timeout}
+         */
+        public final Builder timeout(@Nullable String value) {
+            this.timeout = value;
+            return this;
+        }
+
+        /**
          * Builds a {@link MultisearchBody}.
          *
          * @throws NullPointerException
@@ -909,6 +1013,9 @@ public class MultisearchBody implements JsonpSerializable {
             JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringMapDeserializer(JsonpDeserializer.doubleDeserializer())),
             "indices_boost"
         );
+        op.add(Builder::collapse, FieldCollapse._DESERIALIZER, "collapse");
+        op.add(Builder::version, JsonpDeserializer.booleanDeserializer(), "version");
+        op.add(Builder::timeout, JsonpDeserializer.stringDeserializer(), "timeout");
     }
 
 }

--- a/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/AbstractMultiSearchRequestIT.java
+++ b/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/AbstractMultiSearchRequestIT.java
@@ -36,6 +36,7 @@ import org.opensearch.client.opensearch.core.MsearchResponse;
 import org.opensearch.client.opensearch.core.msearch.MultiSearchResponseItem;
 import org.opensearch.client.opensearch.core.msearch.MultisearchBody;
 import org.opensearch.client.opensearch.core.msearch.RequestItem;
+import org.opensearch.client.opensearch.core.search.FieldCollapse;
 import org.opensearch.client.opensearch.core.search.Highlight;
 import org.opensearch.client.opensearch.core.search.HighlightField;
 import org.opensearch.client.opensearch.core.search.Hit;
@@ -263,6 +264,19 @@ public abstract class AbstractMultiSearchRequestIT extends OpenSearchJavaClientT
         createTestDocuments(index);
 
         RequestItem sortedItemsQuery = createMSearchFuzzyRequest(b -> b.indicesBoost(Collections.singletonMap(index, 2d)));
+
+        MsearchResponse<ShopItem> response = sendMSearchRequest(index, List.of(sortedItemsQuery));
+        assertEquals(1, response.responses().size());
+        assertEquals(3, response.responses().get(0).result().hits().hits().size());
+    }
+
+    public void shouldReturnMultiSearchesCollapse() throws Exception {
+        String index = "multiple_searches_request_indices_boost";
+        createTestDocuments(index);
+
+        RequestItem sortedItemsQuery = createMSearchFuzzyRequest(
+            b -> b.collapse(FieldCollapse.of(f -> f.field("name"))).version(true).timeout("5s")
+        );
 
         MsearchResponse<ShopItem> response = sendMSearchRequest(index, List.of(sortedItemsQuery));
         assertEquals(1, response.responses().size());


### PR DESCRIPTION
### Description
Add missed fields to MultisearchBody: collapse, version, timeout

### Issues Resolved
Came up while implementing https://github.com/opensearch-project/spring-data-opensearch/issues/19

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
