### PR TITLE
Fix author attribution of code-gen auto PRs

### DIFF
--- a/.github/workflows/code-generation.yml
+++ b/.github/workflows/code-generation.yml
@@ -77,6 +77,8 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.github_app_token.outputs.token || secrets.GITHUB_TOKEN }}
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           commit-message: Re-generate client code using latest OpenSearch API specification (${{ steps.date.outputs.date }})
           title: Re-generated client code using latest OpenSearch API specification
           body: |


### PR DESCRIPTION
### Description
Fix author attribution of code-gen auto PRs, otherwise gets attributed to a recent committer due to running on a schedule as in #1077 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
