### PR TITLE
Default normalizer deserialization to custom type when unspecified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Removed
 
 ### Fixed
-
+- Fixed error when deserializing a normalizer without 'type' [#1111](https://github.com/opensearch-project/opensearch-java/pull/1111)
 ### Security
 
 ## [2.12.0] - 07/22/2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Removed
 
 ### Fixed
-- Fixed error when deserializing a normalizer without 'type' [#1111](https://github.com/opensearch-project/opensearch-java/pull/1111)
+- Fixed error when deserializing a normalizer without 'type' ([#1111](https://github.com/opensearch-project/opensearch-java/pull/1111))
+
 ### Security
 
 ## [2.12.0] - 07/22/2024

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/Normalizer.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/analysis/Normalizer.java
@@ -186,7 +186,7 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
         op.add(Builder::custom, CustomNormalizer._DESERIALIZER, "custom");
         op.add(Builder::lowercase, LowercaseNormalizer._DESERIALIZER, "lowercase");
 
-        op.setTypeProperty("type", null);
+        op.setTypeProperty("type", Kind.Custom.jsonValue());
 
     }
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/analysis/NormalizerDeserializerTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/analysis/NormalizerDeserializerTest.java
@@ -12,11 +12,10 @@ import org.junit.Test;
 import org.opensearch.client.opensearch.model.ModelTestCase;
 
 public class NormalizerDeserializerTest extends ModelTestCase {
+
     @Test
     public void deserializesTypelessCustomAnalyzer() {
-        String json = "{\n" +
-            "          \"filter\": \"lowercase\"\n" +
-            "      }";
+        String json = "{\n" + "          \"filter\": \"lowercase\"\n" + "      }";
 
         Normalizer normalizer = fromJson(json, Normalizer._DESERIALIZER);
         assertTrue(normalizer.isCustom());

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/analysis/NormalizerDeserializerTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/analysis/NormalizerDeserializerTest.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch._types.analysis;
+
+import org.junit.Test;
+import org.opensearch.client.opensearch.model.ModelTestCase;
+
+public class NormalizerDeserializerTest extends ModelTestCase {
+    @Test
+    public void deserializesTypelessCustomAnalyzer() {
+        String json = "{\n" +
+            "          \"filter\": \"lowercase\"\n" +
+            "      }";
+
+        Normalizer normalizer = fromJson(json, Normalizer._DESERIALIZER);
+        assertTrue(normalizer.isCustom());
+        assertEquals("lowercase", normalizer.custom().filter().get(0));
+    }
+}


### PR DESCRIPTION
### Description
Fixes an error when deserializing a normalizer without an explicit type specified:

JsonParsingException: Property 'type' not found
    at org.opensearch.client.json.JsonpUtils.lookAheadFieldValue(JsonpUtils.java:145)
The server requires type to be specified unless tokenizer is specified then type: custom is assumed, thus any normalizer without type specified is a custom analyzer.

### Issues Resolved
Fixes #1110 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
