### PR TITLE
[Backport] [2.x] Bump commons-logging:commons-logging from 1.3.3 to 1.3.4 in /java-client (#1155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adds `cancelAfterTimeInterval` to `SearchRequest` and `MsearchRequest` ([#1147](https://github.com/opensearch-project/opensearch-java/pull/1147))
 
 ### Dependencies
+- Bumps `commons-logging:commons-logging` from 1.3.3 to 1.3.4
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -166,7 +166,7 @@ dependencies {
     val jacksonDatabindVersion = "2.17.0"
 
     // Apache 2.0
-    api("commons-logging:commons-logging:1.3.3")
+    api("commons-logging:commons-logging:1.3.4")
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)
     testImplementation("org.hamcrest:hamcrest:2.2")
     testImplementation("com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.8.1") {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1155 to `2.x`