### PR TITLE
Add workflow to ensure generated code is up to date

### DIFF
--- a/.github/workflows/code-generation.yml
+++ b/.github/workflows/code-generation.yml
@@ -1,0 +1,34 @@
+name: Code Generation
+
+on: [pull_request]
+
+jobs:
+  up_to_date:
+    name: Ensure Generated Code Up To Date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Java Client
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Run Code Generator
+        run: ./gradlew clean :java-codegen:run
+
+      - name: Check Has No Changes
+        shell: bash -eo pipefail {0}
+        run: |
+          output=$(git status --porcelain)
+          if [ -z "$output" ]; then
+            echo "Clean working directory"
+            exit 0
+          else
+            echo "Dirty working directory"
+            echo "$output"
+            exit 1
+          fi


### PR DESCRIPTION
### Description
Add workflow to ensure generated code is up to date

Example of failing run: https://github.com/opensearch-project/opensearch-java/actions/runs/9736512856/job/26867247859?pr=1061

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
