### PR TITLE
Add support for phase_took & search_pipeline request params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Added
 - Document HTTP/2 support ([#330](https://github.com/opensearch-project/opensearch-java/pull/330))
+- Add support for phase_took & search_pipeline request params ([#1036](https://github.com/opensearch-project/opensearch-java/pull/1036))
 
 ### Dependencies
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
@@ -106,6 +106,12 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
     private final Boolean ccsMinimizeRoundtrips;
 
     @Nullable
+    private final Boolean phaseTook;
+
+    @Nullable
+    private final String pipeline;
+
+    @Nullable
     private final FieldCollapse collapse;
 
     @Nullable
@@ -239,6 +245,8 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
         this.analyzer = builder.analyzer;
         this.batchedReduceSize = builder.batchedReduceSize;
         this.ccsMinimizeRoundtrips = builder.ccsMinimizeRoundtrips;
+        this.phaseTook = builder.phaseTook;
+        this.pipeline = builder.pipeline;
         this.collapse = builder.collapse;
         this.defaultOperator = builder.defaultOperator;
         this.df = builder.df;
@@ -375,6 +383,27 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
     @Nullable
     public final Boolean ccsMinimizeRoundtrips() {
         return this.ccsMinimizeRoundtrips;
+    }
+
+    /**
+     * Indicates whether search phase took times should be returned
+     * in SearchResponse
+     * <p>
+     * API name: {@code phase_took}
+     */
+    @Nullable
+    public final Boolean phaseTook() {
+        return this.phaseTook;
+    }
+
+    /**
+     * Specifies search pipeline name
+     * <p>
+     * API name: {@code pipeline}
+     */
+    @Nullable
+    public final String pipeline() {
+        return this.pipeline;
     }
 
     /**
@@ -1084,6 +1113,8 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
             .analyzer(analyzer)
             .batchedReduceSize(batchedReduceSize)
             .ccsMinimizeRoundtrips(ccsMinimizeRoundtrips)
+            .phaseTook(phaseTook)
+            .pipeline(pipeline)
             .collapse(collapse)
             .defaultOperator(defaultOperator)
             .df(df)
@@ -1161,6 +1192,12 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
 
         @Nullable
         private Boolean ccsMinimizeRoundtrips;
+
+        @Nullable
+        private Boolean phaseTook;
+
+        @Nullable
+        private String pipeline;
 
         @Nullable
         private FieldCollapse collapse;
@@ -1412,6 +1449,27 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
          */
         public final Builder ccsMinimizeRoundtrips(@Nullable Boolean value) {
             this.ccsMinimizeRoundtrips = value;
+            return this;
+        }
+
+        /**
+         * Indicates whether search phase took times should be returned
+         * in SearchResponse
+         * <p>
+         * API name: {@code phase_took}
+         */
+        public final Builder phaseTook(@Nullable Boolean value) {
+            this.phaseTook = value;
+            return this;
+        }
+
+        /**
+         * Specifies search pipeline name
+         * <p>
+         * API name: {@code pipeline}
+         */
+        public final Builder pipeline(@Nullable String value) {
+            this.pipeline = value;
             return this;
         }
 
@@ -2353,6 +2411,12 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
             }
             if (request.ccsMinimizeRoundtrips != null) {
                 params.put("ccs_minimize_roundtrips", String.valueOf(request.ccsMinimizeRoundtrips));
+            }
+            if (request.phaseTook != null) {
+                params.put("phase_took", String.valueOf(request.phaseTook));
+            }
+            if (request.pipeline != null) {
+                params.put("search_pipeline", request.pipeline);
             }
             if (request.q != null) {
                 params.put("q", request.q);

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchTemplateRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchTemplateRequest.java
@@ -71,6 +71,12 @@ public class SearchTemplateRequest extends RequestBase implements JsonpSerializa
     @Nullable
     private final Boolean ccsMinimizeRoundtrips;
 
+    @Nullable
+    private final Boolean phaseTook;
+
+    @Nullable
+    private final String pipeline;
+
     private final List<ExpandWildcard> expandWildcards;
 
     @Nullable
@@ -113,6 +119,8 @@ public class SearchTemplateRequest extends RequestBase implements JsonpSerializa
 
         this.allowNoIndices = builder.allowNoIndices;
         this.ccsMinimizeRoundtrips = builder.ccsMinimizeRoundtrips;
+        this.phaseTook = builder.phaseTook;
+        this.pipeline = builder.pipeline;
         this.expandWildcards = ApiTypeHelper.unmodifiable(builder.expandWildcards);
         this.explain = builder.explain;
         this.id = builder.id;
@@ -154,6 +162,27 @@ public class SearchTemplateRequest extends RequestBase implements JsonpSerializa
     @Nullable
     public final Boolean ccsMinimizeRoundtrips() {
         return this.ccsMinimizeRoundtrips;
+    }
+
+    /**
+     * Indicates whether search phase took times should be returned
+     * in SearchResponse
+     * <p>
+     * API name: {@code phase_took}
+     */
+    @Nullable
+    public final Boolean phaseTook() {
+        return this.phaseTook;
+    }
+
+    /**
+     * Specifies search pipeline name
+     * <p>
+     * API name: {@code pipeline}
+     */
+    @Nullable
+    public final String pipeline() {
+        return this.pipeline;
     }
 
     /**
@@ -334,6 +363,8 @@ public class SearchTemplateRequest extends RequestBase implements JsonpSerializa
     public Builder toBuilder() {
         return new Builder().allowNoIndices(allowNoIndices)
             .ccsMinimizeRoundtrips(ccsMinimizeRoundtrips)
+            .phaseTook(phaseTook)
+            .pipeline(pipeline)
             .expandWildcards(expandWildcards)
             .explain(explain)
             .id(id)
@@ -361,6 +392,12 @@ public class SearchTemplateRequest extends RequestBase implements JsonpSerializa
 
         @Nullable
         private Boolean ccsMinimizeRoundtrips;
+
+        @Nullable
+        private Boolean phaseTook;
+
+        @Nullable
+        private String pipeline;
 
         @Nullable
         private List<ExpandWildcard> expandWildcards;
@@ -421,6 +458,27 @@ public class SearchTemplateRequest extends RequestBase implements JsonpSerializa
          */
         public final Builder ccsMinimizeRoundtrips(@Nullable Boolean value) {
             this.ccsMinimizeRoundtrips = value;
+            return this;
+        }
+
+        /**
+         * Indicates whether search phase took times should be returned
+         * in SearchResponse
+         * <p>
+         * API name: {@code phase_took}
+         */
+        public final Builder phaseTook(@Nullable Boolean value) {
+            this.phaseTook = value;
+            return this;
+        }
+
+        /**
+         * Specifies search pipeline name
+         * <p>
+         * API name: {@code pipeline}
+         */
+        public final Builder pipeline(@Nullable String value) {
+            this.pipeline = value;
             return this;
         }
 
@@ -699,6 +757,12 @@ public class SearchTemplateRequest extends RequestBase implements JsonpSerializa
             }
             if (request.ccsMinimizeRoundtrips != null) {
                 params.put("ccs_minimize_roundtrips", String.valueOf(request.ccsMinimizeRoundtrips));
+            }
+            if (request.phaseTook != null) {
+                params.put("phase_took", String.valueOf(request.phaseTook));
+            }
+            if (request.pipeline != null) {
+                params.put("search_pipeline", request.pipeline);
             }
             if (request.routing != null) {
                 params.put("routing", request.routing);

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
@@ -33,6 +33,24 @@ public class SearchRequestTest extends ModelTestCase {
     }
 
     @Test
+    public void phaseTook() {
+        SearchRequest request = new SearchRequest.Builder().phaseTook(true).build();
+
+        assertEquals("{}", toJson(request));
+        assertEquals(true, request.phaseTook());
+        assertTrue(Boolean.parseBoolean(SearchRequest._ENDPOINT.queryParameters(request).get("phase_took")));
+    }
+
+    @Test
+    public void pipeline() {
+        SearchRequest request = new SearchRequest.Builder().pipeline("my_pipeline").build();
+
+        assertEquals("{}", toJson(request));
+        assertEquals("my_pipeline", request.pipeline());
+        assertEquals("my_pipeline", SearchRequest._ENDPOINT.queryParameters(request).get("search_pipeline"));
+    }
+
+    @Test
     public void toBuilder() {
         SearchRequest origin = new SearchRequest.Builder().index("index").build();
         SearchRequest copied = origin.toBuilder().build();

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchTemplateRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchTemplateRequestTest.java
@@ -8,10 +8,28 @@
 
 package org.opensearch.client.opensearch.core;
 
-import org.junit.Assert;
 import org.junit.Test;
+import org.opensearch.client.opensearch.model.ModelTestCase;
 
-public class SearchTemplateRequestTest extends Assert {
+public class SearchTemplateRequestTest extends ModelTestCase {
+
+    @Test
+    public void phaseTook() {
+        SearchTemplateRequest request = new SearchTemplateRequest.Builder().phaseTook(true).build();
+
+        assertEquals("{}", toJson(request));
+        assertEquals(true, request.phaseTook());
+        assertTrue(Boolean.parseBoolean(SearchTemplateRequest._ENDPOINT.queryParameters(request).get("phase_took")));
+    }
+
+    @Test
+    public void pipeline() {
+        SearchTemplateRequest request = new SearchTemplateRequest.Builder().pipeline("my_pipeline").build();
+
+        assertEquals("{}", toJson(request));
+        assertEquals("my_pipeline", request.pipeline());
+        assertEquals("my_pipeline", SearchTemplateRequest._ENDPOINT.queryParameters(request).get("search_pipeline"));
+    }
 
     @Test
     public void toBuilder() {


### PR DESCRIPTION
### Description
Add support for `phase_took` & `search_pipeline` request params to OpenSearch Java client

Ref in OpenSearch Core: [RestSearchAction.java#L150-L227](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java#L150-L227)

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-java/issues/1025

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
