### PR TITLE
Added bwc version of `searchAfter` which accepts `FieldValue`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased 2.x]
 ### Added
+- Added `searchAfterVals` to `SearchRequest` to allow passing arbitrary `FieldValue`s to `search_after` ([#1105](https://github.com/opensearch-project/opensearch-java/pull/1105))
 
 ### Dependencies
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
@@ -48,6 +48,7 @@ import org.opensearch.client.json.ObjectDeserializer;
 import org.opensearch.client.json.PlainJsonSerializable;
 import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch._types.ExpandWildcard;
+import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.RequestBase;
 import org.opensearch.client.opensearch._types.ScriptField;
 import org.opensearch.client.opensearch._types.SearchType;
@@ -191,7 +192,7 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
     @Nullable
     private final Time scroll;
 
-    private final List<String> searchAfter;
+    private final List<FieldValue> searchAfter;
 
     @Nullable
     private final SearchType searchType;
@@ -710,8 +711,19 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
 
     /**
      * API name: {@code search_after}
+     *
+     * <p><b>NOTE: In version 3.0.0 of opensearch-java, this method will instead return a {@code List<FieldValue>}.</b></p>
      */
     public final List<String> searchAfter() {
+        return this.searchAfter.stream().map(FieldValue::_toJsonString).collect(Collectors.toList());
+    }
+
+    /**
+     * API name: {@code search_after}
+     *
+     * <p><b>NOTE: In version 3.0.0 of opensearch-java, this method will be renamed to replace {@link #searchAfter()}.</b></p>
+     */
+    public final List<FieldValue> searchAfterVals() {
         return this.searchAfter;
     }
 
@@ -1006,8 +1018,8 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
         if (ApiTypeHelper.isDefined(this.searchAfter)) {
             generator.writeKey("search_after");
             generator.writeStartArray();
-            for (String item0 : this.searchAfter) {
-                generator.write(item0);
+            for (FieldValue item0 : this.searchAfter) {
+                item0.serialize(generator, mapper);
 
             }
             generator.writeEnd();
@@ -1143,7 +1155,7 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
             .runtimeMappings(runtimeMappings)
             .scriptFields(scriptFields)
             .scroll(scroll)
-            .searchAfter(searchAfter)
+            .searchAfterVals(searchAfter)
             .searchType(searchType)
             .seqNoPrimaryTerm(seqNoPrimaryTerm)
             .size(size)
@@ -1288,7 +1300,7 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
         private Time scroll;
 
         @Nullable
-        private List<String> searchAfter;
+        private List<FieldValue> searchAfter;
 
         @Nullable
         private SearchType searchType;
@@ -1998,8 +2010,34 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
          * API name: {@code search_after}
          * <p>
          * Adds all elements of <code>list</code> to <code>searchAfter</code>.
+         *
+         * <p><b>NOTE: In version 3.0.0 of opensearch-java, this method will instead accept a {@code List<FieldValue>}.</b></p>
          */
         public final Builder searchAfter(List<String> list) {
+            this.searchAfter = _listAddAll(this.searchAfter, FieldValue::of, list);
+            return this;
+        }
+
+        /**
+         * API name: {@code search_after}
+         * <p>
+         * Adds one or more values to <code>searchAfter</code>.
+         *
+         * <p><b>NOTE: In version 3.0.0 of opensearch-java, this method will instead accept values of type {@code FieldValue}.</b></p>
+         */
+        public final Builder searchAfter(String value, String... values) {
+            this.searchAfter = _listAdd(this.searchAfter, FieldValue::of, value, values);
+            return this;
+        }
+
+        /**
+         * API name: {@code search_after}
+         * <p>
+         * Adds all elements of <code>list</code> to <code>searchAfter</code>.
+         *
+         * <p><b>NOTE: In version 3.0.0 of opensearch-java, this method will be renamed to replace {@link #searchAfter(List)}.</b></p>
+         */
+        public final Builder searchAfterVals(List<FieldValue> list) {
             this.searchAfter = _listAddAll(this.searchAfter, list);
             return this;
         }
@@ -2008,8 +2046,10 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
          * API name: {@code search_after}
          * <p>
          * Adds one or more values to <code>searchAfter</code>.
+         *
+         * <p><b>NOTE: In version 3.0.0 of opensearch-java, this method will be renamed to replace {@link #searchAfter(String, String...)}.</b></p>
          */
-        public final Builder searchAfter(String value, String... values) {
+        public final Builder searchAfterVals(FieldValue value, FieldValue... values) {
             this.searchAfter = _listAdd(this.searchAfter, value, values);
             return this;
         }
@@ -2301,7 +2341,7 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
         op.add(Builder::rescore, JsonpDeserializer.arrayDeserializer(Rescore._DESERIALIZER), "rescore");
         op.add(Builder::runtimeMappings, JsonpDeserializer.stringMapDeserializer(RuntimeField._DESERIALIZER), "runtime_mappings");
         op.add(Builder::scriptFields, JsonpDeserializer.stringMapDeserializer(ScriptField._DESERIALIZER), "script_fields");
-        op.add(Builder::searchAfter, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "search_after");
+        op.add(Builder::searchAfterVals, JsonpDeserializer.arrayDeserializer(FieldValue._DESERIALIZER), "search_after");
         op.add(Builder::seqNoPrimaryTerm, JsonpDeserializer.booleanDeserializer(), "seq_no_primary_term");
         op.add(Builder::size, JsonpDeserializer.integerDeserializer(), "size");
         op.add(Builder::slice, SlicedScroll._DESERIALIZER, "slice");

--- a/java-client/src/main/java/org/opensearch/client/util/ObjectBuilderBase.java
+++ b/java-client/src/main/java/org/opensearch/client/util/ObjectBuilderBase.java
@@ -39,6 +39,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class ObjectBuilderBase {
     private boolean _used = false;
@@ -75,13 +77,30 @@ public class ObjectBuilderBase {
 
     /** Add a value to a (possibly {@code null}) list */
     @SafeVarargs
+    protected static <TOut, TIn> List<TOut> _listAdd(List<TOut> list, Function<TIn, TOut> mapper, TIn value, TIn... values) {
+        List<TOut> mappedValues = values.length > 0 ? Arrays.stream(values).map(mapper).collect(Collectors.toList()) : null;
+        return _listAdd(list, mapper.apply(value), mappedValues);
+    }
+
+    /** Add a value to a (possibly {@code null}) list */
+    @SafeVarargs
     protected static <T> List<T> _listAdd(List<T> list, T value, T... values) {
+        return _listAdd(list, value, values.length > 0 ? Arrays.asList(values) : null);
+    }
+
+    private static <T> List<T> _listAdd(List<T> list, T value, List<T> values) {
         list = _mutableList(list);
         list.add(value);
-        if (values.length > 0) {
-            list.addAll(Arrays.asList(values));
+        if (values != null) {
+            list.addAll(values);
         }
         return list;
+    }
+
+    /** Add all elements of a list to a (possibly {@code null}) list */
+    protected static <TOut, TIn> List<TOut> _listAddAll(List<TOut> list, Function<TIn, TOut> mapper, List<TIn> values) {
+        List<TOut> mappedValues = values != null ? values.stream().map(mapper).collect(Collectors.toList()) : null;
+        return _listAddAll(list, mappedValues);
     }
 
     /** Add all elements of a list to a (possibly {@code null}) list */

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
@@ -11,9 +11,21 @@ package org.opensearch.client.opensearch.core;
 import java.util.Collections;
 import org.junit.Test;
 import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch.model.ModelTestCase;
 
 public class SearchRequestTest extends ModelTestCase {
+
+    @Test
+    public void afterSearch() {
+        SearchRequest request = new SearchRequest.Builder().searchAfter("string1", "string2").build();
+
+        assertEquals("{\"search_after\":[\"string1\",\"string2\"]}", toJson(request));
+
+        request = new SearchRequest.Builder().searchAfterVals(FieldValue.of(1), FieldValue.of("string")).build();
+
+        assertEquals("{\"search_after\":[1,\"string\"]}", toJson(request));
+    }
 
     @Test
     public void ext() {


### PR DESCRIPTION
### Description
Adds a backwards compatible fix for #755 in `2.x` as the fix in main (#769) was breaking.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
