### PR TITLE
Fixes #1137 - Adding query_image to Neural query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ## [Unreleased 2.x]
 
 ### Added
+- Adds `queryImage` (query_image) field to `NeuralQuery`, following definition in ([Neural Query](https://opensearch.org/docs/latest/query-dsl/specialized/neural/)) ([#1137](https://github.com/opensearch-project/opensearch-java/pull/1138))
 
 ### Dependencies
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/NeuralQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/NeuralQuery.java
@@ -17,6 +17,7 @@ import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.ObjectBuilderDeserializer;
 import org.opensearch.client.json.ObjectDeserializer;
 import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.MissingRequiredPropertiesException;
 import org.opensearch.client.util.ObjectBuilder;
 
 @JsonpDeserializable
@@ -24,6 +25,7 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
 
     private final String field;
     private final String queryText;
+    private final String queryImage;
     private final int k;
     @Nullable
     private final String modelId;
@@ -34,7 +36,11 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
         super(builder);
 
         this.field = ApiTypeHelper.requireNonNull(builder.field, this, "field");
-        this.queryText = ApiTypeHelper.requireNonNull(builder.queryText, this, "queryText");
+        if (builder.queryText == null && builder.queryImage == null && !ApiTypeHelper.requiredPropertiesCheckDisabled()) {
+            throw new MissingRequiredPropertiesException(this, "queryText", "queryImage");
+        }
+        this.queryText = builder.queryText;
+        this.queryImage = builder.queryImage;
         this.k = ApiTypeHelper.requireNonNull(builder.k, this, "k");
         this.modelId = builder.modelId;
         this.filter = builder.filter;
@@ -70,6 +76,15 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
      */
     public final String queryText() {
         return this.queryText;
+    }
+
+    /**
+     * Required - Search query image.
+     *
+     * @return Search query image.
+     */
+    public final String queryImage() {
+        return this.queryImage;
     }
 
     /**
@@ -112,7 +127,13 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
 
         super.serializeInternal(generator, mapper);
 
-        generator.write("query_text", this.queryText);
+        if (this.queryText != null) {
+            generator.write("query_text", this.queryText);
+        }
+
+        if (this.queryImage != null) {
+            generator.write("query_image", this.queryImage);
+        }
 
         if (this.modelId != null) {
             generator.write("model_id", this.modelId);
@@ -129,7 +150,7 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).queryText(queryText).k(k).modelId(modelId).filter(filter);
+        return new Builder().field(field).queryText(queryText).queryImage(queryImage).k(k).modelId(modelId).filter(filter);
     }
 
     /**
@@ -138,6 +159,7 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
     public static class Builder extends QueryBase.AbstractBuilder<NeuralQuery.Builder> implements ObjectBuilder<NeuralQuery> {
         private String field;
         private String queryText;
+        private String queryImage;
         private Integer k;
         @Nullable
         private String modelId;
@@ -163,6 +185,17 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
          */
         public NeuralQuery.Builder queryText(@Nullable String queryText) {
             this.queryText = queryText;
+            return this;
+        }
+
+        /**
+         * Required - Search query image.
+         *
+         * @param queryImage Search query image.
+         * @return This builder.
+         */
+        public NeuralQuery.Builder queryImage(@Nullable String queryImage) {
+            this.queryImage = queryImage;
             return this;
         }
 
@@ -227,6 +260,7 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
         setupQueryBaseDeserializer(op);
 
         op.add(NeuralQuery.Builder::queryText, JsonpDeserializer.stringDeserializer(), "query_text");
+        op.add(NeuralQuery.Builder::queryImage, JsonpDeserializer.stringDeserializer(), "query_image");
         op.add(NeuralQuery.Builder::modelId, JsonpDeserializer.stringDeserializer(), "model_id");
         op.add(NeuralQuery.Builder::k, JsonpDeserializer.integerDeserializer(), "k");
         op.add(NeuralQuery.Builder::filter, Query._DESERIALIZER, "filter");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/NeuralQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/NeuralQuery.java
@@ -70,7 +70,8 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
     }
 
     /**
-     * Required - Search query text.
+     * Required - The query_text if query_image is not set.
+     * Optional - The query_text if query_image is set.
      *
      * @return Search query text.
      */
@@ -79,7 +80,8 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
     }
 
     /**
-     * Required - Search query image.
+     * Required - The query_image if query_text is not set.
+     * Optional - The query_image if query_text is set.
      *
      * @return Search query image.
      */
