### PR TITLE
[Backport] [2.x] Bump io.github.classgraph:classgraph from 4.8.174 to 4.8.175 (#1154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `commons-logging:commons-logging` from 1.3.3 to 1.3.4
+- Bumps `io.github.classgraph:classgraph` from 4.8.174 to 4.8.175
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -215,7 +215,7 @@ dependencies {
     implementation("org.eclipse", "yasson", "2.0.2")
 
     // https://github.com/classgraph/classgraph
-    testImplementation("io.github.classgraph:classgraph:4.8.174")
+    testImplementation("io.github.classgraph:classgraph:4.8.175")
 
     // Eclipse 1.0
     testImplementation("junit", "junit" , "4.13.2") {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1154 to `2.x`