### PR TITLE
Add mappings and settings with json

### DIFF
--- a/java-client/src/main/java/org/opensearch/client/opensearch/indices/CreateIndexRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/indices/CreateIndexRequest.java
@@ -33,6 +33,7 @@
 package org.opensearch.client.opensearch.indices;
 
 import jakarta.json.stream.JsonGenerator;
+import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -43,6 +44,7 @@ import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.JsonpSerializable;
 import org.opensearch.client.json.ObjectBuilderDeserializer;
 import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch._types.RequestBase;
 import org.opensearch.client.opensearch._types.Time;
@@ -314,6 +316,25 @@ public class CreateIndexRequest extends RequestBase implements JsonpSerializable
          * <p>
          * API name: {@code mappings}
          */
+        public final Builder mappings(@Nullable String typeMappingJson) {
+            return this.mappings(deserialize(TypeMapping._DESERIALIZER, typeMappingJson));
+        }
+
+        private <T> T deserialize(JsonpDeserializer<T> deserializer, String json) {
+            JsonpMapper jsonpMapper = new JacksonJsonpMapper();
+            return deserializer.deserialize(jsonpMapper.jsonProvider().createParser(new StringReader(json)), jsonpMapper);
+        }
+
+        /**
+         * Mapping for fields in the index. If specified, this mapping can include:
+         * <ul>
+         * <li>Field names</li>
+         * <li>Field data types</li>
+         * <li>Mapping parameters</li>
+         * </ul>
+         * <p>
+         * API name: {@code mappings}
+         */
         public final Builder mappings(Function<TypeMapping.Builder, ObjectBuilder<TypeMapping>> fn) {
             return this.mappings(fn.apply(new TypeMapping.Builder()).build());
         }
@@ -364,6 +385,13 @@ public class CreateIndexRequest extends RequestBase implements JsonpSerializable
         public final Builder settings(@Nullable IndexSettings value) {
             this.settings = value;
             return this;
+        }
+
+        /**
+         * API name: {@code settings}
+         */
+        public final Builder settings(String indexSettingsJson) {
+            return this.settings(deserialize(IndexSettings._DESERIALIZER, indexSettingsJson));
         }
 
         /**


### PR DESCRIPTION
### Description
This PR adds functionality to use JSON for mappings and settings in CreateIndexRequest.
This makes it easier for developers to create indices.

### Issues Resolved
Fixes #302

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
