### PR TITLE
[Backport] [2.x] Bump org.eclipse.parsson:parsson from 1.1.5 to 1.1.6 (#923)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.3.0 to 5.3.1
 - Bumps `io.github.classgraph:classgraph` from 4.8.165 to 4.8.168
 - Bumps `jackson` from 2.15.2 to 2.17.0
+- Bumps `org.eclipse.parsson:parsson` from 1.1.5 to 1.1.6
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -179,7 +179,7 @@ dependencies {
     // Needed even if using Jackson to have an implementation of the Jsonp object model
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // https://github.com/eclipse-ee4j/parsson
-    api("org.eclipse.parsson:parsson:1.1.4")
+    api("org.eclipse.parsson:parsson:1.1.6")
 
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // http://json-b.net/


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/923 to `2.x`