### PR TITLE
[Backport] [2.x] Bump org.owasp.dependencycheck from 9.2.0 to 10.0.2 (#1069)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `io.github.classgraph:classgraph` from 4.8.173 to 4.8.174
+- Bumps `org.owasp.dependencycheck` from 9.1.0 to 10.0.2
+- Bumps `com.github.jk1.dependency-license-report` from 2.7 to 2.8
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -48,8 +48,8 @@ plugins {
     java
     `java-library`
     `maven-publish`
-    id("com.github.jk1.dependency-license-report") version "2.7"
-    id("org.owasp.dependencycheck") version "9.1.0"
+    id("com.github.jk1.dependency-license-report") version "2.8"
+    id("org.owasp.dependencycheck") version "10.0.2"
     id("com.diffplug.spotless") version "6.25.0"
 }
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1069  to `2.x`