### PR TITLE
Bump org.apache.httpcomponents.core5:httpcore5 from 5.2.4 to 5.2.5 (#1080)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `org.owasp.dependencycheck` from 9.1.0 to 10.0.2
 - Bumps `com.github.jk1.dependency-license-report` from 2.7 to 2.8
 - Bumps `commons-logging:commons-logging` from 1.3.2 to 1.3.3
+- Bumps `org.apache.httpcomponents.core5:httpcore5` from 5.2.4 to 5.2.5
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -196,8 +196,8 @@ dependencies {
     implementation("org.apache.httpcomponents.client5", "httpclient5", "5.3.1") {
       exclude(group = "org.apache.httpcomponents.core5")
     }
-    implementation("org.apache.httpcomponents.core5", "httpcore5", "5.2.4")
-    implementation("org.apache.httpcomponents.core5", "httpcore5-h2", "5.2.4")
+    implementation("org.apache.httpcomponents.core5", "httpcore5", "5.2.5")
+    implementation("org.apache.httpcomponents.core5", "httpcore5-h2", "5.2.5")
 
     // For AwsSdk2Transport
     "awsSdk2SupportCompileOnly"("software.amazon.awssdk","sdk-core","[2.15,3.0)")


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1080 to `2.x`