### PR TITLE
Adding @Xtansia to maintainers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @reta @Bukhtawar @dblock @szczepanczykd @madhusudhankonda @saratvemulapalli @VachaShah
+*   @reta @Bukhtawar @dblock @szczepanczykd @madhusudhankonda @saratvemulapalli @VachaShah @Xtansia

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Dominik Szczepańczyk | [szczepanczykd](https://github.com/szczepanczykd)       | Exadel         |
 | Madhusudhan Konda    | [madhusudhankonda](https://github.com/madhusudhankonda) | Chocolateminds |
 | Sarat Vemulapalli    | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon         |
+| Thomas Farr          | [Xtansia](https://github.com/Xtansia)                   | Amazon         |
 | Vacha Shah           | [VachaShah](https://github.com/VachaShah)               | Amazon         |
 
 ## Emeritus


### PR DESCRIPTION
### Description

Thomas has a [dozen PRs](https://github.com/opensearch-project/opensearch-java/pulls?q=is%3Apr+author%3AXtansia+is%3Aclosed) merged into the project, including several bug fixes and a code generator (a big one). He is on the path of touching every aspect of the Java client, is a strong developer, works full time on clients at Amazon, and is already a maintainer of other OpenSearch clients such as opensearch-rs and opensearch-net.

Current maintainers unanimously approved this addition, welcome @Xtansia!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
