### PR TITLE
Fixes #1116 - Add cancel_after_time_interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 
 ### Added
 - Adds `queryImage` (query_image) field to `NeuralQuery`, following definition in ([Neural Query](https://opensearch.org/docs/latest/query-dsl/specialized/neural/)) ([#1137](https://github.com/opensearch-project/opensearch-java/pull/1138))
+- Adds `cancelAfterTimeInterval` to `SearchRequest` and `MsearchRequest` ([#1147](https://github.com/opensearch-project/opensearch-java/pull/1147))
 
 ### Dependencies
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/MsearchRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/MsearchRequest.java
@@ -353,6 +353,16 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
         }
 
         /**
+         * The time after which the search request will be canceled.
+         * Request-level parameter takes precedence over cancel_after_time_interval cluster setting.
+         * <p>
+         * API name: {@code cancel_after_time_interval}
+         */
+        public final Builder cancelAfterTimeInterval(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+            return this.cancelAfterTimeInterval(fn.apply(new Time.Builder()).build());
+        }
+
+        /**
          * If true, network roundtrips between the coordinating node and remote clusters
          * are minimized for cross-cluster search requests.
          * <p>

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/MsearchRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/MsearchRequest.java
@@ -48,6 +48,7 @@ import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch._types.ExpandWildcard;
 import org.opensearch.client.opensearch._types.RequestBase;
 import org.opensearch.client.opensearch._types.SearchType;
+import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch.core.msearch.RequestItem;
 import org.opensearch.client.transport.Endpoint;
 import org.opensearch.client.transport.endpoints.SimpleEndpoint;
@@ -65,6 +66,9 @@ import org.opensearch.client.util.ObjectBuilderBase;
 public class MsearchRequest extends RequestBase implements NdJsonpSerializable, JsonpSerializable {
     @Nullable
     private final Boolean allowNoIndices;
+
+    @Nullable
+    private final Time cancelAfterTimeInterval;
 
     @Nullable
     private final Boolean ccsMinimizeRoundtrips;
@@ -98,6 +102,7 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
     private MsearchRequest(Builder builder) {
 
         this.allowNoIndices = builder.allowNoIndices;
+        this.cancelAfterTimeInterval = builder.cancelAfterTimeInterval;
         this.ccsMinimizeRoundtrips = builder.ccsMinimizeRoundtrips;
         this.expandWildcards = ApiTypeHelper.unmodifiable(builder.expandWildcards);
         this.ignoreThrottled = builder.ignoreThrottled;
@@ -132,6 +137,17 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
     @Nullable
     public final Boolean allowNoIndices() {
         return this.allowNoIndices;
+    }
+
+    /**
+     * The time after which the search request will be canceled.
+     * Request-level parameter takes precedence over cancel_after_time_interval cluster setting.
+     * <p>
+     * API name: {@code cancel_after_time_interval}
+     */
+    @Nullable
+    public final Time cancelAfterTimeInterval() {
+        return this.cancelAfterTimeInterval;
     }
 
     /**
@@ -256,6 +272,7 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
 
     public Builder toBuilder() {
         return new Builder().allowNoIndices(allowNoIndices)
+            .cancelAfterTimeInterval(cancelAfterTimeInterval)
             .ccsMinimizeRoundtrips(ccsMinimizeRoundtrips)
             .expandWildcards(expandWildcards)
             .ignoreThrottled(ignoreThrottled)
@@ -277,6 +294,9 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<MsearchRequest> {
         @Nullable
         private Boolean allowNoIndices;
+
+        @Nullable
+        private Time cancelAfterTimeInterval;
 
         @Nullable
         private Boolean ccsMinimizeRoundtrips;
@@ -318,6 +338,17 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
          */
         public final Builder allowNoIndices(@Nullable Boolean value) {
             this.allowNoIndices = value;
+            return this;
+        }
+
+        /**
+         * The time after which the search request will be canceled.
+         * Request-level parameter takes precedence over cancel_after_time_interval cluster setting.
+         * <p>
+         * API name: {@code cancel_after_time_interval}
+         */
+        public final Builder cancelAfterTimeInterval(@Nullable Time value) {
+            this.cancelAfterTimeInterval = value;
             return this;
         }
 
@@ -540,6 +571,9 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
         request -> {
             Map<String, String> params = new HashMap<>();
             params.put("typed_keys", "true");
+            if (request.cancelAfterTimeInterval != null) {
+                params.put("cancel_after_time_interval", request.cancelAfterTimeInterval._toJsonString());
+            }
             if (request.preFilterShardSize != null) {
                 params.put("pre_filter_shard_size", String.valueOf(request.preFilterShardSize));
             }

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
@@ -2323,7 +2323,6 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
 
         op.add(Builder::source, SourceConfig._DESERIALIZER, "_source");
         op.add(Builder::aggregations, JsonpDeserializer.stringMapDeserializer(Aggregation._DESERIALIZER), "aggregations", "aggs");
-        op.add(Builder::cancelAfterTimeInterval, Time._DESERIALIZER, "cancel_after_time_interval");
         op.add(Builder::collapse, FieldCollapse._DESERIALIZER, "collapse");
         op.add(Builder::docvalueFields, JsonpDeserializer.arrayDeserializer(FieldAndFormat._DESERIALIZER), "docvalue_fields");
         op.add(Builder::explain, JsonpDeserializer.booleanDeserializer(), "explain");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
@@ -111,6 +111,9 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
     private final String pipeline;
 
     @Nullable
+    private final Time cancelAfterTimeInterval;
+
+    @Nullable
     private final FieldCollapse collapse;
 
     @Nullable
@@ -246,6 +249,7 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
         this.ccsMinimizeRoundtrips = builder.ccsMinimizeRoundtrips;
         this.phaseTook = builder.phaseTook;
         this.pipeline = builder.pipeline;
+        this.cancelAfterTimeInterval = builder.cancelAfterTimeInterval;
         this.collapse = builder.collapse;
         this.defaultOperator = builder.defaultOperator;
         this.df = builder.df;
@@ -403,6 +407,17 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
     @Nullable
     public final String pipeline() {
         return this.pipeline;
+    }
+
+    /**
+     * The time after which the search request will be canceled.
+     * Request-level parameter takes precedence over cancel_after_time_interval cluster setting.
+     * <p>
+     * API name: {@code cancel_after_time_interval}
+     */
+    @Nullable
+    public final Time cancelAfterTimeInterval() {
+        return this.cancelAfterTimeInterval;
     }
 
     /**
@@ -1114,6 +1129,7 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
             .ccsMinimizeRoundtrips(ccsMinimizeRoundtrips)
             .phaseTook(phaseTook)
             .pipeline(pipeline)
+            .cancelAfterTimeInterval(cancelAfterTimeInterval)
             .collapse(collapse)
             .defaultOperator(defaultOperator)
             .df(df)
@@ -1197,6 +1213,9 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
 
         @Nullable
         private String pipeline;
+
+        @Nullable
+        private Time cancelAfterTimeInterval;
 
         @Nullable
         private FieldCollapse collapse;
@@ -1470,6 +1489,27 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
         public final Builder pipeline(@Nullable String value) {
             this.pipeline = value;
             return this;
+        }
+
+        /**
+         * The time after which the search request will be canceled.
+         * Request-level parameter takes precedence over cancel_after_time_interval cluster setting.
+         * <p>
+         * API name: {@code cancel_after_time_interval}
+         */
+        public final Builder cancelAfterTimeInterval(@Nullable Time value) {
+            this.cancelAfterTimeInterval = value;
+            return this;
+        }
+
+        /**
+         * The time after which the search request will be canceled.
+         * Request-level parameter takes precedence over cancel_after_time_interval cluster setting.
+         * <p>
+         * API name: {@code cancel_after_time_interval}
+         */
+        public final Builder cancelAfterTimeInterval(Function<Time.Builder, ObjectBuilder<Time>> fn) {
+            return this.cancelAfterTimeInterval(fn.apply(new Time.Builder()).build());
         }
 
         /**
@@ -2283,6 +2323,7 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
 
         op.add(Builder::source, SourceConfig._DESERIALIZER, "_source");
         op.add(Builder::aggregations, JsonpDeserializer.stringMapDeserializer(Aggregation._DESERIALIZER), "aggregations", "aggs");
+        op.add(Builder::cancelAfterTimeInterval, Time._DESERIALIZER, "cancel_after_time_interval");
         op.add(Builder::collapse, FieldCollapse._DESERIALIZER, "collapse");
         op.add(Builder::docvalueFields, JsonpDeserializer.arrayDeserializer(FieldAndFormat._DESERIALIZER), "docvalue_fields");
         op.add(Builder::explain, JsonpDeserializer.booleanDeserializer(), "explain");
@@ -2404,6 +2445,9 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
             }
             if (request.scroll != null) {
                 params.put("scroll", request.scroll._toJsonString());
+            }
+            if (request.cancelAfterTimeInterval != null) {
+                params.put("cancel_after_time_interval", request.cancelAfterTimeInterval._toJsonString());
             }
             if (request.searchType != null) {
                 params.put("search_type", request.searchType.jsonValue());

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/MsearchRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/MsearchRequestTest.java
@@ -26,10 +26,10 @@ public class MsearchRequestTest extends ModelTestCase {
     @Test
     public void cancelAfterTimeInterval() {
         Time cancelAfterTimeInterval = Time.of(ti -> ti.time("1000ms"));
-        MsearchRequest request = new MsearchRequest.Builder()
-                                        .index("index")
-                                        .searches(Collections.emptyList())
-                                        .cancelAfterTimeInterval(cancelAfterTimeInterval).build();
+        MsearchRequest request = new MsearchRequest.Builder().index("index")
+            .searches(Collections.emptyList())
+            .cancelAfterTimeInterval(cancelAfterTimeInterval)
+            .build();
 
         assertEquals("[]", toJson(request));
         assertEquals(cancelAfterTimeInterval, request.cancelAfterTimeInterval());

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/MsearchRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/MsearchRequestTest.java
@@ -9,10 +9,11 @@
 package org.opensearch.client.opensearch.core;
 
 import java.util.Collections;
-import org.junit.Assert;
 import org.junit.Test;
+import org.opensearch.client.opensearch._types.Time;
+import org.opensearch.client.opensearch.model.ModelTestCase;
 
-public class MsearchRequestTest extends Assert {
+public class MsearchRequestTest extends ModelTestCase {
 
     @Test
     public void toBuilder() {
@@ -20,5 +21,18 @@ public class MsearchRequestTest extends Assert {
         MsearchRequest copied = origin.toBuilder().build();
 
         assertEquals(copied.index(), origin.index());
+    }
+
+    @Test
+    public void cancelAfterTimeInterval() {
+        Time cancelAfterTimeInterval = Time.of(ti -> ti.time("1000ms"));
+        MsearchRequest request = new MsearchRequest.Builder()
+                                        .index("index")
+                                        .searches(Collections.emptyList())
+                                        .cancelAfterTimeInterval(cancelAfterTimeInterval).build();
+
+        assertEquals("[]", toJson(request));
+        assertEquals(cancelAfterTimeInterval, request.cancelAfterTimeInterval());
+        assertEquals("1000ms", MsearchRequest._ENDPOINT.queryParameters(request).get("cancel_after_time_interval"));
     }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/SearchRequestTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.junit.Test;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch.core.search.SourceConfig;
 import org.opensearch.client.opensearch.core.search.SourceFilter;
 import org.opensearch.client.opensearch.model.ModelTestCase;
@@ -51,6 +52,16 @@ public class SearchRequestTest extends ModelTestCase {
         assertEquals("{}", toJson(request));
         assertEquals("my_pipeline", request.pipeline());
         assertEquals("my_pipeline", SearchRequest._ENDPOINT.queryParameters(request).get("search_pipeline"));
+    }
+
+    @Test
+    public void cancelAfterTimeInterval() {
+        Time cancelAfterTimeInterval = Time.of(ti -> ti.time("1000ms"));
+        SearchRequest request = new SearchRequest.Builder().cancelAfterTimeInterval(cancelAfterTimeInterval).build();
+
+        assertEquals("{}", toJson(request));
+        assertEquals(cancelAfterTimeInterval, request.cancelAfterTimeInterval());
+        assertEquals("1000ms", SearchRequest._ENDPOINT.queryParameters(request).get("cancel_after_time_interval"));
     }
 
     @Test


### PR DESCRIPTION
### Description
_Describe what this change achieves._
Add `cancel_after_time_interval` field to `SearchRequest` and `MsearchRequest` requests in the Java client.

### Issues Resolved
- Fixes #1116 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
