### PR TITLE
Added json.md - Serialization part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Added
 - Document HTTP/2 support ([#330](https://github.com/opensearch-project/opensearch-java/pull/330))
 - Add support for phase_took & search_pipeline request params ([#1036](https://github.com/opensearch-project/opensearch-java/pull/1036))
-- Add an interface PlainJsonSerializable inherit from JsonpSerializable with a default method streamlining serialization ([#1064](https://github.com/opensearch-project/opensearch-java/pull/1064))
+- Add an interface PlainJsonSerializable with a default method for serialization to Json ([#1064](https://github.com/opensearch-project/opensearch-java/pull/1064))
 
 ### Dependencies
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -199,6 +199,7 @@ You can find a working sample of the above code in [IndexingBasics.java](./sampl
 - [Point-in-Time APIs](./guides/point_in_time.md)
 - [Search](./guides/search.md)
 - [Generic Client](./guides/generic.md)
+- [Json](./guides/json.md)
 
 ## Plugins
 

--- a/guides/json.md
+++ b/guides/json.md
@@ -1,0 +1,53 @@
+- [Working With JSON](#working-with-json)
+  - [Serialization](#serialization)
+    - [Using toJsonString](#using-tojsonstring)
+    - [Manual Serialization](#manual-serialization)
+ 
+
+# Working With JSON
+
+OpenSearch Java client seamlessly integrates with JSON, providing serialization and deserialization capability.
+
+## Serialization
+
+For demonstration let's consider an instance of `SearchRequest`.
+
+```java
+
+SearchRequest searchRequest = SearchRequest.of(
+        request -> request.index("index1", "index2")
+                .aggregations(Collections.emptyMap())
+                .terminateAfter(5L)
+                .query(q -> q.match(t -> t.field("name").query(FieldValue.of("OpenSearch"))))
+);
+```
+### Using toJsonString
+For classes implementing `PlainJsonSerializable`, which extends `JsonpSerializable`, a default `toJsonString` method is provided.
+This implementation uses `jakarta.json.spi.JsonProvider` SPI to discover the available JSON provider instance 
+from the classpath and to create a new mapper. The `JsonpUtils` utility class streamlines this serialization process.
+The following code example demonstrates how to use the `toJsonString` method to serialize objects:
+
+```java
+String requestString = searchRequest.toJsonString();
+```
+
+
+### Manual Serialization
+For classes implementing the `JsonpSerializable` interface, a serialize method is provided, which takes a mapper and a generator 
+as arguments and returns the JSON string representation of the instance.
+
+The following sample code demonstrates how to serialize an instance of a Java class:
+
+```java
+private String toJson(JsonpSerializable object) {
+  try (StringWriter writer = new StringWriter()) {
+    JsonbJsonpMapper mapper = new JsonbJsonpMapper();
+    try (JsonGenerator generator = mapper.jsonProvider().createGenerator(writer)) {
+      serialize(generator, mapper);
+    }
+    return writer.toString();
+  } catch (IOException ex) {
+    throw new UncheckedIOException(ex);
+  }
+}
+```

--- a/samples/src/main/java/org/opensearch/client/samples/json/SerializationBasics.java
+++ b/samples/src/main/java/org/opensearch/client/samples/json/SerializationBasics.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.samples.json;
+
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
+import org.opensearch.client.opensearch.indices.PutIndexTemplateResponse;
+import org.opensearch.client.samples.SampleClient;
+import org.opensearch.client.samples.Search;
+
+public class SerializationBasics {
+
+    private static final Logger LOGGER = LogManager.getLogger(Search.class);
+
+    private static OpenSearchClient client;
+
+    public static void main(String[] args) {
+        try {
+            client = SampleClient.create();
+
+            var version = client.info().version();
+            LOGGER.info("Server: {}@{}.", version.distribution(), version.number());
+
+            final var indexTemplateName = "my-index";
+            final var indexSettingsComponentTemplate = "index-settings";
+            final var indexMappingsComponentTemplate = "index-mappings";
+
+            // Create Index Template Request for index 'my-index'.
+            PutIndexTemplateRequest putIndexTemplateRequest = PutIndexTemplateRequest.of(
+                it -> it.name(indexTemplateName)
+                    .indexPatterns("my-index-*")
+                    .composedOf(List.of(indexSettingsComponentTemplate, indexMappingsComponentTemplate))
+            );
+
+            LOGGER.info("Creating index template {}.", indexTemplateName);
+
+            // Use toJsonString method to log Request and Response string.
+            LOGGER.debug("Index Template Request: {}.", putIndexTemplateRequest.toJsonString());
+            PutIndexTemplateResponse response = client.indices().putIndexTemplate(putIndexTemplateRequest);
+            LOGGER.info("Index Template Response: {}.", response.toJsonString());
+
+        } catch (Exception e) {
+            LOGGER.error("Exception occurred.", e);
+        }
+    }
+}


### PR DESCRIPTION
### Description
* Added documentation  json.md in guides folder for Json serialization with openSearch java Client.
* Added code samples to guide users to use the `toJsonString `method added [here ](https://github.com/opensearch-project/opensearch-java/pull/1064)and manual serialization with serialize method in `JsonpSerializable`
* Added a Working  Sample , created a new directory for json in /samples.

### Issues Resolved
Documentation for Json serialization with code samples
Work samples demonstrating logging with toJsonString method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