@@ -178,7 +180,8 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
         }
 
         /**
-         * Required - Search query text.
+         * Required - The query_text if query_image is not set.
+         * Optional - The query_text if query_image is set.
          *
          * @param queryText Search query text.
          * @return This builder.
@@ -189,7 +192,8 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
         }
 
         /**
-         * Required - Search query image.
+         * Required - The query_image if query_text is not set.
+         * Optional - The query_image if query_text is set.
          *
          * @param queryImage Search query image.
          * @return This builder.

--- a/java-client/src/main/java/org/opensearch/client/util/MissingRequiredPropertiesException.java
+++ b/java-client/src/main/java/org/opensearch/client/util/MissingRequiredPropertiesException.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client.util;
+
+import java.util.StringJoiner;
+
+/**
+ * Thrown by {@link ObjectBuilder#build()} when one of the required properties is missing.
+ * <p>
+ * If you think this is an error and that the reported property is actually optional, a workaround is
+ * available in {@link ApiTypeHelper} to disable checks. Use with caution.
+ */
+public class MissingRequiredPropertiesException extends RuntimeException {
+    private Class<?> clazz;
+    private String[] properties;
+
+    public MissingRequiredPropertiesException(Object obj, String... properties) {
+        super(
+            "Missing at least one required property between "
+                + buildPropertiesMsg(properties)
+                + " in '"
+                + obj.getClass().getSimpleName()
+                + "'"
+        );
+        this.clazz = obj.getClass();
+        this.properties = properties;
+    }
+
+    /**
+     * The class where the missing property was found
+     */
+    public Class<?> getObjectClass() {
+        return clazz;
+    }
+
+    public String[] getPropertiesName() {
+        return properties;
+    }
+
+    private static String buildPropertiesMsg(String[] properties) {
+        final StringJoiner sj = new StringJoiner(",", "'", "'");
+        for (final String property : properties) {
+            sj.add(property);
+        }
+        return sj.toString();
+    }
+}

--- a/java-client/src/main/java/org/opensearch/client/util/MissingRequiredPropertiesException.java
+++ b/java-client/src/main/java/org/opensearch/client/util/MissingRequiredPropertiesException.java
@@ -6,30 +6,6 @@
  * compatible open source license.
  */
 
-/*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
 package org.opensearch.client.util;
 
 import java.util.StringJoiner;

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/NeuralQueryTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/NeuralQueryTest.java
@@ -10,10 +10,11 @@ package org.opensearch.client.opensearch._types.query_dsl;
 
 import org.junit.Test;
 import org.opensearch.client.opensearch.model.ModelTestCase;
+import org.opensearch.client.util.MissingRequiredPropertiesException;
 
 public class NeuralQueryTest extends ModelTestCase {
     @Test
-    public void toBuilder() {
+    public void toBuilder_queryText() {
         NeuralQuery origin = new NeuralQuery.Builder().field("field")
             .queryText("queryText")
             .k(1)
@@ -22,5 +23,38 @@ public class NeuralQueryTest extends ModelTestCase {
         NeuralQuery copied = origin.toBuilder().build();
 
         assertEquals(toJson(copied), toJson(origin));
+    }
+
+    @Test
+    public void toBuilder_queryImage() {
+        NeuralQuery origin = new NeuralQuery.Builder().field("field")
+            .queryImage("queryImage")
+            .k(1)
+            .filter(IdsQuery.of(builder -> builder.values("Some_ID")).toQuery())
+            .build();
+        NeuralQuery copied = origin.toBuilder().build();
+
+        assertEquals(toJson(copied), toJson(origin));
+    }
+
+    @Test
+    public void toBuilder_both() {
+        NeuralQuery origin = new NeuralQuery.Builder().field("field")
+            .queryText("queryText")
+            .queryImage("queryImage")
+            .k(1)
+            .filter(IdsQuery.of(builder -> builder.values("Some_ID")).toQuery())
+            .build();
+        NeuralQuery copied = origin.toBuilder().build();
+
+        assertEquals(toJson(copied), toJson(origin));
+    }
+
+    @Test
+    public void toBuilder_missing_query() {
+        assertThrows(
+            MissingRequiredPropertiesException.class,
+            () -> new NeuralQuery.Builder().field("field").k(1).filter(IdsQuery.of(builder -> builder.values("Some_ID")).toQuery()).build()
+        );
     }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/model/VariantsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/model/VariantsTest.java
@@ -234,6 +234,7 @@ public class VariantsTest extends ModelTestCase {
             + "    \"neural\": {\n"
             + "      \"passage_embedding\": {\n"
             + "        \"query_text\": \"Hi world!\",\n"
+            + "        \"query_image\": \"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdj+L+U4T8ABu8CpCYJ1DQAAAAASUVORK5CYII=\",\n"
             + "        \"model_id\": \"bQ1J8ooBpBj3wT4HVUsb\",\n"
             + "        \"k\": 100\n"
             + "      }\n"
@@ -245,6 +246,10 @@ public class VariantsTest extends ModelTestCase {
 
         assertEquals("passage_embedding", searchRequest.query().neural().field());
         assertEquals("Hi world!", searchRequest.query().neural().queryText());
+        assertEquals(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdj+L+U4T8ABu8CpCYJ1DQAAAAASUVORK5CYII=",
+            searchRequest.query().neural().queryImage()
+        );
         assertEquals("bQ1J8ooBpBj3wT4HVUsb", searchRequest.query().neural().modelId());
         assertEquals(100, searchRequest.query().neural().k());
     }


### PR DESCRIPTION
### Description
Fixes missing field for query_image in Neural Query. See [Neural query](https://opensearch.org/docs/latest/query-dsl/specialized/neural/).

### Issues Resolved
- Fixes #1137 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
