### PR TITLE
[Backport 2.11] Made InlineGet source field nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 
 ### Changed
+- Made InlineGet source field nullable. ([#1042](https://github.com/opensearch-project/opensearch-java/pull/1042))
 
 ### Deprecated
 
@@ -23,7 +24,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `io.github.classgraph:classgraph` from 4.8.172 to 4.8.173
 
 ### Changed
-- Made InlineGet source field nullable. ([#1042](https://github.com/opensearch-project/opensearch-java/pull/1042))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `io.github.classgraph:classgraph` from 4.8.172 to 4.8.173
 
 ### Changed
+- Made InlineGet source field nullable. ([#1042](https://github.com/opensearch-project/opensearch-java/pull/1042))
 
 ### Deprecated
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/InlineGet.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/InlineGet.java
@@ -68,6 +68,7 @@ public class InlineGet<TDocument> implements JsonpSerializable {
     @Nullable
     private final String routing;
 
+    @Nullable
     private final TDocument source;
 
     @Nullable
@@ -84,7 +85,7 @@ public class InlineGet<TDocument> implements JsonpSerializable {
         this.seqNo = builder.seqNo;
         this.primaryTerm = builder.primaryTerm;
         this.routing = builder.routing;
-        this.source = ApiTypeHelper.requireNonNull(builder.source, this, "source");
+        this.source = builder.source;
         this.tDocumentSerializer = builder.tDocumentSerializer;
 
     }
@@ -139,8 +140,9 @@ public class InlineGet<TDocument> implements JsonpSerializable {
     }
 
     /**
-     * Required - API name: {@code _source}
+     * API name: {@code _source}
      */
+    @Nullable
     public final TDocument source() {
         return this.source;
     }
@@ -191,9 +193,11 @@ public class InlineGet<TDocument> implements JsonpSerializable {
             generator.write(this.routing);
 
         }
-        generator.writeKey("_source");
-        JsonpUtils.serialize(this.source, generator, tDocumentSerializer, mapper);
+        if (this.source != null) {
+            generator.writeKey("_source");
+            JsonpUtils.serialize(this.source, generator, tDocumentSerializer, mapper);
 
+        }
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -240,6 +244,7 @@ public class InlineGet<TDocument> implements JsonpSerializable {
         @Nullable
         private String routing;
 
+        @Nullable
         private TDocument source;
 
         @Nullable
@@ -298,9 +303,9 @@ public class InlineGet<TDocument> implements JsonpSerializable {
         }
 
         /**
-         * Required - API name: {@code _source}
+         * API name: {@code _source}
          */
-        public final Builder<TDocument> source(TDocument value) {
+        public final Builder<TDocument> source(@Nullable TDocument value) {
             this.source = value;
             return this;
         }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/InlineGetTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/InlineGetTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch._types;
+
+import static org.junit.Assert.assertEquals;
+
+import jakarta.json.stream.JsonParser;
+import java.io.StringReader;
+import org.junit.Test;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+
+public class InlineGetTest {
+    @Test
+    public void testInlineGet_withSource() {
+        final InlineGet inlineGet = InlineGet.of(
+            b -> b.found(true).seqNo(1L).primaryTerm(2L).routing("routing").source("{\"name\":\"John Doe\"}")
+        );
+
+        final String jsonString = "{\"found\":true,\"_seq_no\":1,\"_primary_term\":2,\"_routing\":\"routing\","
+            + "\"_source\":\"{\\\"name\\\":\\\"John Doe\\\"}\"}";
+
+        final StringReader reader = new StringReader(jsonString);
+        final JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        final JsonParser parser = mapper.jsonProvider().createParser(reader);
+        final InlineGet actual = InlineGet.createInlineGetDeserializer(JsonpDeserializer.stringDeserializer()).deserialize(parser, mapper);
+        assertEquals(inlineGet.found(), actual.found());
+        assertEquals(inlineGet.seqNo(), actual.seqNo());
+        assertEquals(inlineGet.primaryTerm(), actual.primaryTerm());
+        assertEquals(inlineGet.routing(), actual.routing());
+        assertEquals(inlineGet.source(), actual.source());
+    }
+
+    @Test
+    public void testInlineGet_withoutSource() {
+        final InlineGet inlineGet = InlineGet.of(b -> b.found(true).seqNo(1L).primaryTerm(2L).routing("routing"));
+
+        final String jsonString = "{\"found\":true,\"_seq_no\":1,\"_primary_term\":2,\"_routing\":\"routing\"}";
+
+        final StringReader reader = new StringReader(jsonString);
+        final JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        final JsonParser parser = mapper.jsonProvider().createParser(reader);
+        final InlineGet actual = InlineGet.createInlineGetDeserializer(JsonpDeserializer.stringDeserializer()).deserialize(parser, mapper);
+        assertEquals(inlineGet.found(), actual.found());
+        assertEquals(inlineGet.seqNo(), actual.seqNo());
+        assertEquals(inlineGet.primaryTerm(), actual.primaryTerm());
+        assertEquals(inlineGet.routing(), actual.routing());
+    }
+}


### PR DESCRIPTION
### Description
Backports #1046 to 2.11. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
