### PR TITLE
Default analyzer deserialization to custom type when unspecified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Removed
 
 ### Fixed
+- Fixed error when deserializing an analyzer without `type` specified ([#1033](https://github.com/opensearch-project/opensearch-java/pull/1033))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/Analyzer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/Analyzer.java
@@ -606,7 +606,7 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
         op.add(Builder::smartcn, SmartcnAnalyzer._DESERIALIZER, Kind.Smartcn.jsonValue());
         op.add(Builder::cjk, CjkAnalyzer._DESERIALIZER, Kind.Cjk.jsonValue());
 
-        op.setTypeProperty("type", null);
+        op.setTypeProperty("type", Kind.Custom.jsonValue());
 
     }
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/analysis/AnalyzerDeserializerTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/analysis/AnalyzerDeserializerTest.java
@@ -14,13 +14,13 @@ import org.opensearch.client.opensearch.model.ModelTestCase;
 public class AnalyzerDeserializerTest extends ModelTestCase {
     @Test
     public void deserializesTypelessCustomAnalyzer() {
-        var json = "{\n"
+        String json = "{\n"
             + "    \"filter\": [\"kuromoji_baseform\", \"ja_stop\"],\n"
             + "    \"char_filter\": [\"icu_normalizer\"],\n"
             + "    \"tokenizer\": \"kuromoji_tokenizer\"\n"
             + "}";
 
-        var analyzer = fromJson(json, Analyzer._DESERIALIZER);
+        Analyzer analyzer = fromJson(json, Analyzer._DESERIALIZER);
         assertTrue(analyzer.isCustom());
         assertEquals("kuromoji_tokenizer", analyzer.custom().tokenizer());
         assertEquals("icu_normalizer", analyzer.custom().charFilter().get(0));

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/analysis/AnalyzerDeserializerTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/analysis/AnalyzerDeserializerTest.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import org.junit.Test;
+import org.opensearch.client.opensearch.model.ModelTestCase;
+
+public class AnalyzerDeserializerTest extends ModelTestCase {
+    @Test
+    public void deserializesTypelessCustomAnalyzer() {
+        var json = "{\n"
+            + "    \"filter\": [\"kuromoji_baseform\", \"ja_stop\"],\n"
+            + "    \"char_filter\": [\"icu_normalizer\"],\n"
+            + "    \"tokenizer\": \"kuromoji_tokenizer\"\n"
+            + "}";
+
+        var analyzer = fromJson(json, Analyzer._DESERIALIZER);
+        assertTrue(analyzer.isCustom());
+        assertEquals("kuromoji_tokenizer", analyzer.custom().tokenizer());
+        assertEquals("icu_normalizer", analyzer.custom().charFilter().get(0));
+        assertEquals("kuromoji_baseform", analyzer.custom().filter().get(0));
+        assertEquals("ja_stop", analyzer.custom().filter().get(1));
+    }
+}


### PR DESCRIPTION
### Description
Fixes an error when deserializing an analyzer without an explicit type specified:
```
JsonParsingException: Property 'type' not found
    at org.opensearch.client.json.JsonpUtils.lookAheadFieldValue(JsonpUtils.java:145)
```

The server requires type to be specified unless tokenizer is specified then `type: custom` is assumed, thus any analyzer without type specified is a custom analyzer.

### Issues Resolved
Fixes #1032 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
