### PR TITLE
Client with Java 8 runtime and Apache HttpClient 5 Transport fails with java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 - Fix integer overflow for variables in indices stats response ([#877](https://github.com/opensearch-project/opensearch-java/pull/877))
 - Support weight function in function score query ([#880](https://github.com/opensearch-project/opensearch-java/pull/880))
 - Fix pattern replace by making flag and replacement optional as on api  ([#895](https://github.com/opensearch-project/opensearch-java/pull/895))
+- Client with Java 8 runtime and Apache HttpClient 5 Transport fails with java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer ([#920](https://github.com/opensearch-project/opensearch-java/pull/920)) 
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/internal/HttpEntityAsyncEntityProducer.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/internal/HttpEntityAsyncEntityProducer.java
@@ -9,6 +9,7 @@
 package org.opensearch.client.transport.httpclient5.internal;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
@@ -140,7 +141,7 @@ public class HttpEntityAsyncEntityProducer implements AsyncEntityProducer {
             }
         }
         if (byteBuffer.position() > 0) {
-            byteBuffer.flip();
+            ((Buffer) byteBuffer).flip();
             channel.write(byteBuffer);
             byteBuffer.compact();
         }


### PR DESCRIPTION
### Description
Client with Java 8 runtime and Apache HttpClient 5 Transport fails with java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer (thanks to @peekar). We changed tests (HeapBufferedAsyncEntityConsumerTest) but it slipped in sadly.

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-java/issues/904

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
