### PR TITLE
Fix integer overflow for remaining index stats

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 11, 17, 21 ]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-13]
     steps:
       - name: Checkout Java Client
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 - Delete shape property ([#884](https://github.com/opensearch-project/opensearch-java/pull/885))
 
 ### Fixed
--  Fix integer overflow for variables in indices stats response ([#959](https://github.com/opensearch-project/opensearch-java/pull/96))
+-  Fix integer overflow for variables in indices stats response ([#959](https://github.com/opensearch-project/opensearch-java/pull/960))
 
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
-- Fix integer overflow for variables in indices stats response ([#959](https://github.com/opensearch-project/opensearch-java/pull/960))
+- Fix integer overflow for variables in indices stats response ([#960](https://github.com/opensearch-project/opensearch-java/pull/960))
 
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ This section is for maintaining a changelog for all breaking changes for the cli
 - Delete shape property ([#884](https://github.com/opensearch-project/opensearch-java/pull/885))
 
 ### Fixed
-- Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
+-  Fix integer overflow for variables in indices stats response ([#959](https://github.com/opensearch-project/opensearch-java/pull/96))
+
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearcjava/pull/254))
-
 - Fix integer overflow for variables in indices stats response ([#959](https://github.com/opensearch-project/opensearch-java/pull/960))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ This section is for maintaining a changelog for all breaking changes for the cli
 - Delete shape property ([#884](https://github.com/opensearch-project/opensearch-java/pull/885))
 
 ### Fixed
--  Fix integer overflow for variables in indices stats response ([#959](https://github.com/opensearch-project/opensearch-java/pull/960))
+- Fix version and build ([#254](https://github.com/opensearch-project/opensearcjava/pull/254))
+
+- Fix integer overflow for variables in indices stats response ([#959](https://github.com/opensearch-project/opensearch-java/pull/960))
 
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 - Delete shape property ([#884](https://github.com/opensearch-project/opensearch-java/pull/885))
 
 ### Fixed
-- Fix version and build ([#254](https://github.com/opensearch-project/opensearcjava/pull/254))
+- Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
 - Fix integer overflow for variables in indices stats response ([#959](https://github.com/opensearch-project/opensearch-java/pull/960))
 
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/QueryCacheStats.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/QueryCacheStats.java
@@ -32,9 +32,10 @@
 
 package org.opensearch.client.opensearch._types;
 
-import jakarta.json.stream.JsonGenerator;
 import java.util.function.Function;
+
 import javax.annotation.Nullable;
+
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
@@ -45,26 +46,28 @@ import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.ObjectBuilder;
 import org.opensearch.client.util.ObjectBuilderBase;
 
+import jakarta.json.stream.JsonGenerator;
+
 // typedef: _types.QueryCacheStats
 
 @JsonpDeserializable
 public class QueryCacheStats implements JsonpSerializable {
-    private final int cacheCount;
+    private final long cacheCount;
 
-    private final int cacheSize;
+    private final long cacheSize;
 
-    private final int evictions;
+    private final long evictions;
 
-    private final int hitCount;
+    private final long hitCount;
 
     @Nullable
     private final String memorySize;
 
     private final long memorySizeInBytes;
 
-    private final int missCount;
+    private final long missCount;
 
-    private final int totalCount;
+    private final long totalCount;
 
     // ---------------------------------------------------------------------------------------------
 
@@ -88,28 +91,28 @@ public class QueryCacheStats implements JsonpSerializable {
     /**
      * Required - API name: {@code cache_count}
      */
-    public final int cacheCount() {
+    public final long cacheCount() {
         return this.cacheCount;
     }
 
     /**
      * Required - API name: {@code cache_size}
      */
-    public final int cacheSize() {
+    public final long cacheSize() {
         return this.cacheSize;
     }
 
     /**
      * Required - API name: {@code evictions}
      */
-    public final int evictions() {
+    public final long evictions() {
         return this.evictions;
     }
 
     /**
      * Required - API name: {@code hit_count}
      */
-    public final int hitCount() {
+    public final long hitCount() {
         return this.hitCount;
     }
 
@@ -131,20 +134,21 @@ public class QueryCacheStats implements JsonpSerializable {
     /**
      * Required - API name: {@code miss_count}
      */
-    public final int missCount() {
+    public final long missCount() {
         return this.missCount;
     }
 
     /**
      * Required - API name: {@code total_count}
      */
-    public final int totalCount() {
+    public final long totalCount() {
         return this.totalCount;
     }
 
     /**
      * Serialize this object to JSON.
      */
+    @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
         serializeInternal(generator, mapper);
@@ -188,27 +192,27 @@ public class QueryCacheStats implements JsonpSerializable {
      */
 
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<QueryCacheStats> {
-        private Integer cacheCount;
+      private Long cacheCount;
 
-        private Integer cacheSize;
+      private Long cacheSize;
 
-        private Integer evictions;
+      private Long evictions;
 
-        private Integer hitCount;
+      private Long hitCount;
 
         @Nullable
         private String memorySize;
 
         private Long memorySizeInBytes;
 
-        private Integer missCount;
+        private Long missCount;
 
-        private Integer totalCount;
+        private Long totalCount;
 
         /**
          * Required - API name: {@code cache_count}
          */
-        public final Builder cacheCount(int value) {
+        public final Builder cacheCount(long value) {
             this.cacheCount = value;
             return this;
         }
@@ -216,7 +220,7 @@ public class QueryCacheStats implements JsonpSerializable {
         /**
          * Required - API name: {@code cache_size}
          */
-        public final Builder cacheSize(int value) {
+        public final Builder cacheSize(long value) {
             this.cacheSize = value;
             return this;
         }
@@ -224,7 +228,7 @@ public class QueryCacheStats implements JsonpSerializable {
         /**
          * Required - API name: {@code evictions}
          */
-        public final Builder evictions(int value) {
+        public final Builder evictions(long value) {
             this.evictions = value;
             return this;
         }
@@ -232,7 +236,7 @@ public class QueryCacheStats implements JsonpSerializable {
         /**
          * Required - API name: {@code hit_count}
          */
-        public final Builder hitCount(int value) {
+        public final Builder hitCount(long value) {
             this.hitCount = value;
             return this;
         }
@@ -256,7 +260,7 @@ public class QueryCacheStats implements JsonpSerializable {
         /**
          * Required - API name: {@code miss_count}
          */
-        public final Builder missCount(int value) {
+        public final Builder missCount(long value) {
             this.missCount = value;
             return this;
         }
@@ -264,7 +268,7 @@ public class QueryCacheStats implements JsonpSerializable {
         /**
          * Required - API name: {@code total_count}
          */
-        public final Builder totalCount(int value) {
+        public final Builder totalCount(long value) {
             this.totalCount = value;
             return this;
         }
@@ -275,6 +279,7 @@ public class QueryCacheStats implements JsonpSerializable {
          * @throws NullPointerException
          *             if some of the required fields are null.
          */
+        @Override
         public QueryCacheStats build() {
             _checkSingleUse();
 
@@ -294,14 +299,14 @@ public class QueryCacheStats implements JsonpSerializable {
 
     protected static void setupQueryCacheStatsDeserializer(ObjectDeserializer<QueryCacheStats.Builder> op) {
 
-        op.add(Builder::cacheCount, JsonpDeserializer.integerDeserializer(), "cache_count");
-        op.add(Builder::cacheSize, JsonpDeserializer.integerDeserializer(), "cache_size");
-        op.add(Builder::evictions, JsonpDeserializer.integerDeserializer(), "evictions");
-        op.add(Builder::hitCount, JsonpDeserializer.integerDeserializer(), "hit_count");
+      op.add(Builder::cacheCount, JsonpDeserializer.longDeserializer(), "cache_count");
+      op.add(Builder::cacheSize, JsonpDeserializer.longDeserializer(), "cache_size");
+      op.add(Builder::evictions, JsonpDeserializer.longDeserializer(), "evictions");
+      op.add(Builder::hitCount, JsonpDeserializer.longDeserializer(), "hit_count");
         op.add(Builder::memorySize, JsonpDeserializer.stringDeserializer(), "memory_size");
         op.add(Builder::memorySizeInBytes, JsonpDeserializer.longDeserializer(), "memory_size_in_bytes");
-        op.add(Builder::missCount, JsonpDeserializer.integerDeserializer(), "miss_count");
-        op.add(Builder::totalCount, JsonpDeserializer.integerDeserializer(), "total_count");
+        op.add(Builder::missCount, JsonpDeserializer.longDeserializer(), "miss_count");
+        op.add(Builder::totalCount, JsonpDeserializer.longDeserializer(), "total_count");
 
     }
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/QueryCacheStats.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/QueryCacheStats.java
@@ -32,10 +32,9 @@
 
 package org.opensearch.client.opensearch._types;
 
+import jakarta.json.stream.JsonGenerator;
 import java.util.function.Function;
-
 import javax.annotation.Nullable;
-
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
@@ -45,8 +44,6 @@ import org.opensearch.client.json.ObjectDeserializer;
 import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.ObjectBuilder;
 import org.opensearch.client.util.ObjectBuilderBase;
-
-import jakarta.json.stream.JsonGenerator;
 
 // typedef: _types.QueryCacheStats
 
@@ -192,13 +189,13 @@ public class QueryCacheStats implements JsonpSerializable {
      */
 
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<QueryCacheStats> {
-      private Long cacheCount;
+        private Long cacheCount;
 
-      private Long cacheSize;
+        private Long cacheSize;
 
-      private Long evictions;
+        private Long evictions;
 
-      private Long hitCount;
+        private Long hitCount;
 
         @Nullable
         private String memorySize;
@@ -299,10 +296,10 @@ public class QueryCacheStats implements JsonpSerializable {
 
     protected static void setupQueryCacheStatsDeserializer(ObjectDeserializer<QueryCacheStats.Builder> op) {
 
-      op.add(Builder::cacheCount, JsonpDeserializer.longDeserializer(), "cache_count");
-      op.add(Builder::cacheSize, JsonpDeserializer.longDeserializer(), "cache_size");
-      op.add(Builder::evictions, JsonpDeserializer.longDeserializer(), "evictions");
-      op.add(Builder::hitCount, JsonpDeserializer.longDeserializer(), "hit_count");
+        op.add(Builder::cacheCount, JsonpDeserializer.longDeserializer(), "cache_count");
+        op.add(Builder::cacheSize, JsonpDeserializer.longDeserializer(), "cache_size");
+        op.add(Builder::evictions, JsonpDeserializer.longDeserializer(), "evictions");
+        op.add(Builder::hitCount, JsonpDeserializer.longDeserializer(), "hit_count");
         op.add(Builder::memorySize, JsonpDeserializer.stringDeserializer(), "memory_size");
         op.add(Builder::memorySizeInBytes, JsonpDeserializer.longDeserializer(), "memory_size_in_bytes");
         op.add(Builder::missCount, JsonpDeserializer.longDeserializer(), "miss_count");

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/QueryCacheStatsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/QueryCacheStatsTest.java
@@ -12,30 +12,30 @@ import jakarta.json.stream.JsonParser;
 public class QueryCacheStatsTest {
 
   @Test
-  public void testLongSerailization() {
-    QueryCacheStats expected = new QueryCacheStats.Builder().cacheCount(8757938874l)
-                                                            .cacheSize(8757938874l)
-                                                            .evictions(8757938874l)
-                                                            .hitCount(8757938874l)
-                                                            .memorySizeInBytes(8757938874l)
-                                                            .missCount(8757938874l)
-                                                            .totalCount(8757938874l)
-                                                            .build();
+    public void testLongSerailization() {
+        QueryCacheStats expected = new QueryCacheStats.Builder().cacheCount(8757938874l)
+                                                                .cacheSize(8757938874l)
+                                                                .evictions(8757938874l)
+                                                                .hitCount(8757938874l)
+                                                                .memorySizeInBytes(8757938874l)
+                                                                .missCount(8757938874l)
+                                                                .totalCount(8757938874l)
+                                                                .build();
 
-    String jsonString = "{\"cache_count\": 8757938874, \"cache_size\": 8757938874, \"evictions\":" +
-        " 8757938874, \"hit_count\": 8757938874, \"memory_size_in_bytes\": 8757938874, \"miss_count\":" +
-        " 8757938874, \"total_count\": 8757938874}";
+        String jsonString = "{\"cache_count\": 8757938874, \"cache_size\": 8757938874, \"evictions\":" +
+            " 8757938874, \"hit_count\": 8757938874, \"memory_size_in_bytes\": 8757938874, \"miss_count\":" +
+            " 8757938874, \"total_count\": 8757938874}";
 
-    StringReader reader = new StringReader(jsonString);
-    JacksonJsonpMapper mapper = new JacksonJsonpMapper();
-    JsonParser parser = mapper.jsonProvider().createParser(reader);
-    QueryCacheStats actual = QueryCacheStats._DESERIALIZER.deserialize(parser, mapper);
-    assertEquals(expected.hitCount(), actual.hitCount());
-    assertEquals(expected.memorySizeInBytes(), actual.memorySizeInBytes());
-    assertEquals(expected.missCount(), actual.missCount());
-    assertEquals(expected.cacheCount(), actual.cacheCount());
-    assertEquals(expected.totalCount(), actual.totalCount());
-    assertEquals(expected.cacheSize(), actual.cacheSize());
-    assertEquals(expected.evictions(), actual.evictions());
-  }
+        StringReader reader = new StringReader(jsonString);
+        JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        JsonParser parser = mapper.jsonProvider().createParser(reader);
+        QueryCacheStats actual = QueryCacheStats._DESERIALIZER.deserialize(parser, mapper);
+        assertEquals(expected.hitCount(), actual.hitCount());
+        assertEquals(expected.memorySizeInBytes(), actual.memorySizeInBytes());
+        assertEquals(expected.missCount(), actual.missCount());
+        assertEquals(expected.cacheCount(), actual.cacheCount());
+        assertEquals(expected.totalCount(), actual.totalCount());
+        assertEquals(expected.cacheSize(), actual.cacheSize());
+        assertEquals(expected.evictions(), actual.evictions());
+     }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/QueryCacheStatsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/QueryCacheStatsTest.java
@@ -1,4 +1,3 @@
-// (c) Copyright 2024 Hewlett Packard Enterprise Development LP
 package org.opensearch.client.opensearch._types;
 
 import static org.junit.Assert.assertEquals;

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/QueryCacheStatsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/QueryCacheStatsTest.java
@@ -2,29 +2,27 @@ package org.opensearch.client.opensearch._types;
 
 import static org.junit.Assert.assertEquals;
 
+import jakarta.json.stream.JsonParser;
 import java.io.StringReader;
-
 import org.junit.Test;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 
-import jakarta.json.stream.JsonParser;
-
 public class QueryCacheStatsTest {
 
-  @Test
+    @Test
     public void testLongSerailization() {
         QueryCacheStats expected = new QueryCacheStats.Builder().cacheCount(8757938874l)
-                                                                .cacheSize(8757938874l)
-                                                                .evictions(8757938874l)
-                                                                .hitCount(8757938874l)
-                                                                .memorySizeInBytes(8757938874l)
-                                                                .missCount(8757938874l)
-                                                                .totalCount(8757938874l)
-                                                                .build();
+            .cacheSize(8757938874l)
+            .evictions(8757938874l)
+            .hitCount(8757938874l)
+            .memorySizeInBytes(8757938874l)
+            .missCount(8757938874l)
+            .totalCount(8757938874l)
+            .build();
 
-        String jsonString = "{\"cache_count\": 8757938874, \"cache_size\": 8757938874, \"evictions\":" +
-            " 8757938874, \"hit_count\": 8757938874, \"memory_size_in_bytes\": 8757938874, \"miss_count\":" +
-            " 8757938874, \"total_count\": 8757938874}";
+        String jsonString = "{\"cache_count\": 8757938874, \"cache_size\": 8757938874, \"evictions\":"
+            + " 8757938874, \"hit_count\": 8757938874, \"memory_size_in_bytes\": 8757938874, \"miss_count\":"
+            + " 8757938874, \"total_count\": 8757938874}";
 
         StringReader reader = new StringReader(jsonString);
         JacksonJsonpMapper mapper = new JacksonJsonpMapper();
@@ -37,5 +35,5 @@ public class QueryCacheStatsTest {
         assertEquals(expected.totalCount(), actual.totalCount());
         assertEquals(expected.cacheSize(), actual.cacheSize());
         assertEquals(expected.evictions(), actual.evictions());
-     }
+    }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/QueryCacheStatsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/QueryCacheStatsTest.java
@@ -10,19 +10,19 @@ import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 public class QueryCacheStatsTest {
 
     @Test
-    public void testLongSerailization() {
-        QueryCacheStats expected = new QueryCacheStats.Builder().cacheCount(8757938874l)
-            .cacheSize(8757938874l)
-            .evictions(8757938874l)
-            .hitCount(8757938874l)
-            .memorySizeInBytes(8757938874l)
-            .missCount(8757938874l)
-            .totalCount(8757938874l)
+    public void testLongSerialization() {
+        QueryCacheStats expected = new QueryCacheStats.Builder().cacheCount(2757938871l)
+            .cacheSize(1757938872l)
+            .evictions(3757938873l)
+            .hitCount(4757938874l)
+            .memorySizeInBytes(5757938875l)
+            .missCount(6757938876l)
+            .totalCount(7757938877l)
             .build();
 
-        String jsonString = "{\"cache_count\": 8757938874, \"cache_size\": 8757938874, \"evictions\":"
-            + " 8757938874, \"hit_count\": 8757938874, \"memory_size_in_bytes\": 8757938874, \"miss_count\":"
-            + " 8757938874, \"total_count\": 8757938874}";
+        String jsonString = "{\"cache_count\": 2757938871, \"cache_size\": 1757938872, \"evictions\":"
+            + " 3757938873, \"hit_count\": 4757938874, \"memory_size_in_bytes\": 5757938875, \"miss_count\":"
+            + " 6757938876, \"total_count\": 7757938877}";
 
         StringReader reader = new StringReader(jsonString);
         JacksonJsonpMapper mapper = new JacksonJsonpMapper();

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/QueryCacheStatsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/QueryCacheStatsTest.java
@@ -1,0 +1,42 @@
+// (c) Copyright 2024 Hewlett Packard Enterprise Development LP
+package org.opensearch.client.opensearch._types;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.StringReader;
+
+import org.junit.Test;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+
+import jakarta.json.stream.JsonParser;
+
+public class QueryCacheStatsTest {
+
+  @Test
+  public void testLongSerailization() {
+    QueryCacheStats expected = new QueryCacheStats.Builder().cacheCount(8757938874l)
+                                                            .cacheSize(8757938874l)
+                                                            .evictions(8757938874l)
+                                                            .hitCount(8757938874l)
+                                                            .memorySizeInBytes(8757938874l)
+                                                            .missCount(8757938874l)
+                                                            .totalCount(8757938874l)
+                                                            .build();
+
+    String jsonString = "{\"cache_count\": 8757938874, \"cache_size\": 8757938874, \"evictions\":" +
+        " 8757938874, \"hit_count\": 8757938874, \"memory_size_in_bytes\": 8757938874, \"miss_count\":" +
+        " 8757938874, \"total_count\": 8757938874}";
+
+    StringReader reader = new StringReader(jsonString);
+    JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+    JsonParser parser = mapper.jsonProvider().createParser(reader);
+    QueryCacheStats actual = QueryCacheStats._DESERIALIZER.deserialize(parser, mapper);
+    assertEquals(expected.hitCount(), actual.hitCount());
+    assertEquals(expected.memorySizeInBytes(), actual.memorySizeInBytes());
+    assertEquals(expected.missCount(), actual.missCount());
+    assertEquals(expected.cacheCount(), actual.cacheCount());
+    assertEquals(expected.totalCount(), actual.totalCount());
+    assertEquals(expected.cacheSize(), actual.cacheSize());
+    assertEquals(expected.evictions(), actual.evictions());
+  }
+}


### PR DESCRIPTION
### Description
Changed data types in QueryCacheStats object to be longs
Example of the data which is having problem when datatypes are integers
"query_cache" : {
        "memory_size_in_bytes" : 892496036,
        "total_count" : 8757938874,
        "hit_count" : 347443703,
        "miss_count" : 8410495171,
        "cache_size" : 18507,
        "cache_count" : 169300,
        "evictions" : 150793
      }


### Issues Resolved
https://github.com/opensearch-project/opensearch-java/issues/959

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
