### PR TITLE
possible fix for #1106

### DIFF
--- a/java-client/src/main/java/org/opensearch/client/util/PathEncoder.java
+++ b/java-client/src/main/java/org/opensearch/client/util/PathEncoder.java
@@ -31,7 +31,11 @@ public class PathEncoder {
     static {
         Class<?> clazz = null;
         try {
+<<<<<<< Updated upstream
             // Try Apache HttpClient5 first since this is a default one
+=======
+            // Try Apache HttpClient5 first since this is the "better" encoder
+>>>>>>> Stashed changes
             clazz = Class.forName(HTTP_CLIENT5_UTILS_CLASS);
         } catch (final ClassNotFoundException ex) {
             try {

--- a/java-client/src/test/java/org/opensearch/client/opensearch/model/EndpointTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/model/EndpointTest.java
@@ -57,6 +57,7 @@ public class EndpointTest extends Assert {
         assertEquals("/a/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
 
         req = RefreshRequest.of(b -> b.index("a", "b"));
+<<<<<<< Updated upstream
         if (isHttpClient5Present()) {
             assertEquals("/a%2Cb/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
 
@@ -70,6 +71,12 @@ public class EndpointTest extends Assert {
         } else {
             assertEquals("/a,b,c/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
         }
+=======
+        assertEquals("/a%2Cb/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
+
+        req = RefreshRequest.of(b -> b.index("a", "b", "c"));
+        assertEquals("/a%2Cb%2Cc/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
+>>>>>>> Stashed changes
     }
 
     @Test
@@ -80,11 +87,15 @@ public class EndpointTest extends Assert {
         assertEquals("/a%2Fb/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
 
         req = RefreshRequest.of(b -> b.index("a/b", "c/d"));
+<<<<<<< Updated upstream
         if (isHttpClient5Present()) {
             assertEquals("/a%2Fb%2Cc%2Fd/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
         } else {
             assertEquals("/a%2Fb,c%2Fd/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
         }
+=======
+        assertEquals("/a%2Fb%2Cc%2Fd/_refresh", RefreshRequest._ENDPOINT.requestUrl(req));
+>>>>>>> Stashed changes
 
     }
 


### PR DESCRIPTION
### Description
Change order of libraries found for URL encoding

### Issues Resolved
Might solve #1106 but it leaves a bad bug in the code for those that do not use httpClient5.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
