### PR TITLE
Made InlineGet source nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Dependencies
 
 ### Changed
+- Made InlineGet source field nullable. ([#1042](https://github.com/opensearch-project/opensearch-java/pull/1042))
 
 ### Deprecated
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/InlineGet.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/InlineGet.java
@@ -68,6 +68,7 @@ public class InlineGet<TDocument> implements JsonpSerializable {
     @Nullable
     private final String routing;
 
+    @Nullable
     private final TDocument source;
 
     @Nullable
@@ -84,7 +85,7 @@ public class InlineGet<TDocument> implements JsonpSerializable {
         this.seqNo = builder.seqNo;
         this.primaryTerm = builder.primaryTerm;
         this.routing = builder.routing;
-        this.source = ApiTypeHelper.requireNonNull(builder.source, this, "source");
+        this.source = builder.source;
         this.tDocumentSerializer = builder.tDocumentSerializer;
 
     }
@@ -139,8 +140,9 @@ public class InlineGet<TDocument> implements JsonpSerializable {
     }
 
     /**
-     * Required - API name: {@code _source}
+     * API name: {@code _source}
      */
+    @Nullable
     public final TDocument source() {
         return this.source;
     }
@@ -191,8 +193,11 @@ public class InlineGet<TDocument> implements JsonpSerializable {
             generator.write(this.routing);
 
         }
-        generator.writeKey("_source");
-        JsonpUtils.serialize(this.source, generator, tDocumentSerializer, mapper);
+        if (this.source != null) {
+            generator.writeKey("_source");
+            JsonpUtils.serialize(this.source, generator, tDocumentSerializer, mapper);
+
+        }
 
     }
 
@@ -240,6 +245,7 @@ public class InlineGet<TDocument> implements JsonpSerializable {
         @Nullable
         private String routing;
 
+        @Nullable
         private TDocument source;
 
         @Nullable
@@ -298,9 +304,9 @@ public class InlineGet<TDocument> implements JsonpSerializable {
         }
 
         /**
-         * Required - API name: {@code _source}
+         * API name: {@code _source}
          */
-        public final Builder<TDocument> source(TDocument value) {
+        public final Builder<TDocument> source(@Nullable TDocument value) {
             this.source = value;
             return this;
         }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/InlineGetTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/InlineGetTest.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch._types;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.StringReader;
+
+import org.junit.Test;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+import org.opensearch.client.opensearch.model.ModelTestCase;
+
+import jakarta.json.stream.JsonParser;
+
+public class InlineGetTest extends ModelTestCase {
+    @Test
+    public void testInlineGet_withSource() {
+        final InlineGet inlineGet = InlineGet.of(b -> b
+            .found(true)
+            .seqNo(1L)
+            .primaryTerm(2L)
+            .routing("routing")
+            .source("{\"name\":\"John Doe\"}"));
+
+        final String jsonString = "{\"found\":true,\"_seq_no\":1,\"_primary_term\":2,\"_routing\":\"routing\","
+            + "\"_source\":\"{\\\"name\\\":\\\"John Doe\\\"}\"}";
+
+        final StringReader reader = new StringReader(jsonString);
+        final JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        final JsonParser parser = mapper.jsonProvider().createParser(reader);
+        final InlineGet actual = InlineGet.createInlineGetDeserializer(JsonpDeserializer.jsonValueDeserializer())
+            .deserialize(parser, mapper);
+        assertEquals(inlineGet.found(), actual.found());
+        assertEquals(inlineGet.seqNo(), actual.seqNo());
+        assertEquals(inlineGet.primaryTerm(), actual.primaryTerm());
+        assertEquals(inlineGet.routing(), actual.routing());
+        assertEquals(inlineGet.source(), actual.source());
+    }
+
+    @Test
+    public void testInlineGet_withoutSource() {
+        final InlineGet inlineGet = InlineGet.of(b -> b
+            .found(true)
+            .seqNo(1L)
+            .primaryTerm(2L)
+            .routing("routing"));
+
+        final String jsonString = "{\"found\":true,\"_seq_no\":1,\"_primary_term\":2,\"_routing\":\"routing\"}";
+
+        final StringReader reader = new StringReader(jsonString);
+        final JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        final JsonParser parser = mapper.jsonProvider().createParser(reader);
+        final InlineGet actual = InlineGet.createInlineGetDeserializer(JsonpDeserializer.jsonValueDeserializer())
+            .deserialize(parser, mapper);
+        assertEquals(inlineGet.found(), actual.found());
+        assertEquals(inlineGet.seqNo(), actual.seqNo());
+        assertEquals(inlineGet.primaryTerm(), actual.primaryTerm());
+        assertEquals(inlineGet.routing(), actual.routing());
+    }
+}


### PR DESCRIPTION
This addresses the bug in https://github.com/opensearch-project/opensearch-java/issues/1042

Developer's Certificate of Origin 1.1
By making a contribution to this project, I certify that:
(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or
(b) The contribution is based upon previous work that, to the
    best of my knowledge, is covered under an appropriate open
    source license and I have the right under that license to
    submit that work with modifications, whether created in whole
    or in part by me, under the same open source license (unless
    I am permitted to submit under a different license), as
    Indicated in the file; or
(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.
(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including
    all personal information I submit with it, including my
    sign-off) is maintained indefinitely and may be redistributed
    consistent with this project or the open source license(s)
    involved.

Signed-off-by: Brendon Faleiro <bren.faleiro@gmail.com>
