### PR TITLE
[Backport] [2.x] Bump commons-logging:commons-logging from 1.3.2 to 1.3.3 in /java-client (#1079)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `io.github.classgraph:classgraph` from 4.8.173 to 4.8.174
 - Bumps `org.owasp.dependencycheck` from 9.1.0 to 10.0.2
 - Bumps `com.github.jk1.dependency-license-report` from 2.7 to 2.8
+- Bumps `commons-logging:commons-logging` from 1.3.2 to 1.3.3
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -166,7 +166,7 @@ dependencies {
     val jacksonDatabindVersion = "2.17.0"
 
     // Apache 2.0
-    api("commons-logging:commons-logging:1.3.2")
+    api("commons-logging:commons-logging:1.3.3")
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)
     testImplementation("org.hamcrest:hamcrest:2.2")
     testImplementation("com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.8.1") {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1079 to `2.x`