### PR TITLE
Add missed fields to MultisearchBody: ext, rescore and to SearchRequest: ext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Added
 - Add missed fields to MultisearchBody: seqNoPrimaryTerm, storedFields, explain, fields, indicesBoost ([#914](https://github.com/opensearch-project/opensearch-java/pull/914))
 - Add missed fields to MultisearchBody: collapse, version, timeout ([#916](https://github.com/opensearch-project/opensearch-java/pull/916)
+- Add missed fields to MultisearchBody: ext, rescore and to SearchRequest: ext ([#918](https://github.com/opensearch-project/opensearch-java/pull/918)
 
 ### Dependencies
 - Bumps `io.github.classgraph:classgraph` from 4.8.161 to 4.8.165

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
@@ -59,6 +60,7 @@ import org.opensearch.client.opensearch._types.mapping.RuntimeField;
 import org.opensearch.client.opensearch._types.query_dsl.FieldAndFormat;
 import org.opensearch.client.opensearch._types.query_dsl.Operator;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchTemplateRequest.Builder;
 import org.opensearch.client.opensearch.core.search.FieldCollapse;
 import org.opensearch.client.opensearch.core.search.Highlight;
 import org.opensearch.client.opensearch.core.search.Pit;
@@ -223,6 +225,8 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
     @Nullable
     private final Boolean version;
 
+    private final Map<String, JsonData> ext;
+
     // ---------------------------------------------------------------------------------------------
 
     private SearchRequest(Builder builder) {
@@ -279,6 +283,7 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
         this.trackScores = builder.trackScores;
         this.trackTotalHits = builder.trackTotalHits;
         this.version = builder.version;
+        this.ext = ApiTypeHelper.unmodifiable(builder.ext);
 
     }
 
@@ -822,6 +827,13 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
     }
 
     /**
+     * API name: {@code ext}
+     */
+    public final Map<String, JsonData> ext() {
+        return this.ext;
+    }
+
+    /**
      * Serialize this object to JSON.
      */
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
@@ -1050,6 +1062,17 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
 
         }
 
+        if (ApiTypeHelper.isDefined(this.ext)) {
+            generator.writeKey("ext");
+            generator.writeStartObject();
+            for (Map.Entry<String, JsonData> item0 : this.ext.entrySet()) {
+                generator.writeKey(item0.getKey());
+                item0.getValue().serialize(generator, mapper);
+
+            }
+            generator.writeEnd();
+        }
+
     }
 
     public Builder toBuilder() {
@@ -1104,7 +1127,8 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
             .timeout(timeout)
             .trackScores(trackScores)
             .trackTotalHits(trackTotalHits)
-            .version(version);
+            .version(version)
+            .ext(ext);
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -1269,6 +1293,9 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
 
         @Nullable
         private Boolean version;
+
+        @Nullable
+        private Map<String, JsonData> ext;
 
         /**
          * Indicates which source fields are returned for matching documents. These
@@ -2153,6 +2180,26 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
         }
 
         /**
+         * API name: {@code ext}
+         * <p>
+         * Adds all entries of <code>map</code> to <code>ext</code>.
+         */
+        public final Builder ext(Map<String, JsonData> map) {
+            this.ext = _mapPutAll(this.ext, map);
+            return this;
+        }
+
+        /**
+         * API name: {@code ext}
+         * <p>
+         * Adds an entry to <code>ext</code>.
+         */
+        public final Builder ext(String key, JsonData value) {
+            this.ext = _mapPut(this.ext, key, value);
+            return this;
+        }
+
+        /**
          * Builds a {@link SearchRequest}.
          *
          * @throws NullPointerException
@@ -2211,6 +2258,7 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
         op.add(Builder::trackScores, JsonpDeserializer.booleanDeserializer(), "track_scores");
         op.add(Builder::trackTotalHits, TrackHits._DESERIALIZER, "track_total_hits");
         op.add(Builder::version, JsonpDeserializer.booleanDeserializer(), "version");
+        op.add(Builder::ext, JsonpDeserializer.stringMapDeserializer(JsonData._DESERIALIZER), "ext");
 
     }
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/msearch/MultisearchBody.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/msearch/MultisearchBody.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
@@ -51,6 +52,7 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.SearchRequest.Builder;
 import org.opensearch.client.opensearch.core.search.FieldCollapse;
 import org.opensearch.client.opensearch.core.search.Highlight;
+import org.opensearch.client.opensearch.core.search.Rescore;
 import org.opensearch.client.opensearch.core.search.SourceConfig;
 import org.opensearch.client.opensearch.core.search.Suggester;
 import org.opensearch.client.opensearch.core.search.TrackHits;
@@ -121,6 +123,10 @@ public class MultisearchBody implements JsonpSerializable {
     @Nullable
     private final String timeout;
 
+    private final List<Rescore> rescore;
+
+    private final Map<String, JsonData> ext;
+
     // ---------------------------------------------------------------------------------------------
 
     private MultisearchBody(Builder builder) {
@@ -147,6 +153,8 @@ public class MultisearchBody implements JsonpSerializable {
         this.collapse = builder.collapse;
         this.version = builder.version;
         this.timeout = builder.timeout;
+        this.rescore = ApiTypeHelper.unmodifiable(builder.rescore);
+        this.ext = ApiTypeHelper.unmodifiable(builder.ext);
     }
 
     public static MultisearchBody of(Function<Builder, ObjectBuilder<MultisearchBody>> fn) {
@@ -342,6 +350,20 @@ public class MultisearchBody implements JsonpSerializable {
     }
 
     /**
+     * API name: {@code rescore}
+     */
+    public final List<Rescore> rescore() {
+        return this.rescore;
+    }
+
+    /**
+     * API name: {@code ext}
+     */
+    public final Map<String, JsonData> ext() {
+        return this.ext;
+    }
+
+    /**
      * Serialize this object to JSON.
      */
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
@@ -511,6 +533,27 @@ public class MultisearchBody implements JsonpSerializable {
             generator.writeKey("timeout");
             generator.write(this.timeout);
         }
+
+        if (ApiTypeHelper.isDefined(this.rescore)) {
+            generator.writeKey("rescore");
+            generator.writeStartArray();
+            for (Rescore item0 : this.rescore) {
+                item0.serialize(generator, mapper);
+
+            }
+            generator.writeEnd();
+        }
+
+        if (ApiTypeHelper.isDefined(this.ext)) {
+            generator.writeKey("ext");
+            generator.writeStartObject();
+            for (Map.Entry<String, JsonData> item0 : this.ext.entrySet()) {
+                generator.writeKey(item0.getKey());
+                item0.getValue().serialize(generator, mapper);
+
+            }
+            generator.writeEnd();
+        }
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -584,6 +627,12 @@ public class MultisearchBody implements JsonpSerializable {
 
         @Nullable
         private String timeout;
+
+        @Nullable
+        private List<Rescore> rescore;
+
+        @Nullable
+        private Map<String, JsonData> ext;
 
         /**
          * API name: {@code aggregations}
@@ -966,6 +1015,55 @@ public class MultisearchBody implements JsonpSerializable {
         }
 
         /**
+         * API name: {@code rescore}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>rescore</code>.
+         */
+        public final Builder rescore(List<Rescore> list) {
+            this.rescore = _listAddAll(this.rescore, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code rescore}
+         * <p>
+         * Adds one or more values to <code>rescore</code>.
+         */
+        public final Builder rescore(Rescore value, Rescore... values) {
+            this.rescore = _listAdd(this.rescore, value, values);
+            return this;
+        }
+
+        /**
+         * API name: {@code rescore}
+         * <p>
+         * Adds a value to <code>rescore</code> using a builder lambda.
+         */
+        public final Builder rescore(Function<Rescore.Builder, ObjectBuilder<Rescore>> fn) {
+            return rescore(fn.apply(new Rescore.Builder()).build());
+        }
+
+        /**
+         * API name: {@code ext}
+         * <p>
+         * Adds all entries of <code>map</code> to <code>ext</code>.
+         */
+        public final Builder ext(Map<String, JsonData> map) {
+            this.ext = _mapPutAll(this.ext, map);
+            return this;
+        }
+
+        /**
+         * API name: {@code ext}
+         * <p>
+         * Adds an entry to <code>ext</code>.
+         */
+        public final Builder ext(String key, JsonData value) {
+            this.ext = _mapPut(this.ext, key, value);
+            return this;
+        }
+
+        /**
          * Builds a {@link MultisearchBody}.
          *
          * @throws NullPointerException
@@ -1016,6 +1114,8 @@ public class MultisearchBody implements JsonpSerializable {
         op.add(Builder::collapse, FieldCollapse._DESERIALIZER, "collapse");
         op.add(Builder::version, JsonpDeserializer.booleanDeserializer(), "version");
         op.add(Builder::timeout, JsonpDeserializer.stringDeserializer(), "timeout");
+        op.add(Builder::rescore, JsonpDeserializer.arrayDeserializer(Rescore._DESERIALIZER), "rescore");
+        op.add(Builder::ext, JsonpDeserializer.stringMapDeserializer(JsonData._DESERIALIZER), "ext");
     }
 
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
@@ -1,6 +1,8 @@
 package org.opensearch.client.opensearch.core;
 
+import java.util.Collections;
 import org.junit.Test;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch.model.ModelTestCase;
 
@@ -10,6 +12,16 @@ public class SearchRequestTest extends ModelTestCase {
         SearchRequest request = new SearchRequest.Builder().searchAfter(FieldValue.of(1), FieldValue.of("string")).build();
 
         assertEquals("{\"search_after\":[1,\"string\"]}", toJson(request));
+    }
+
+    @Test
+    public void ext() {
+        SearchRequest request = new SearchRequest.Builder().ext(
+            "similarity",
+            JsonData.of(Collections.singletonMap("fields", Collections.singletonList("name")))
+        ).build();
+
+        assertEquals("{\"ext\":{\"similarity\":{\"fields\":[\"name\"]}}}", toJson(request));
     }
 
     @Test

--- a/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/AbstractSearchRequestIT.java
+++ b/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/AbstractSearchRequestIT.java
@@ -10,6 +10,7 @@ package org.opensearch.client.opensearch.integTest;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.Test;
 import org.opensearch.Version;
@@ -18,6 +19,7 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.mapping.Property;
 import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
@@ -118,6 +120,22 @@ public abstract class AbstractSearchRequestIT extends OpenSearchJavaClientTestCa
         assertEquals(response.hits().hits().size(), 2);
         assertNull(response.hits().hits().get(0).id());
         assertNull(response.hits().hits().get(1).id());
+    }
+
+    @Test
+    public void shouldReturnSearchResultsWithExt() throws Exception {
+        final String index = "search_request";
+        createIndex(index);
+
+        final SearchRequest request = SearchRequest.of(
+            r -> r.index(index)
+                .sort(s -> s.field(f -> f.field("name").order(SortOrder.Asc)))
+                .query(b -> b.matchAll(QueryBuilders.matchAll().build()))
+                .ext(Map.of())
+        );
+
+        final SearchResponse<ShopItem> response = javaClient().search(request, ShopItem.class);
+        assertEquals(response.hits().hits().size(), 8);
     }
 
     private void createTestDocuments(String index) throws IOException {


### PR DESCRIPTION
### Description
Add missed fields to MultisearchBody: ext, rescore and to SearchRequest: ext

### Issues Resolved
Came up while implementing https://github.com/opensearch-project/spring-data-opensearch/issues/19

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
