### PR TITLE
[Backport 2.x] Bump io.github.classgraph:classgraph from 4.8.170 to 4.8.172

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
+- Bumps `io.github.classgraph:classgraph` from 4.8.170 to 4.8.172
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [2.10.2]
+### Added
+
+### Dependencies
 
 ### Changed
 
@@ -15,8 +31,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fix integer overflow for variables in indices stats response ([#960](https://github.com/opensearch-project/opensearch-java/pull/960))
 - Fix composite aggregations for search requests ([#967](https://github.com/opensearch-project/opensearch-java/pull/967))
-
-### Security
 
 ## [2.10.1] - 04/16/2024
 ### Added

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -214,7 +214,7 @@ dependencies {
     implementation("org.eclipse", "yasson", "2.0.2")
 
     // https://github.com/classgraph/classgraph
-    testImplementation("io.github.classgraph:classgraph:4.8.170")
+    testImplementation("io.github.classgraph:classgraph:4.8.172")
 
     // Eclipse 1.0
     testImplementation("junit", "junit" , "4.13.2") {


### PR DESCRIPTION
### Description
Backport of #955 to 2.x.
Also updating changelog after 2.10.2 release.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
