### PR TITLE
Fixed deserialization of SearchRequest when `_source` is an array

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Run Docker
         run: |
           echo "PASSWORD=admin" >> $GITHUB_ENV
-          docker-compose --project-directory .ci/opensearch build --build-arg OPENSEARCH_VERSION=${{ matrix.entry.opensearch_version }}
-          docker-compose --project-directory .ci/opensearch up -d
+          docker compose --project-directory .ci/opensearch build --build-arg OPENSEARCH_VERSION=${{ matrix.entry.opensearch_version }}
+          docker compose --project-directory .ci/opensearch up -d
           sleep 60
 
       - name: Sets password (new versions)
@@ -64,4 +64,4 @@ jobs:
 
       - name: Stop Docker
         run: |
-          docker-compose --project-directory .ci/opensearch down
+          docker compose --project-directory .ci/opensearch down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Fixed
 - Fixed error when deserializing a normalizer without 'type' ([#1111](https://github.com/opensearch-project/opensearch-java/pull/1111))
+- Fixed deserialization of SearchRequest when `_source` is an array ([#1117](https://github.com/opensearch-project/opensearch-java/pull/1117))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/json/ObjectDeserializer.java
+++ b/java-client/src/main/java/org/opensearch/client/json/ObjectDeserializer.java
@@ -239,7 +239,12 @@ public class ObjectDeserializer<ObjectType> implements JsonpDeserializer<ObjectT
             throw new NoSuchElementException("No deserializer was setup for '" + name + "'");
         }
 
-        acceptedEvents = EventSetObjectAndString;
+        this.acceptedEvents = EventSetObjectAndString.clone();
+
+        if (this.shortcutProperty instanceof FieldObjectDeserializer) {
+            JsonpDeserializer<?> shortcutDeserializer = ((FieldObjectDeserializer<?, ?>) this.shortcutProperty).deserializer;
+            this.acceptedEvents.addAll(shortcutDeserializer.nativeEvents());
+        }
     }
 
     // ----- Object types

--- a/java-client/src/main/java/org/opensearch/client/json/UnionDeserializer.java
+++ b/java-client/src/main/java/org/opensearch/client/json/UnionDeserializer.java
@@ -179,8 +179,13 @@ public class UnionDeserializer<Union, Kind, Member> implements JsonpDeserializer
                 );
                 objectMembers.add(member);
                 if (od.shortcutProperty() != null) {
-                    // also add it as a string
-                    addMember(Event.VALUE_STRING, tag, member);
+                    // also add it as the shortcut property events
+                    for (Event e : od.acceptedEvents()) {
+                        if (e == Event.START_OBJECT || e == Event.KEY_NAME) {
+                            continue;
+                        }
+                        addMember(e, tag, member);
+                    }
                 }
             } else {
                 UnionDeserializer.SingleMemberHandler<Union, Kind, Member> member = new SingleMemberHandler<>(tag, deserializer);

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
@@ -9,9 +9,12 @@
 package org.opensearch.client.opensearch.core;
 
 import java.util.Collections;
+import java.util.List;
 import org.junit.Test;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch.core.search.SourceConfig;
+import org.opensearch.client.opensearch.core.search.SourceFilter;
 import org.opensearch.client.opensearch.model.ModelTestCase;
 
 public class SearchRequestTest extends ModelTestCase {
@@ -56,5 +59,77 @@ public class SearchRequestTest extends ModelTestCase {
         SearchRequest copied = origin.toBuilder().build();
 
         assertEquals(copied.index(), origin.index());
+    }
+
+    @Test
+    public void canDeserializeSourceAsBoolean() {
+        String json = "{\"query\":{\"match_all\":{}},\"_source\":true,\"size\":1}";
+
+        SearchRequest searchRequest = fromJson(json, SearchRequest._DESERIALIZER);
+
+        SourceConfig _source = searchRequest.source();
+        assertNotNull(_source);
+        assertTrue(_source.isFetch());
+        assertTrue(_source.fetch());
+    }
+
+    @Test
+    public void canDeserializeSourceAsString() {
+        String json = "{\"query\":{\"match_all\":{}},\"_source\":\"_id\",\"size\":1}";
+
+        SearchRequest searchRequest = fromJson(json, SearchRequest._DESERIALIZER);
+
+        SourceConfig _source = searchRequest.source();
+        assertNotNull(_source);
+        assertTrue(_source.isFilter());
+
+        SourceFilter filter = _source.filter();
+        assertNotNull(filter);
+
+        List<String> includes = filter.includes();
+        assertEquals(1, includes.size());
+        assertEquals("_id", includes.get(0));
+
+        assertTrue(filter.excludes().isEmpty());
+    }
+
+    @Test
+    public void canDeserializeSourceAsArray() {
+        String json = "{\"query\":{\"match_all\":{}},\"_source\":[\"_id\"],\"size\":1}";
+
+        SearchRequest searchRequest = fromJson(json, SearchRequest._DESERIALIZER);
+
+        SourceConfig _source = searchRequest.source();
+        assertNotNull(_source);
+        assertTrue(_source.isFilter());
+
+        SourceFilter filter = _source.filter();
+        assertNotNull(filter);
+
+        List<String> includes = filter.includes();
+        assertEquals(1, includes.size());
+        assertEquals("_id", includes.get(0));
+
+        assertTrue(filter.excludes().isEmpty());
+    }
+
+    @Test
+    public void canDeserializeSourceAsObject() {
+        String json = "{\"query\":{\"match_all\":{}},\"_source\":{\"includes\":[\"_id\"]},\"size\":1}";
+
+        SearchRequest searchRequest = fromJson(json, SearchRequest._DESERIALIZER);
+
+        SourceConfig _source = searchRequest.source();
+        assertNotNull(_source);
+        assertTrue(_source.isFilter());
+
+        SourceFilter filter = _source.filter();
+        assertNotNull(filter);
+
+        List<String> includes = filter.includes();
+        assertEquals(1, includes.size());
+        assertEquals("_id", includes.get(0));
+
+        assertTrue(filter.excludes().isEmpty());
     }
 }


### PR DESCRIPTION
### Description
Fixed deserialization of SearchRequest when `_source` is an array

### Issues Resolved
Fixes #1087 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
