### PR TITLE
[Backport] [2.x] Bump io.github.classgraph:classgraph from 4.8.173 to 4.8.174 in /java-client (#1050)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
-- Bumps `io.github.classgraph:classgraph` from 4.8.172 to 4.8.173
+- Bumps `io.github.classgraph:classgraph` from 4.8.172 to 4.8.174
 
 ### Changed
 - Made InlineGet source field nullable. ([#1042](https://github.com/opensearch-project/opensearch-java/pull/1042))

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -215,7 +215,7 @@ dependencies {
     implementation("org.eclipse", "yasson", "2.0.2")
 
     // https://github.com/classgraph/classgraph
-    testImplementation("io.github.classgraph:classgraph:4.8.173")
+    testImplementation("io.github.classgraph:classgraph:4.8.174")
 
     // Eclipse 1.0
     testImplementation("junit", "junit" , "4.13.2") {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1050 to `2.x`