### PR TITLE
[Backport] [2.x] ApacheHttpClient5Transport requires Apache Commons Logging dependency (#1003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- ApacheHttpClient5Transport requires Apache Commons Logging dependency ([#1003](https://github.com/opensearch-project/opensearch-java/pull/1003))
 
 ### Security
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -166,6 +166,7 @@ dependencies {
     val jacksonDatabindVersion = "2.17.0"
 
     // Apache 2.0
+    api("commons-logging:commons-logging:1.3.2")
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)
     testImplementation("org.hamcrest:hamcrest:2.2")
     testImplementation("com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.8.1") {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1003 to `2.x`