### PR TITLE
Bump commons-codec:commons-codec from 1.11.0 to 1.17.0 in java-codegen

### DIFF
--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -131,6 +131,7 @@ dependencies {
 
     // Apache 2.0
     implementation("commons-cli", "commons-cli", "1.8.0")
+    implementation("commons-codec", "commons-codec", "1.17.0")
     implementation("commons-logging", "commons-logging", "1.3.2")
     implementation("org.apache.commons", "commons-lang3", "3.14.0")
     implementation("org.apache.commons", "commons-text", "1.12.0")


### PR DESCRIPTION
### Description
Bump the version of commons-codec:commons-codec being transitively pulled in in java-codegen to appease Mend/WhiteSource.

### Issues Resolved
Fixes #1022 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
