### PR TITLE
[Backport] [2.x] Bump com.github.jk1.dependency-license-report from 2.6 to 2.7 in /java-client (#944)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add missed fields to PhraseSuggestOption: collapseMatch ([#940](https://github.com/opensearch-project/opensearch-java/pull/940))
 
 ### Dependencies
+- Bumps `com.github.jk1.dependency-license-report` from 2.6 to 2.7
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -48,7 +48,7 @@ plugins {
     java
     `java-library`
     `maven-publish`
-    id("com.github.jk1.dependency-license-report") version "2.6"
+    id("com.github.jk1.dependency-license-report") version "2.7"
     id("org.owasp.dependencycheck") version "9.1.0"
     id("com.diffplug.spotless") version "6.25.0"
 }


### PR DESCRIPTION
Backport of #944 to `2.x`