### PR TITLE
Updated CHANGELOG, 2.11.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -459,7 +459,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Security
 
 [Unreleased 3.0]: https://github.com/opensearch-project/opensearch-java/compare/2.x...HEAD
-[Unreleased 2.x]: https://github.com/opensearch-project/opensearch-java/compare/v2.10.4...2.x
+[Unreleased 2.x]: https://github.com/opensearch-project/opensearch-java/compare/v2.11.0...2.x
 [2.11.0]: https://github.com/opensearch-project/opensearch-java/compare/v2.10.4...v2.11.0
 [2.10.4]: https://github.com/opensearch-project/opensearch-java/compare/v2.10.3...v2.10.4
 [2.10.3]: https://github.com/opensearch-project/opensearch-java/compare/v2.10.2...v2.10.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,25 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Fixed
 - Fix version and build ([#254](https://github.com/opensearch-project/opensearch-java/pull/254))
 
-
 ### Security
 
 ## [Unreleased 2.x]
+
+### Added
+
+### Dependencies
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [2.11.0] - 06/20/2024
 
 ### Added
 
@@ -445,6 +460,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 [Unreleased 3.0]: https://github.com/opensearch-project/opensearch-java/compare/2.x...HEAD
 [Unreleased 2.x]: https://github.com/opensearch-project/opensearch-java/compare/v2.10.4...2.x
+[2.11.0]: https://github.com/opensearch-project/opensearch-java/compare/v2.10.4...v2.11.0
 [2.10.4]: https://github.com/opensearch-project/opensearch-java/compare/v2.10.3...v2.10.4
 [2.10.3]: https://github.com/opensearch-project/opensearch-java/compare/v2.10.2...v2.10.3
 [2.10.2]: https://github.com/opensearch-project/opensearch-java/compare/v2.10.1...v2.10.2


### PR DESCRIPTION
### Description

This release should have been 2.10.5 since it's only 1 patch, I was incorrectly reading the changelog. But that ship has sailed, let's leave it as 2.11.0. This will also need to be backported to 2.x to match the changes.

I will update #1039 for CHANGELOG changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
