### PR TITLE
Add missed fields to bulk's UpdateOperation: source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Added
 - Add missed fields to PhraseSuggestOption: collapseMatch ([#940](https://github.com/opensearch-project/opensearch-java/pull/940))
+- Add missed fields to bulk's UpdateOperation: source ([#947](https://github.com/opensearch-project/opensearch-java/pull/947))
 
 ### Dependencies
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperation.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperation.java
@@ -41,6 +41,7 @@ import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.JsonpSerializer;
 import org.opensearch.client.json.NdJsonpSerializable;
 import org.opensearch.client.opensearch._types.Script;
+import org.opensearch.client.opensearch.core.search.SourceConfig;
 import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.ObjectBuilder;
 
@@ -156,6 +157,9 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
         @Nullable
         private Script script;
 
+        @Nullable
+        private SourceConfig source;
+
         /**
          * API name: {@code document}
          */
@@ -221,6 +225,21 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
         }
 
         /**
+         * API name: {@code _source}
+         */
+        public final Builder<TDocument> source(@Nullable SourceConfig value) {
+            this.source = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code _source}
+         */
+        public final Builder<TDocument> source(Function<SourceConfig.Builder, ObjectBuilder<SourceConfig>> fn) {
+            return this.source(fn.apply(new SourceConfig.Builder()).build());
+        }
+
+        /**
          * Serializer for TDocument. If not set, an attempt will be made to find a
          * serializer from the JSON context.
          */
@@ -249,6 +268,7 @@ public class UpdateOperation<TDocument> extends BulkOperationBase implements NdJ
                 .detectNoop(detectNoop)
                 .script(script)
                 .upsert(upsert)
+                .source(source)
                 .tDocumentSerializer(tDocumentSerializer)
                 .build();
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperationData.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/bulk/UpdateOperationData.java
@@ -9,12 +9,14 @@
 package org.opensearch.client.opensearch.core.bulk;
 
 import jakarta.json.stream.JsonGenerator;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.JsonpSerializable;
 import org.opensearch.client.json.JsonpSerializer;
 import org.opensearch.client.json.JsonpUtils;
 import org.opensearch.client.opensearch._types.Script;
+import org.opensearch.client.opensearch.core.search.SourceConfig;
 import org.opensearch.client.util.ObjectBuilder;
 
 public class UpdateOperationData<TDocument> implements JsonpSerializable {
@@ -39,6 +41,9 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
     @Nullable
     private final JsonpSerializer<TDocument> tDocumentSerializer;
 
+    @Nullable
+    private final SourceConfig source;
+
     private UpdateOperationData(Builder<TDocument> builder) {
         this.document = builder.document;
         this.docAsUpsert = builder.docAsUpsert;
@@ -47,7 +52,7 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
         this.script = builder.script;
         this.upsert = builder.upsert;
         this.tDocumentSerializer = builder.tDocumentSerializer;
-
+        this.source = builder.source;
     }
 
     @Override
@@ -87,6 +92,11 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
             generator.writeKey("script");
             this.script.serialize(generator, mapper);
         }
+
+        if (this.source != null) {
+            generator.writeKey("_source");
+            this.source.serialize(generator, mapper);
+        }
     }
 
     /**
@@ -116,6 +126,9 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
 
         @Nullable
         private Script script;
+
+        @Nullable
+        private SourceConfig source;
 
         /**
          * API name: {@code document}
@@ -163,6 +176,21 @@ public class UpdateOperationData<TDocument> implements JsonpSerializable {
         public final Builder<TDocument> script(@Nullable Script value) {
             this.script = value;
             return this;
+        }
+
+        /**
+         * API name: {@code _source}
+         */
+        public final Builder<TDocument> source(@Nullable SourceConfig value) {
+            this.source = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code _source}
+         */
+        public final Builder<TDocument> source(Function<SourceConfig.Builder, ObjectBuilder<SourceConfig>> fn) {
+            return this.source(fn.apply(new SourceConfig.Builder()).build());
         }
 
         /**

--- a/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/AbstractCrudIT.java
+++ b/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/AbstractCrudIT.java
@@ -204,6 +204,7 @@ public abstract class AbstractCrudIT extends OpenSearchJavaClientTestCase {
             UpdateRequest<AppData, AppData> updateRequest = new UpdateRequest.Builder<AppData, AppData>().index("index")
                 .id("does_not_exist")
                 .doc(appData)
+                .source(s -> s.fetch(randomBoolean()))
                 .build();
             try {
                 javaClient().update(updateRequest, AppData.class);


### PR DESCRIPTION
### Description
Add missed fields to bulk's `UpdateOperation`: `source` (reference https://www.elastic.co/guide/en/elasticsearch/reference/7.10/docs-bulk.html#bulk-update)

### Issues Resolved
Discovered in scope of https://github.com/opensearch-project/spring-data-opensearch/issues/19

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
