### PR TITLE
Add missed fields to PhraseSuggestOption: collapseMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ## [Unreleased 2.x]
 
 ### Added
+- Add missed fields to PhraseSuggestOption: collapseMatch ([#940](https://github.com/opensearch-project/opensearch-java/pull/940))
 
 ### Dependencies
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/search/PhraseSuggestOption.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/search/PhraseSuggestOption.java
@@ -56,6 +56,9 @@ public class PhraseSuggestOption implements JsonpSerializable {
 
     private final double score;
 
+    @Nullable
+    private final Boolean collateMatch;
+
     // ---------------------------------------------------------------------------------------------
 
     private PhraseSuggestOption(Builder builder) {
@@ -63,6 +66,7 @@ public class PhraseSuggestOption implements JsonpSerializable {
         this.text = ApiTypeHelper.requireNonNull(builder.text, this, "text");
         this.highlighted = builder.highlighted;
         this.score = ApiTypeHelper.requireNonNull(builder.score, this, "score");
+        this.collateMatch = builder.collateMatch;
 
     }
 
@@ -93,6 +97,13 @@ public class PhraseSuggestOption implements JsonpSerializable {
     }
 
     /**
+     * API name: {@code collate_match}
+     */
+    public final Boolean collateMatch() {
+        return this.collateMatch;
+    }
+
+    /**
      * Serialize this object to JSON.
      */
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
@@ -114,6 +125,10 @@ public class PhraseSuggestOption implements JsonpSerializable {
         generator.writeKey("score");
         generator.write(this.score);
 
+        if (this.collateMatch != null) {
+            generator.writeKey("collate_match");
+            generator.write(this.collateMatch);
+        }
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -129,6 +144,9 @@ public class PhraseSuggestOption implements JsonpSerializable {
         private String highlighted;
 
         private Double score;
+
+        @Nullable
+        private Boolean collateMatch;
 
         /**
          * Required - API name: {@code text}
@@ -151,6 +169,14 @@ public class PhraseSuggestOption implements JsonpSerializable {
          */
         public final Builder score(double value) {
             this.score = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code collate_match}
+         */
+        public final Builder collateMatch(@Nullable Boolean value) {
+            this.collateMatch = value;
             return this;
         }
 
@@ -182,6 +208,7 @@ public class PhraseSuggestOption implements JsonpSerializable {
         op.add(Builder::text, JsonpDeserializer.stringDeserializer(), "text");
         op.add(Builder::highlighted, JsonpDeserializer.stringDeserializer(), "highlighted");
         op.add(Builder::score, JsonpDeserializer.doubleDeserializer(), "score");
+        op.add(Builder::collateMatch, JsonpDeserializer.booleanDeserializer(), "collate_match");
 
     }
 


### PR DESCRIPTION
### Description
Add missed fields to PhraseSuggestOption: collapseMatch

### Issues Resolved
Discovered in scope of https://github.com/opensearch-project/spring-data-opensearch/issues/19

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
