### PR TITLE
ApacheHttpClient5Transport requires Apache Commons Logging dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Removed
 
 ### Fixed
+- ApacheHttpClient5Transport requires Apache Commons Logging dependency ([#1003](https://github.com/opensearch-project/opensearch-java/pull/1003))
 
 ### Security
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -169,6 +169,7 @@ dependencies {
     val jacksonDatabindVersion = "2.17.0"
 
     // Apache 2.0
+    api("commons-logging:commons-logging:1.3.2")
     compileOnly("org.opensearch.client", "opensearch-rest-client", opensearchVersion)
     testImplementation("org.hamcrest:hamcrest:2.2")
     testImplementation("com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.8.1") {


### PR DESCRIPTION
### Description
ApacheHttpClient5Transport requires Apache Commons Logging dependency

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-java/issues/1002

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
