### PR TITLE
Added OpenSearch 2.12 and 2.13 to integration tests.

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -25,6 +25,8 @@ jobs:
           - { opensearch_version: 2.9.0, java: 11 }
           - { opensearch_version: 2.10.0, java: 11 }
           - { opensearch_version: 2.11.1, java: 11 }
+          - { opensearch_version: 2.12.0, java: 11 }
+          - { opensearch_version: 2.13.0, java: 11 }
     steps:
       - name: Checkout Java Client
         uses: actions/checkout@v3


### PR DESCRIPTION
### Description

Added OpenSearch 2.12 and 2.13 to integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
