### PR TITLE
Fix the deserialization of SortOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Removed
 
 ### Fixed
+- Fix the deserialization of SortOptions ([#981](https://github.com/opensearch-project/opensearch-java/pull/981))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/SortOptions.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/SortOptions.java
@@ -281,10 +281,9 @@ public class SortOptions implements TaggedUnion<SortOptions.Kind, Object>, Jsonp
     }
 
     public static final JsonpDeserializer<SortOptions> _DESERIALIZER = JsonpDeserializer.lazy(
-        () -> JsonpDeserializer.of(EnumSet.of(JsonParser.Event.START_OBJECT, JsonParser.Event.VALUE_STRING), (parser, mapper) -> {
+        () -> JsonpDeserializer.of(EnumSet.of(JsonParser.Event.START_OBJECT, JsonParser.Event.VALUE_STRING), (parser, mapper, event) -> {
             SortOptions.Builder b = new SortOptions.Builder();
 
-            JsonParser.Event event = parser.next();
             if (event == JsonParser.Event.VALUE_STRING) {
                 switch (parser.getString()) {
                     case "_score":

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/SortOptionsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/SortOptionsTest.java
@@ -1,24 +1,19 @@
 package org.opensearch.client.opensearch._types;
 
+import static org.junit.Assert.assertEquals;
+
 import jakarta.json.stream.JsonParser;
+import java.io.StringReader;
+import java.util.List;
 import org.junit.Test;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
-
-import java.io.StringReader;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 public class SortOptionsTest {
 
     @Test
     public void testSortOptions() {
-        String jsonString = "[{\n" +
-                "    \"entityId\": {\n" +
-                "      \"order\": \"asc\"\n" +
-                "    }\n" +
-                "  }]";
+        String jsonString = "[{\"entityId\":{\"order\":\"asc\"}}]";
         StringReader reader = new StringReader(jsonString);
         JacksonJsonpMapper mapper = new JacksonJsonpMapper();
         JsonParser parser = mapper.jsonProvider().createParser(reader);

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/SortOptionsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/SortOptionsTest.java
@@ -1,0 +1,33 @@
+package org.opensearch.client.opensearch._types;
+
+import jakarta.json.stream.JsonParser;
+import org.junit.Test;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+
+import java.io.StringReader;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SortOptionsTest {
+
+    @Test
+    public void testSortOptions() {
+        String jsonString = "[{\n" +
+                "    \"entityId\": {\n" +
+                "      \"order\": \"asc\"\n" +
+                "    }\n" +
+                "  }]";
+        StringReader reader = new StringReader(jsonString);
+        JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        JsonParser parser = mapper.jsonProvider().createParser(reader);
+
+        List<SortOptions> sortOptions = JsonpDeserializer.arrayDeserializer(SortOptions._DESERIALIZER).deserialize(parser, mapper);
+        assertEquals(1, sortOptions.size());
+        assertEquals(SortOptions.Kind.Field, sortOptions.get(0)._kind());
+        FieldSort fieldSort = (FieldSort) sortOptions.get(0)._get();
+        assertEquals("entityId", fieldSort.field());
+        assertEquals(SortOrder.Asc, fieldSort.order());
+    }
+}


### PR DESCRIPTION
### Description
Not familiar with this repo. Just helping to fix the deserialization logic of SortOptions.

Reason for the failure

array deserializer invoke the deserialize method with event
https://github.com/opensearch-project/opensearch-java/blob/d092df5602f164364466e323eff80cdc12ebd057/java-client/src/main/java/org/opensearch/client/json/JsonpDeserializerBase.java#L343

which end up throw exception for [SortOptions deserializer](https://github.com/opensearch-project/opensearch-java/blob/d092df5602f164364466e323eff80cdc12ebd057/java-client/src/main/java/org/opensearch/client/opensearch/_types/SortOptions.java#L284)

https://github.com/opensearch-project/opensearch-java/blob/d092df5602f164364466e323eff80cdc12ebd057/java-client/src/main/java/org/opensearch/client/json/JsonpDeserializer.java#L115



### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
