### PR TITLE
[BUG] Generic HTTP Actions in Java Client does not work with AwsSdk2Transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix the deserialization of SortOptions ([#981](https://github.com/opensearch-project/opensearch-java/pull/981))
+- [BUG] Generic HTTP Actions in Java Client does not work with AwsSdk2Transport ([#978](https://github.com/opensearch-project/opensearch-java/pull/978))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fix the deserialization of SortOptions ([#981](https://github.com/opensearch-project/opensearch-java/pull/981))
-- [BUG] Generic HTTP Actions in Java Client does not work with AwsSdk2Transport ([#978](https://github.com/opensearch-project/opensearch-java/pull/978))
+- Generic HTTP Actions in Java Client does not work with AwsSdk2Transport ([#978](https://github.com/opensearch-project/opensearch-java/pull/978))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/util/OpenSearchRequestBodyBuffer.java
+++ b/java-client/src/main/java/org/opensearch/client/util/OpenSearchRequestBodyBuffer.java
@@ -18,8 +18,10 @@ import java.util.Iterator;
 import java.util.zip.GZIPOutputStream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.apache.hc.core5.http.ContentType;
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.NdJsonpSerializable;
+import org.opensearch.client.transport.GenericSerializable;
 import org.opensearch.client.transport.OpenSearchTransport;
 
 /**
@@ -71,6 +73,11 @@ public class OpenSearchRequestBodyBuffer {
         if (content instanceof NdJsonpSerializable) {
             isMulti = true;
             addNdJson(((NdJsonpSerializable) content));
+        } else if (content instanceof GenericSerializable) {
+            ContentType.parse(((GenericSerializable) content).serialize(captureBuffer));
+            if (isMulti) {
+                captureBuffer.write((byte) '\n');
+            }
         } else {
             mapper.serialize(content, jsonGenerator);
             jsonGenerator.flush();


### PR DESCRIPTION
### Description
Generic HTTP Actions in Java Client does not work with AwsSdk2Transport

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-java/issues/969

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
