### PR TITLE
Invert abstractness of generated vs "handwritten" client classes

### DIFF
--- a/java-client/src/generated/java/org/opensearch/client/opensearch/OpenSearchAsyncClientBase.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/OpenSearchAsyncClientBase.java
@@ -37,13 +37,15 @@
 package org.opensearch.client.opensearch;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Generated;
 import javax.annotation.Nullable;
+import org.opensearch.client.ApiClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch.core.InfoRequest;
 import org.opensearch.client.opensearch.core.InfoResponse;
-import org.opensearch.client.opensearch.dangling_indices.OpenSearchDanglingIndicesClient;
-import org.opensearch.client.opensearch.ml.OpenSearchMlClient;
+import org.opensearch.client.opensearch.dangling_indices.OpenSearchDanglingIndicesAsyncClient;
+import org.opensearch.client.opensearch.ml.OpenSearchMlAsyncClient;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.TransportOptions;
 
@@ -51,28 +53,19 @@ import org.opensearch.client.transport.TransportOptions;
  * Client for the namespace.
  */
 @Generated("org.opensearch.client.codegen.CodeGenerator")
-public class OpenSearchClient extends OpenSearchClientBase<OpenSearchClient> {
-    public OpenSearchClient(OpenSearchTransport transport) {
-        super(transport, null);
-    }
-
-    public OpenSearchClient(OpenSearchTransport transport, @Nullable TransportOptions transportOptions) {
+public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClientBase<Self>> extends ApiClient<OpenSearchTransport, Self> {
+    public OpenSearchAsyncClientBase(OpenSearchTransport transport, @Nullable TransportOptions transportOptions) {
         super(transport, transportOptions);
-    }
-
-    @Override
-    public OpenSearchClient withTransportOptions(@Nullable TransportOptions transportOptions) {
-        return new OpenSearchClient(this.transport, transportOptions);
     }
 
     // ----- Child clients
 
-    public OpenSearchDanglingIndicesClient danglingIndices() {
-        return new OpenSearchDanglingIndicesClient(this.transport, this.transportOptions);
+    public OpenSearchDanglingIndicesAsyncClient danglingIndices() {
+        return new OpenSearchDanglingIndicesAsyncClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchMlClient ml() {
-        return new OpenSearchMlClient(this.transport, this.transportOptions);
+    public OpenSearchMlAsyncClient ml() {
+        return new OpenSearchMlAsyncClient(this.transport, this.transportOptions);
     }
 
     // ----- Endpoint: info
@@ -80,7 +73,7 @@ public class OpenSearchClient extends OpenSearchClientBase<OpenSearchClient> {
     /**
      * Returns basic information about the cluster.
      */
-    public InfoResponse info() throws IOException, OpenSearchException {
-        return this.transport.performRequest(InfoRequest._INSTANCE, InfoRequest._ENDPOINT, this.transportOptions);
+    public CompletableFuture<InfoResponse> info() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(InfoRequest._INSTANCE, InfoRequest._ENDPOINT, this.transportOptions);
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/OpenSearchClientBase.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/OpenSearchClientBase.java
@@ -37,14 +37,14 @@
 package org.opensearch.client.opensearch;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 import javax.annotation.Generated;
 import javax.annotation.Nullable;
+import org.opensearch.client.ApiClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch.core.InfoRequest;
 import org.opensearch.client.opensearch.core.InfoResponse;
-import org.opensearch.client.opensearch.dangling_indices.OpenSearchDanglingIndicesAsyncClient;
-import org.opensearch.client.opensearch.ml.OpenSearchMlAsyncClient;
+import org.opensearch.client.opensearch.dangling_indices.OpenSearchDanglingIndicesClient;
+import org.opensearch.client.opensearch.ml.OpenSearchMlClient;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.TransportOptions;
 
@@ -52,28 +52,19 @@ import org.opensearch.client.transport.TransportOptions;
  * Client for the namespace.
  */
 @Generated("org.opensearch.client.codegen.CodeGenerator")
-public class OpenSearchAsyncClient extends OpenSearchAsyncClientBase<OpenSearchAsyncClient> {
-    public OpenSearchAsyncClient(OpenSearchTransport transport) {
-        super(transport, null);
-    }
-
-    public OpenSearchAsyncClient(OpenSearchTransport transport, @Nullable TransportOptions transportOptions) {
+public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Self>> extends ApiClient<OpenSearchTransport, Self> {
+    public OpenSearchClientBase(OpenSearchTransport transport, @Nullable TransportOptions transportOptions) {
         super(transport, transportOptions);
-    }
-
-    @Override
-    public OpenSearchAsyncClient withTransportOptions(@Nullable TransportOptions transportOptions) {
-        return new OpenSearchAsyncClient(this.transport, transportOptions);
     }
 
     // ----- Child clients
 
-    public OpenSearchDanglingIndicesAsyncClient danglingIndices() {
-        return new OpenSearchDanglingIndicesAsyncClient(this.transport, this.transportOptions);
+    public OpenSearchDanglingIndicesClient danglingIndices() {
+        return new OpenSearchDanglingIndicesClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchMlAsyncClient ml() {
-        return new OpenSearchMlAsyncClient(this.transport, this.transportOptions);
+    public OpenSearchMlClient ml() {
+        return new OpenSearchMlClient(this.transport, this.transportOptions);
     }
 
     // ----- Endpoint: info
@@ -81,7 +72,7 @@ public class OpenSearchAsyncClient extends OpenSearchAsyncClientBase<OpenSearchA
     /**
      * Returns basic information about the cluster.
      */
-    public CompletableFuture<InfoResponse> info() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(InfoRequest._INSTANCE, InfoRequest._ENDPOINT, this.transportOptions);
+    public InfoResponse info() throws IOException, OpenSearchException {
+        return this.transport.performRequest(InfoRequest._INSTANCE, InfoRequest._ENDPOINT, this.transportOptions);
     }
 }

--- a/java-client/src/main/java/org/opensearch/client/opensearch/OpenSearchAsyncClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/OpenSearchAsyncClient.java
@@ -33,13 +33,13 @@
 package org.opensearch.client.opensearch;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import javax.annotation.Nullable;
-import org.opensearch.client.ApiClient;
 import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch._types.OpenSearchException;
-import org.opensearch.client.opensearch.cat.OpenSearchCatClient;
-import org.opensearch.client.opensearch.cluster.OpenSearchClusterClient;
+import org.opensearch.client.opensearch.cat.OpenSearchCatAsyncClient;
+import org.opensearch.client.opensearch.cluster.OpenSearchClusterAsyncClient;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.ClearScrollRequest;
@@ -119,14 +119,13 @@ import org.opensearch.client.opensearch.core.pit.DeletePitRequest;
 import org.opensearch.client.opensearch.core.pit.DeletePitResponse;
 import org.opensearch.client.opensearch.core.pit.ListAllPitRequest;
 import org.opensearch.client.opensearch.core.pit.ListAllPitResponse;
-import org.opensearch.client.opensearch.features.OpenSearchFeaturesClient;
-import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
-import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
-import org.opensearch.client.opensearch.ingest.OpenSearchIngestClient;
-import org.opensearch.client.opensearch.nodes.OpenSearchNodesClient;
-import org.opensearch.client.opensearch.shutdown.OpenSearchShutdownClient;
-import org.opensearch.client.opensearch.snapshot.OpenSearchSnapshotClient;
-import org.opensearch.client.opensearch.tasks.OpenSearchTasksClient;
+import org.opensearch.client.opensearch.features.OpenSearchFeaturesAsyncClient;
+import org.opensearch.client.opensearch.indices.OpenSearchIndicesAsyncClient;
+import org.opensearch.client.opensearch.ingest.OpenSearchIngestAsyncClient;
+import org.opensearch.client.opensearch.nodes.OpenSearchNodesAsyncClient;
+import org.opensearch.client.opensearch.shutdown.OpenSearchShutdownAsyncClient;
+import org.opensearch.client.opensearch.snapshot.OpenSearchSnapshotAsyncClient;
+import org.opensearch.client.opensearch.tasks.OpenSearchTasksAsyncClient;
 import org.opensearch.client.transport.JsonEndpoint;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.TransportOptions;
@@ -137,51 +136,56 @@ import org.opensearch.client.util.ObjectBuilder;
 /**
  * Client for the namespace.
  */
-public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Self>> extends ApiClient<OpenSearchTransport, Self> {
+public class OpenSearchAsyncClient extends OpenSearchAsyncClientBase<OpenSearchAsyncClient> {
+    public OpenSearchAsyncClient(OpenSearchTransport transport) {
+        super(transport, null);
+    }
 
-    public OpenSearchClientBase(OpenSearchTransport transport, @Nullable TransportOptions transportOptions) {
+    public OpenSearchAsyncClient(OpenSearchTransport transport, @Nullable TransportOptions transportOptions) {
         super(transport, transportOptions);
     }
 
+    @Override
+    public OpenSearchAsyncClient withTransportOptions(@Nullable TransportOptions transportOptions) {
+        return new OpenSearchAsyncClient(this.transport, transportOptions);
+    }
+
     // ----- Child clients
-    public OpenSearchGenericClient generic() {
-        return new OpenSearchGenericClient(this.transport, this.transportOptions);
+
+    public OpenSearchCatAsyncClient cat() {
+        return new OpenSearchCatAsyncClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchCatClient cat() {
-        return new OpenSearchCatClient(this.transport, this.transportOptions);
+    public OpenSearchClusterAsyncClient cluster() {
+        return new OpenSearchClusterAsyncClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchClusterClient cluster() {
-        return new OpenSearchClusterClient(this.transport, this.transportOptions);
+    public OpenSearchFeaturesAsyncClient features() {
+        return new OpenSearchFeaturesAsyncClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchFeaturesClient features() {
-        return new OpenSearchFeaturesClient(this.transport, this.transportOptions);
+    public OpenSearchIndicesAsyncClient indices() {
+        return new OpenSearchIndicesAsyncClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchIndicesClient indices() {
-        return new OpenSearchIndicesClient(this.transport, this.transportOptions);
+    public OpenSearchIngestAsyncClient ingest() {
+        return new OpenSearchIngestAsyncClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchIngestClient ingest() {
-        return new OpenSearchIngestClient(this.transport, this.transportOptions);
+    public OpenSearchNodesAsyncClient nodes() {
+        return new OpenSearchNodesAsyncClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchNodesClient nodes() {
-        return new OpenSearchNodesClient(this.transport, this.transportOptions);
+    public OpenSearchShutdownAsyncClient shutdown() {
+        return new OpenSearchShutdownAsyncClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchShutdownClient shutdown() {
-        return new OpenSearchShutdownClient(this.transport, this.transportOptions);
+    public OpenSearchSnapshotAsyncClient snapshot() {
+        return new OpenSearchSnapshotAsyncClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchSnapshotClient snapshot() {
-        return new OpenSearchSnapshotClient(this.transport, this.transportOptions);
-    }
-
-    public OpenSearchTasksClient tasks() {
-        return new OpenSearchTasksClient(this.transport, this.transportOptions);
+    public OpenSearchTasksAsyncClient tasks() {
+        return new OpenSearchTasksAsyncClient(this.transport, this.transportOptions);
     }
 
     // ----- Endpoint: bulk
@@ -193,14 +197,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public BulkResponse bulk(BulkRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<BulkResponse> bulk(BulkRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<BulkRequest, BulkResponse, ErrorResponse> endpoint = (JsonEndpoint<
             BulkRequest,
             BulkResponse,
             ErrorResponse>) BulkRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -213,7 +217,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final BulkResponse bulk(Function<BulkRequest.Builder, ObjectBuilder<BulkRequest>> fn) throws IOException, OpenSearchException {
+    public final CompletableFuture<BulkResponse> bulk(Function<BulkRequest.Builder, ObjectBuilder<BulkRequest>> fn) throws IOException,
+        OpenSearchException {
         return bulk(fn.apply(new BulkRequest.Builder()).build());
     }
 
@@ -224,8 +229,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public BulkResponse bulk() throws IOException, OpenSearchException {
-        return this.transport.performRequest(new BulkRequest.Builder().build(), BulkRequest._ENDPOINT, this.transportOptions);
+    public CompletableFuture<BulkResponse> bulk() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(new BulkRequest.Builder().build(), BulkRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: clear_scroll
@@ -236,14 +241,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public ClearScrollResponse clearScroll(ClearScrollRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<ClearScrollResponse> clearScroll(ClearScrollRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ClearScrollRequest, ClearScrollResponse, ErrorResponse> endpoint = (JsonEndpoint<
             ClearScrollRequest,
             ClearScrollResponse,
             ErrorResponse>) ClearScrollRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -255,8 +260,9 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final ClearScrollResponse clearScroll(Function<ClearScrollRequest.Builder, ObjectBuilder<ClearScrollRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final CompletableFuture<ClearScrollResponse> clearScroll(
+        Function<ClearScrollRequest.Builder, ObjectBuilder<ClearScrollRequest>> fn
+    ) throws IOException, OpenSearchException {
         return clearScroll(fn.apply(new ClearScrollRequest.Builder()).build());
     }
 
@@ -266,8 +272,12 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public ClearScrollResponse clearScroll() throws IOException, OpenSearchException {
-        return this.transport.performRequest(new ClearScrollRequest.Builder().build(), ClearScrollRequest._ENDPOINT, this.transportOptions);
+    public CompletableFuture<ClearScrollResponse> clearScroll() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(
+            new ClearScrollRequest.Builder().build(),
+            ClearScrollRequest._ENDPOINT,
+            this.transportOptions
+        );
     }
 
     // ----- Endpoint: count
@@ -278,14 +288,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public CountResponse count(CountRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<CountResponse> count(CountRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<CountRequest, CountResponse, ErrorResponse> endpoint = (JsonEndpoint<
             CountRequest,
             CountResponse,
             ErrorResponse>) CountRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -297,7 +307,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final CountResponse count(Function<CountRequest.Builder, ObjectBuilder<CountRequest>> fn) throws IOException,
+    public final CompletableFuture<CountResponse> count(Function<CountRequest.Builder, ObjectBuilder<CountRequest>> fn) throws IOException,
         OpenSearchException {
         return count(fn.apply(new CountRequest.Builder()).build());
     }
@@ -308,8 +318,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public CountResponse count() throws IOException, OpenSearchException {
-        return this.transport.performRequest(new CountRequest.Builder().build(), CountRequest._ENDPOINT, this.transportOptions);
+    public CompletableFuture<CountResponse> count() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(new CountRequest.Builder().build(), CountRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: create
@@ -323,14 +333,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument> CreateResponse create(CreateRequest<TDocument> request) throws IOException, OpenSearchException {
+    public <TDocument> CompletableFuture<CreateResponse> create(CreateRequest<TDocument> request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<CreateRequest<?>, CreateResponse, ErrorResponse> endpoint = (JsonEndpoint<
             CreateRequest<?>,
             CreateResponse,
             ErrorResponse>) CreateRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -345,8 +355,9 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TDocument> CreateResponse create(Function<CreateRequest.Builder<TDocument>, ObjectBuilder<CreateRequest<TDocument>>> fn)
-        throws IOException, OpenSearchException {
+    public final <TDocument> CompletableFuture<CreateResponse> create(
+        Function<CreateRequest.Builder<TDocument>, ObjectBuilder<CreateRequest<TDocument>>> fn
+    ) throws IOException, OpenSearchException {
         return create(fn.apply(new CreateRequest.Builder<TDocument>()).build());
     }
 
@@ -359,14 +370,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public CreatePitResponse createPit(CreatePitRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<CreatePitResponse> createPit(CreatePitRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<CreatePitRequest, CreatePitResponse, ErrorResponse> endpoint = (JsonEndpoint<
             CreatePitRequest,
             CreatePitResponse,
             ErrorResponse>) CreatePitRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -379,8 +390,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final CreatePitResponse createPit(Function<CreatePitRequest.Builder, ObjectBuilder<CreatePitRequest>> fn) throws IOException,
-        OpenSearchException {
+    public final CompletableFuture<CreatePitResponse> createPit(Function<CreatePitRequest.Builder, ObjectBuilder<CreatePitRequest>> fn)
+        throws IOException, OpenSearchException {
         return createPit(fn.apply(new CreatePitRequest.Builder()).build());
     }
 
@@ -392,14 +403,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public DeleteResponse delete(DeleteRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<DeleteResponse> delete(DeleteRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<DeleteRequest, DeleteResponse, ErrorResponse> endpoint = (JsonEndpoint<
             DeleteRequest,
             DeleteResponse,
             ErrorResponse>) DeleteRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -411,8 +422,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final DeleteResponse delete(Function<DeleteRequest.Builder, ObjectBuilder<DeleteRequest>> fn) throws IOException,
-        OpenSearchException {
+    public final CompletableFuture<DeleteResponse> delete(Function<DeleteRequest.Builder, ObjectBuilder<DeleteRequest>> fn)
+        throws IOException, OpenSearchException {
         return delete(fn.apply(new DeleteRequest.Builder()).build());
     }
 
@@ -424,14 +435,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public DeletePitResponse deletePit(DeletePitRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<DeletePitResponse> deletePit(DeletePitRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<DeletePitRequest, DeletePitResponse, ErrorResponse> endpoint = (JsonEndpoint<
             DeletePitRequest,
             DeletePitResponse,
             ErrorResponse>) DeletePitRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -443,8 +454,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final DeletePitResponse deletePit(Function<DeletePitRequest.Builder, ObjectBuilder<DeletePitRequest>> fn) throws IOException,
-        OpenSearchException {
+    public final CompletableFuture<DeletePitResponse> deletePit(Function<DeletePitRequest.Builder, ObjectBuilder<DeletePitRequest>> fn)
+        throws IOException, OpenSearchException {
         return deletePit(fn.apply(new DeletePitRequest.Builder()).build());
     }
 
@@ -456,14 +467,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public DeleteByQueryResponse deleteByQuery(DeleteByQueryRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<DeleteByQueryResponse> deleteByQuery(DeleteByQueryRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<DeleteByQueryRequest, DeleteByQueryResponse, ErrorResponse> endpoint = (JsonEndpoint<
             DeleteByQueryRequest,
             DeleteByQueryResponse,
             ErrorResponse>) DeleteByQueryRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -475,8 +486,9 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final DeleteByQueryResponse deleteByQuery(Function<DeleteByQueryRequest.Builder, ObjectBuilder<DeleteByQueryRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final CompletableFuture<DeleteByQueryResponse> deleteByQuery(
+        Function<DeleteByQueryRequest.Builder, ObjectBuilder<DeleteByQueryRequest>> fn
+    ) throws IOException, OpenSearchException {
         return deleteByQuery(fn.apply(new DeleteByQueryRequest.Builder()).build());
     }
 
@@ -489,15 +501,15 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public DeleteByQueryRethrottleResponse deleteByQueryRethrottle(DeleteByQueryRethrottleRequest request) throws IOException,
-        OpenSearchException {
+    public CompletableFuture<DeleteByQueryRethrottleResponse> deleteByQueryRethrottle(DeleteByQueryRethrottleRequest request)
+        throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<DeleteByQueryRethrottleRequest, DeleteByQueryRethrottleResponse, ErrorResponse> endpoint = (JsonEndpoint<
             DeleteByQueryRethrottleRequest,
             DeleteByQueryRethrottleResponse,
             ErrorResponse>) DeleteByQueryRethrottleRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -510,7 +522,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final DeleteByQueryRethrottleResponse deleteByQueryRethrottle(
+    public final CompletableFuture<DeleteByQueryRethrottleResponse> deleteByQueryRethrottle(
         Function<DeleteByQueryRethrottleRequest.Builder, ObjectBuilder<DeleteByQueryRethrottleRequest>> fn
     ) throws IOException, OpenSearchException {
         return deleteByQueryRethrottle(fn.apply(new DeleteByQueryRethrottleRequest.Builder()).build());
@@ -524,14 +536,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public DeleteScriptResponse deleteScript(DeleteScriptRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<DeleteScriptResponse> deleteScript(DeleteScriptRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<DeleteScriptRequest, DeleteScriptResponse, ErrorResponse> endpoint = (JsonEndpoint<
             DeleteScriptRequest,
             DeleteScriptResponse,
             ErrorResponse>) DeleteScriptRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -543,8 +555,9 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final DeleteScriptResponse deleteScript(Function<DeleteScriptRequest.Builder, ObjectBuilder<DeleteScriptRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final CompletableFuture<DeleteScriptResponse> deleteScript(
+        Function<DeleteScriptRequest.Builder, ObjectBuilder<DeleteScriptRequest>> fn
+    ) throws IOException, OpenSearchException {
         return deleteScript(fn.apply(new DeleteScriptRequest.Builder()).build());
     }
 
@@ -556,14 +569,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public BooleanResponse exists(ExistsRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<BooleanResponse> exists(ExistsRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ExistsRequest, BooleanResponse, ErrorResponse> endpoint = (JsonEndpoint<
             ExistsRequest,
             BooleanResponse,
             ErrorResponse>) ExistsRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -575,8 +588,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final BooleanResponse exists(Function<ExistsRequest.Builder, ObjectBuilder<ExistsRequest>> fn) throws IOException,
-        OpenSearchException {
+    public final CompletableFuture<BooleanResponse> exists(Function<ExistsRequest.Builder, ObjectBuilder<ExistsRequest>> fn)
+        throws IOException, OpenSearchException {
         return exists(fn.apply(new ExistsRequest.Builder()).build());
     }
 
@@ -588,14 +601,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public BooleanResponse existsSource(ExistsSourceRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<BooleanResponse> existsSource(ExistsSourceRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ExistsSourceRequest, BooleanResponse, ErrorResponse> endpoint = (JsonEndpoint<
             ExistsSourceRequest,
             BooleanResponse,
             ErrorResponse>) ExistsSourceRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -607,8 +620,9 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final BooleanResponse existsSource(Function<ExistsSourceRequest.Builder, ObjectBuilder<ExistsSourceRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final CompletableFuture<BooleanResponse> existsSource(
+        Function<ExistsSourceRequest.Builder, ObjectBuilder<ExistsSourceRequest>> fn
+    ) throws IOException, OpenSearchException {
         return existsSource(fn.apply(new ExistsSourceRequest.Builder()).build());
     }
 
@@ -620,8 +634,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument> ExplainResponse<TDocument> explain(ExplainRequest request, Class<TDocument> tDocumentClass) throws IOException,
-        OpenSearchException {
+    public <TDocument> CompletableFuture<ExplainResponse<TDocument>> explain(ExplainRequest request, Class<TDocument> tDocumentClass)
+        throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ExplainRequest, ExplainResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             ExplainRequest,
@@ -633,7 +647,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -645,7 +659,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TDocument> ExplainResponse<TDocument> explain(
+    public final <TDocument> CompletableFuture<ExplainResponse<TDocument>> explain(
         Function<ExplainRequest.Builder, ObjectBuilder<ExplainRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -657,18 +671,16 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
     /**
      * Returns the information about the capabilities of fields among multiple
      * indices.
-     *
-     *
      */
 
-    public FieldCapsResponse fieldCaps(FieldCapsRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<FieldCapsResponse> fieldCaps(FieldCapsRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<FieldCapsRequest, FieldCapsResponse, ErrorResponse> endpoint = (JsonEndpoint<
             FieldCapsRequest,
             FieldCapsResponse,
             ErrorResponse>) FieldCapsRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -681,8 +693,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final FieldCapsResponse fieldCaps(Function<FieldCapsRequest.Builder, ObjectBuilder<FieldCapsRequest>> fn) throws IOException,
-        OpenSearchException {
+    public final CompletableFuture<FieldCapsResponse> fieldCaps(Function<FieldCapsRequest.Builder, ObjectBuilder<FieldCapsRequest>> fn)
+        throws IOException, OpenSearchException {
         return fieldCaps(fn.apply(new FieldCapsRequest.Builder()).build());
     }
 
@@ -693,8 +705,12 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public FieldCapsResponse fieldCaps() throws IOException, OpenSearchException {
-        return this.transport.performRequest(new FieldCapsRequest.Builder().build(), FieldCapsRequest._ENDPOINT, this.transportOptions);
+    public CompletableFuture<FieldCapsResponse> fieldCaps() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(
+            new FieldCapsRequest.Builder().build(),
+            FieldCapsRequest._ENDPOINT,
+            this.transportOptions
+        );
     }
 
     // ----- Endpoint: get
@@ -705,8 +721,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument> GetResponse<TDocument> get(GetRequest request, Class<TDocument> tDocumentClass) throws IOException,
-        OpenSearchException {
+    public <TDocument> CompletableFuture<GetResponse<TDocument>> get(GetRequest request, Class<TDocument> tDocumentClass)
+        throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<GetRequest, GetResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             GetRequest,
@@ -718,7 +734,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -730,7 +746,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TDocument> GetResponse<TDocument> get(
+    public final <TDocument> CompletableFuture<GetResponse<TDocument>> get(
         Function<GetRequest.Builder, ObjectBuilder<GetRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -745,14 +761,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public GetScriptResponse getScript(GetScriptRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<GetScriptResponse> getScript(GetScriptRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<GetScriptRequest, GetScriptResponse, ErrorResponse> endpoint = (JsonEndpoint<
             GetScriptRequest,
             GetScriptResponse,
             ErrorResponse>) GetScriptRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -764,8 +780,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final GetScriptResponse getScript(Function<GetScriptRequest.Builder, ObjectBuilder<GetScriptRequest>> fn) throws IOException,
-        OpenSearchException {
+    public final CompletableFuture<GetScriptResponse> getScript(Function<GetScriptRequest.Builder, ObjectBuilder<GetScriptRequest>> fn)
+        throws IOException, OpenSearchException {
         return getScript(fn.apply(new GetScriptRequest.Builder()).build());
     }
 
@@ -776,8 +792,12 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      *
      */
-    public GetScriptContextResponse getScriptContext() throws IOException, OpenSearchException {
-        return this.transport.performRequest(GetScriptContextRequest._INSTANCE, GetScriptContextRequest._ENDPOINT, this.transportOptions);
+    public CompletableFuture<GetScriptContextResponse> getScriptContext() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(
+            GetScriptContextRequest._INSTANCE,
+            GetScriptContextRequest._ENDPOINT,
+            this.transportOptions
+        );
     }
 
     // ----- Endpoint: get_script_languages
@@ -787,8 +807,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      *
      */
-    public GetScriptLanguagesResponse getScriptLanguages() throws IOException, OpenSearchException {
-        return this.transport.performRequest(
+    public CompletableFuture<GetScriptLanguagesResponse> getScriptLanguages() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(
             GetScriptLanguagesRequest._INSTANCE,
             GetScriptLanguagesRequest._ENDPOINT,
             this.transportOptions
@@ -803,8 +823,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument> GetSourceResponse<TDocument> getSource(GetSourceRequest request, Class<TDocument> tDocumentClass) throws IOException,
-        OpenSearchException {
+    public <TDocument> CompletableFuture<GetSourceResponse<TDocument>> getSource(GetSourceRequest request, Class<TDocument> tDocumentClass)
+        throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<GetSourceRequest, GetSourceResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             GetSourceRequest,
@@ -816,7 +836,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -828,7 +848,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TDocument> GetSourceResponse<TDocument> getSource(
+    public final <TDocument> CompletableFuture<GetSourceResponse<TDocument>> getSource(
         Function<GetSourceRequest.Builder, ObjectBuilder<GetSourceRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -843,14 +863,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument> IndexResponse index(IndexRequest<TDocument> request) throws IOException, OpenSearchException {
+    public <TDocument> CompletableFuture<IndexResponse> index(IndexRequest<TDocument> request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<IndexRequest<?>, IndexResponse, ErrorResponse> endpoint = (JsonEndpoint<
             IndexRequest<?>,
             IndexResponse,
             ErrorResponse>) IndexRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -862,8 +882,9 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TDocument> IndexResponse index(Function<IndexRequest.Builder<TDocument>, ObjectBuilder<IndexRequest<TDocument>>> fn)
-        throws IOException, OpenSearchException {
+    public final <TDocument> CompletableFuture<IndexResponse> index(
+        Function<IndexRequest.Builder<TDocument>, ObjectBuilder<IndexRequest<TDocument>>> fn
+    ) throws IOException, OpenSearchException {
         return index(fn.apply(new IndexRequest.Builder<TDocument>()).build());
     }
 
@@ -875,8 +896,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public ListAllPitResponse listAllPit() throws IOException, OpenSearchException {
-        return this.transport.performRequest(ListAllPitRequest._INSTANCE, ListAllPitRequest._ENDPOINT, this.transportOptions);
+    public CompletableFuture<ListAllPitResponse> listAllPit() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(ListAllPitRequest._INSTANCE, ListAllPitRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: mget
@@ -887,8 +908,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument> MgetResponse<TDocument> mget(MgetRequest request, Class<TDocument> tDocumentClass) throws IOException,
-        OpenSearchException {
+    public <TDocument> CompletableFuture<MgetResponse<TDocument>> mget(MgetRequest request, Class<TDocument> tDocumentClass)
+        throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<MgetRequest, MgetResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             MgetRequest,
@@ -900,7 +921,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -912,7 +933,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TDocument> MgetResponse<TDocument> mget(
+    public final <TDocument> CompletableFuture<MgetResponse<TDocument>> mget(
         Function<MgetRequest.Builder, ObjectBuilder<MgetRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -927,8 +948,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument> MsearchResponse<TDocument> msearch(MsearchRequest request, Class<TDocument> tDocumentClass) throws IOException,
-        OpenSearchException {
+    public <TDocument> CompletableFuture<MsearchResponse<TDocument>> msearch(MsearchRequest request, Class<TDocument> tDocumentClass)
+        throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<MsearchRequest, MsearchResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             MsearchRequest,
@@ -940,7 +961,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -952,7 +973,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TDocument> MsearchResponse<TDocument> msearch(
+    public final <TDocument> CompletableFuture<MsearchResponse<TDocument>> msearch(
         Function<MsearchRequest.Builder, ObjectBuilder<MsearchRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -967,8 +988,10 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument> MsearchTemplateResponse<TDocument> msearchTemplate(MsearchTemplateRequest request, Class<TDocument> tDocumentClass)
-        throws IOException, OpenSearchException {
+    public <TDocument> CompletableFuture<MsearchTemplateResponse<TDocument>> msearchTemplate(
+        MsearchTemplateRequest request,
+        Class<TDocument> tDocumentClass
+    ) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<MsearchTemplateRequest, MsearchTemplateResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             MsearchTemplateRequest,
@@ -980,7 +1003,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -992,7 +1015,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TDocument> MsearchTemplateResponse<TDocument> msearchTemplate(
+    public final <TDocument> CompletableFuture<MsearchTemplateResponse<TDocument>> msearchTemplate(
         Function<MsearchTemplateRequest.Builder, ObjectBuilder<MsearchTemplateRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -1007,14 +1030,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public MtermvectorsResponse mtermvectors(MtermvectorsRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<MtermvectorsResponse> mtermvectors(MtermvectorsRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<MtermvectorsRequest, MtermvectorsResponse, ErrorResponse> endpoint = (JsonEndpoint<
             MtermvectorsRequest,
             MtermvectorsResponse,
             ErrorResponse>) MtermvectorsRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1026,8 +1049,9 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final MtermvectorsResponse mtermvectors(Function<MtermvectorsRequest.Builder, ObjectBuilder<MtermvectorsRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final CompletableFuture<MtermvectorsResponse> mtermvectors(
+        Function<MtermvectorsRequest.Builder, ObjectBuilder<MtermvectorsRequest>> fn
+    ) throws IOException, OpenSearchException {
         return mtermvectors(fn.apply(new MtermvectorsRequest.Builder()).build());
     }
 
@@ -1037,8 +1061,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public MtermvectorsResponse mtermvectors() throws IOException, OpenSearchException {
-        return this.transport.performRequest(
+    public CompletableFuture<MtermvectorsResponse> mtermvectors() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(
             new MtermvectorsRequest.Builder().build(),
             MtermvectorsRequest._ENDPOINT,
             this.transportOptions
@@ -1052,8 +1076,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      *
      */
-    public BooleanResponse ping() throws IOException, OpenSearchException {
-        return this.transport.performRequest(PingRequest._INSTANCE, PingRequest._ENDPOINT, this.transportOptions);
+    public CompletableFuture<BooleanResponse> ping() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(PingRequest._INSTANCE, PingRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: put_script
@@ -1064,14 +1088,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public PutScriptResponse putScript(PutScriptRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<PutScriptResponse> putScript(PutScriptRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<PutScriptRequest, PutScriptResponse, ErrorResponse> endpoint = (JsonEndpoint<
             PutScriptRequest,
             PutScriptResponse,
             ErrorResponse>) PutScriptRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1083,8 +1107,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final PutScriptResponse putScript(Function<PutScriptRequest.Builder, ObjectBuilder<PutScriptRequest>> fn) throws IOException,
-        OpenSearchException {
+    public final CompletableFuture<PutScriptResponse> putScript(Function<PutScriptRequest.Builder, ObjectBuilder<PutScriptRequest>> fn)
+        throws IOException, OpenSearchException {
         return putScript(fn.apply(new PutScriptRequest.Builder()).build());
     }
 
@@ -1097,14 +1121,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public RankEvalResponse rankEval(RankEvalRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<RankEvalResponse> rankEval(RankEvalRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<RankEvalRequest, RankEvalResponse, ErrorResponse> endpoint = (JsonEndpoint<
             RankEvalRequest,
             RankEvalResponse,
             ErrorResponse>) RankEvalRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1117,8 +1141,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final RankEvalResponse rankEval(Function<RankEvalRequest.Builder, ObjectBuilder<RankEvalRequest>> fn) throws IOException,
-        OpenSearchException {
+    public final CompletableFuture<RankEvalResponse> rankEval(Function<RankEvalRequest.Builder, ObjectBuilder<RankEvalRequest>> fn)
+        throws IOException, OpenSearchException {
         return rankEval(fn.apply(new RankEvalRequest.Builder()).build());
     }
 
@@ -1132,14 +1156,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public ReindexResponse reindex(ReindexRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<ReindexResponse> reindex(ReindexRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ReindexRequest, ReindexResponse, ErrorResponse> endpoint = (JsonEndpoint<
             ReindexRequest,
             ReindexResponse,
             ErrorResponse>) ReindexRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1153,8 +1177,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final ReindexResponse reindex(Function<ReindexRequest.Builder, ObjectBuilder<ReindexRequest>> fn) throws IOException,
-        OpenSearchException {
+    public final CompletableFuture<ReindexResponse> reindex(Function<ReindexRequest.Builder, ObjectBuilder<ReindexRequest>> fn)
+        throws IOException, OpenSearchException {
         return reindex(fn.apply(new ReindexRequest.Builder()).build());
     }
 
@@ -1166,8 +1190,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public ReindexResponse reindex() throws IOException, OpenSearchException {
-        return this.transport.performRequest(new ReindexRequest.Builder().build(), ReindexRequest._ENDPOINT, this.transportOptions);
+    public CompletableFuture<ReindexResponse> reindex() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(new ReindexRequest.Builder().build(), ReindexRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: reindex_rethrottle
@@ -1178,14 +1202,15 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public ReindexRethrottleResponse reindexRethrottle(ReindexRethrottleRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<ReindexRethrottleResponse> reindexRethrottle(ReindexRethrottleRequest request) throws IOException,
+        OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ReindexRethrottleRequest, ReindexRethrottleResponse, ErrorResponse> endpoint = (JsonEndpoint<
             ReindexRethrottleRequest,
             ReindexRethrottleResponse,
             ErrorResponse>) ReindexRethrottleRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1197,7 +1222,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final ReindexRethrottleResponse reindexRethrottle(
+    public final CompletableFuture<ReindexRethrottleResponse> reindexRethrottle(
         Function<ReindexRethrottleRequest.Builder, ObjectBuilder<ReindexRethrottleRequest>> fn
     ) throws IOException, OpenSearchException {
         return reindexRethrottle(fn.apply(new ReindexRethrottleRequest.Builder()).build());
@@ -1211,14 +1236,15 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public RenderSearchTemplateResponse renderSearchTemplate(RenderSearchTemplateRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<RenderSearchTemplateResponse> renderSearchTemplate(RenderSearchTemplateRequest request) throws IOException,
+        OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<RenderSearchTemplateRequest, RenderSearchTemplateResponse, ErrorResponse> endpoint = (JsonEndpoint<
             RenderSearchTemplateRequest,
             RenderSearchTemplateResponse,
             ErrorResponse>) RenderSearchTemplateRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1230,7 +1256,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final RenderSearchTemplateResponse renderSearchTemplate(
+    public final CompletableFuture<RenderSearchTemplateResponse> renderSearchTemplate(
         Function<RenderSearchTemplateRequest.Builder, ObjectBuilder<RenderSearchTemplateRequest>> fn
     ) throws IOException, OpenSearchException {
         return renderSearchTemplate(fn.apply(new RenderSearchTemplateRequest.Builder()).build());
@@ -1242,8 +1268,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public RenderSearchTemplateResponse renderSearchTemplate() throws IOException, OpenSearchException {
-        return this.transport.performRequest(
+    public CompletableFuture<RenderSearchTemplateResponse> renderSearchTemplate() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(
             new RenderSearchTemplateRequest.Builder().build(),
             RenderSearchTemplateRequest._ENDPOINT,
             this.transportOptions
@@ -1258,7 +1284,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TResult> ScriptsPainlessExecuteResponse<TResult> scriptsPainlessExecute(
+    public <TResult> CompletableFuture<ScriptsPainlessExecuteResponse<TResult>> scriptsPainlessExecute(
         ScriptsPainlessExecuteRequest request,
         Class<TResult> tResultClass
     ) throws IOException, OpenSearchException {
@@ -1273,7 +1299,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
             getDeserializer(tResultClass)
         );
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1285,7 +1311,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TResult> ScriptsPainlessExecuteResponse<TResult> scriptsPainlessExecute(
+    public final <TResult> CompletableFuture<ScriptsPainlessExecuteResponse<TResult>> scriptsPainlessExecute(
         Function<ScriptsPainlessExecuteRequest.Builder, ObjectBuilder<ScriptsPainlessExecuteRequest>> fn,
         Class<TResult> tResultClass
     ) throws IOException, OpenSearchException {
@@ -1299,8 +1325,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument> ScrollResponse<TDocument> scroll(ScrollRequest request, Class<TDocument> tDocumentClass) throws IOException,
-        OpenSearchException {
+    public <TDocument> CompletableFuture<ScrollResponse<TDocument>> scroll(ScrollRequest request, Class<TDocument> tDocumentClass)
+        throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ScrollRequest, ScrollResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             ScrollRequest,
@@ -1312,7 +1338,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1323,7 +1349,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *            {@link ScrollRequest}
      */
 
-    public final <TDocument> ScrollResponse<TDocument> scroll(
+    public final <TDocument> CompletableFuture<ScrollResponse<TDocument>> scroll(
         Function<ScrollRequest.Builder, ObjectBuilder<ScrollRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -1338,8 +1364,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument> SearchResponse<TDocument> search(SearchRequest request, Class<TDocument> tDocumentClass) throws IOException,
-        OpenSearchException {
+    public <TDocument> CompletableFuture<SearchResponse<TDocument>> search(SearchRequest request, Class<TDocument> tDocumentClass)
+        throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<SearchRequest, SearchResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             SearchRequest,
@@ -1351,7 +1377,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1363,7 +1389,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TDocument> SearchResponse<TDocument> search(
+    public final <TDocument> CompletableFuture<SearchResponse<TDocument>> search(
         Function<SearchRequest.Builder, ObjectBuilder<SearchRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -1379,14 +1405,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public SearchShardsResponse searchShards(SearchShardsRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<SearchShardsResponse> searchShards(SearchShardsRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<SearchShardsRequest, SearchShardsResponse, ErrorResponse> endpoint = (JsonEndpoint<
             SearchShardsRequest,
             SearchShardsResponse,
             ErrorResponse>) SearchShardsRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1399,8 +1425,9 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final SearchShardsResponse searchShards(Function<SearchShardsRequest.Builder, ObjectBuilder<SearchShardsRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final CompletableFuture<SearchShardsResponse> searchShards(
+        Function<SearchShardsRequest.Builder, ObjectBuilder<SearchShardsRequest>> fn
+    ) throws IOException, OpenSearchException {
         return searchShards(fn.apply(new SearchShardsRequest.Builder()).build());
     }
 
@@ -1411,8 +1438,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public SearchShardsResponse searchShards() throws IOException, OpenSearchException {
-        return this.transport.performRequest(
+    public CompletableFuture<SearchShardsResponse> searchShards() throws IOException, OpenSearchException {
+        return this.transport.performRequestAsync(
             new SearchShardsRequest.Builder().build(),
             SearchShardsRequest._ENDPOINT,
             this.transportOptions
@@ -1427,8 +1454,10 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument> SearchTemplateResponse<TDocument> searchTemplate(SearchTemplateRequest request, Class<TDocument> tDocumentClass)
-        throws IOException, OpenSearchException {
+    public <TDocument> CompletableFuture<SearchTemplateResponse<TDocument>> searchTemplate(
+        SearchTemplateRequest request,
+        Class<TDocument> tDocumentClass
+    ) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<SearchTemplateRequest, SearchTemplateResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             SearchTemplateRequest,
@@ -1439,7 +1468,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
             "org.opensearch.client:Deserializer:_global.search_template.TDocument",
             getDeserializer(tDocumentClass)
         );
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1451,7 +1481,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TDocument> SearchTemplateResponse<TDocument> searchTemplate(
+    public final <TDocument> CompletableFuture<SearchTemplateResponse<TDocument>> searchTemplate(
         Function<SearchTemplateRequest.Builder, ObjectBuilder<SearchTemplateRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -1468,14 +1498,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public TermsEnumResponse termsEnum(TermsEnumRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<TermsEnumResponse> termsEnum(TermsEnumRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<TermsEnumRequest, TermsEnumResponse, ErrorResponse> endpoint = (JsonEndpoint<
             TermsEnumRequest,
             TermsEnumResponse,
             ErrorResponse>) TermsEnumRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1489,8 +1519,8 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final TermsEnumResponse termsEnum(Function<TermsEnumRequest.Builder, ObjectBuilder<TermsEnumRequest>> fn) throws IOException,
-        OpenSearchException {
+    public final CompletableFuture<TermsEnumResponse> termsEnum(Function<TermsEnumRequest.Builder, ObjectBuilder<TermsEnumRequest>> fn)
+        throws IOException, OpenSearchException {
         return termsEnum(fn.apply(new TermsEnumRequest.Builder()).build());
     }
 
@@ -1503,14 +1533,15 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument> TermvectorsResponse termvectors(TermvectorsRequest<TDocument> request) throws IOException, OpenSearchException {
+    public <TDocument> CompletableFuture<TermvectorsResponse> termvectors(TermvectorsRequest<TDocument> request) throws IOException,
+        OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<TermvectorsRequest<?>, TermvectorsResponse, ErrorResponse> endpoint = (JsonEndpoint<
             TermvectorsRequest<?>,
             TermvectorsResponse,
             ErrorResponse>) TermvectorsRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1523,7 +1554,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TDocument> TermvectorsResponse termvectors(
+    public final <TDocument> CompletableFuture<TermvectorsResponse> termvectors(
         Function<TermvectorsRequest.Builder<TDocument>, ObjectBuilder<TermvectorsRequest<TDocument>>> fn
     ) throws IOException, OpenSearchException {
         return termvectors(fn.apply(new TermvectorsRequest.Builder<TDocument>()).build());
@@ -1537,7 +1568,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public <TDocument, TPartialDocument> UpdateResponse<TDocument> update(
+    public <TDocument, TPartialDocument> CompletableFuture<UpdateResponse<TDocument>> update(
         UpdateRequest<TDocument, TPartialDocument> request,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -1552,7 +1583,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1564,8 +1595,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final <TDocument, TPartialDocument> UpdateResponse<TDocument> update(
-
+    public final <TDocument, TPartialDocument> CompletableFuture<UpdateResponse<TDocument>> update(
         Function<UpdateRequest.Builder<TDocument, TPartialDocument>, ObjectBuilder<UpdateRequest<TDocument, TPartialDocument>>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -1581,14 +1611,14 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public UpdateByQueryResponse updateByQuery(UpdateByQueryRequest request) throws IOException, OpenSearchException {
+    public CompletableFuture<UpdateByQueryResponse> updateByQuery(UpdateByQueryRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<UpdateByQueryRequest, UpdateByQueryResponse, ErrorResponse> endpoint = (JsonEndpoint<
             UpdateByQueryRequest,
             UpdateByQueryResponse,
             ErrorResponse>) UpdateByQueryRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1601,8 +1631,9 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final UpdateByQueryResponse updateByQuery(Function<UpdateByQueryRequest.Builder, ObjectBuilder<UpdateByQueryRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final CompletableFuture<UpdateByQueryResponse> updateByQuery(
+        Function<UpdateByQueryRequest.Builder, ObjectBuilder<UpdateByQueryRequest>> fn
+    ) throws IOException, OpenSearchException {
         return updateByQuery(fn.apply(new UpdateByQueryRequest.Builder()).build());
     }
 
@@ -1615,15 +1646,15 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public UpdateByQueryRethrottleResponse updateByQueryRethrottle(UpdateByQueryRethrottleRequest request) throws IOException,
-        OpenSearchException {
+    public CompletableFuture<UpdateByQueryRethrottleResponse> updateByQueryRethrottle(UpdateByQueryRethrottleRequest request)
+        throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<UpdateByQueryRethrottleRequest, UpdateByQueryRethrottleResponse, ErrorResponse> endpoint = (JsonEndpoint<
             UpdateByQueryRethrottleRequest,
             UpdateByQueryRethrottleResponse,
             ErrorResponse>) UpdateByQueryRethrottleRequest._ENDPOINT;
 
-        return this.transport.performRequest(request, endpoint, this.transportOptions);
+        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1636,7 +1667,7 @@ public abstract class OpenSearchClientBase<Self extends OpenSearchClientBase<Sel
      *
      */
 
-    public final UpdateByQueryRethrottleResponse updateByQueryRethrottle(
+    public final CompletableFuture<UpdateByQueryRethrottleResponse> updateByQueryRethrottle(
         Function<UpdateByQueryRethrottleRequest.Builder, ObjectBuilder<UpdateByQueryRethrottleRequest>> fn
     ) throws IOException, OpenSearchException {
         return updateByQueryRethrottle(fn.apply(new UpdateByQueryRethrottleRequest.Builder()).build());

--- a/java-client/src/main/java/org/opensearch/client/opensearch/OpenSearchClient.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/OpenSearchClient.java
@@ -33,14 +33,12 @@
 package org.opensearch.client.opensearch;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import javax.annotation.Nullable;
-import org.opensearch.client.ApiClient;
 import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch._types.OpenSearchException;
-import org.opensearch.client.opensearch.cat.OpenSearchCatAsyncClient;
-import org.opensearch.client.opensearch.cluster.OpenSearchClusterAsyncClient;
+import org.opensearch.client.opensearch.cat.OpenSearchCatClient;
+import org.opensearch.client.opensearch.cluster.OpenSearchClusterClient;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.ClearScrollRequest;
@@ -120,13 +118,14 @@ import org.opensearch.client.opensearch.core.pit.DeletePitRequest;
 import org.opensearch.client.opensearch.core.pit.DeletePitResponse;
 import org.opensearch.client.opensearch.core.pit.ListAllPitRequest;
 import org.opensearch.client.opensearch.core.pit.ListAllPitResponse;
-import org.opensearch.client.opensearch.features.OpenSearchFeaturesAsyncClient;
-import org.opensearch.client.opensearch.indices.OpenSearchIndicesAsyncClient;
-import org.opensearch.client.opensearch.ingest.OpenSearchIngestAsyncClient;
-import org.opensearch.client.opensearch.nodes.OpenSearchNodesAsyncClient;
-import org.opensearch.client.opensearch.shutdown.OpenSearchShutdownAsyncClient;
-import org.opensearch.client.opensearch.snapshot.OpenSearchSnapshotAsyncClient;
-import org.opensearch.client.opensearch.tasks.OpenSearchTasksAsyncClient;
+import org.opensearch.client.opensearch.features.OpenSearchFeaturesClient;
+import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
+import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
+import org.opensearch.client.opensearch.ingest.OpenSearchIngestClient;
+import org.opensearch.client.opensearch.nodes.OpenSearchNodesClient;
+import org.opensearch.client.opensearch.shutdown.OpenSearchShutdownClient;
+import org.opensearch.client.opensearch.snapshot.OpenSearchSnapshotClient;
+import org.opensearch.client.opensearch.tasks.OpenSearchTasksClient;
 import org.opensearch.client.transport.JsonEndpoint;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.TransportOptions;
@@ -137,48 +136,59 @@ import org.opensearch.client.util.ObjectBuilder;
 /**
  * Client for the namespace.
  */
-public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClientBase<Self>> extends ApiClient<OpenSearchTransport, Self> {
+public class OpenSearchClient extends OpenSearchClientBase<OpenSearchClient> {
+    public OpenSearchClient(OpenSearchTransport transport) {
+        super(transport, null);
+    }
 
-    public OpenSearchAsyncClientBase(OpenSearchTransport transport, @Nullable TransportOptions transportOptions) {
+    public OpenSearchClient(OpenSearchTransport transport, @Nullable TransportOptions transportOptions) {
         super(transport, transportOptions);
     }
 
+    @Override
+    public OpenSearchClient withTransportOptions(@Nullable TransportOptions transportOptions) {
+        return new OpenSearchClient(this.transport, transportOptions);
+    }
+
     // ----- Child clients
-
-    public OpenSearchCatAsyncClient cat() {
-        return new OpenSearchCatAsyncClient(this.transport, this.transportOptions);
+    public OpenSearchGenericClient generic() {
+        return new OpenSearchGenericClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchClusterAsyncClient cluster() {
-        return new OpenSearchClusterAsyncClient(this.transport, this.transportOptions);
+    public OpenSearchCatClient cat() {
+        return new OpenSearchCatClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchFeaturesAsyncClient features() {
-        return new OpenSearchFeaturesAsyncClient(this.transport, this.transportOptions);
+    public OpenSearchClusterClient cluster() {
+        return new OpenSearchClusterClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchIndicesAsyncClient indices() {
-        return new OpenSearchIndicesAsyncClient(this.transport, this.transportOptions);
+    public OpenSearchFeaturesClient features() {
+        return new OpenSearchFeaturesClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchIngestAsyncClient ingest() {
-        return new OpenSearchIngestAsyncClient(this.transport, this.transportOptions);
+    public OpenSearchIndicesClient indices() {
+        return new OpenSearchIndicesClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchNodesAsyncClient nodes() {
-        return new OpenSearchNodesAsyncClient(this.transport, this.transportOptions);
+    public OpenSearchIngestClient ingest() {
+        return new OpenSearchIngestClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchShutdownAsyncClient shutdown() {
-        return new OpenSearchShutdownAsyncClient(this.transport, this.transportOptions);
+    public OpenSearchNodesClient nodes() {
+        return new OpenSearchNodesClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchSnapshotAsyncClient snapshot() {
-        return new OpenSearchSnapshotAsyncClient(this.transport, this.transportOptions);
+    public OpenSearchShutdownClient shutdown() {
+        return new OpenSearchShutdownClient(this.transport, this.transportOptions);
     }
 
-    public OpenSearchTasksAsyncClient tasks() {
-        return new OpenSearchTasksAsyncClient(this.transport, this.transportOptions);
+    public OpenSearchSnapshotClient snapshot() {
+        return new OpenSearchSnapshotClient(this.transport, this.transportOptions);
+    }
+
+    public OpenSearchTasksClient tasks() {
+        return new OpenSearchTasksClient(this.transport, this.transportOptions);
     }
 
     // ----- Endpoint: bulk
@@ -190,14 +200,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<BulkResponse> bulk(BulkRequest request) throws IOException, OpenSearchException {
+    public BulkResponse bulk(BulkRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<BulkRequest, BulkResponse, ErrorResponse> endpoint = (JsonEndpoint<
             BulkRequest,
             BulkResponse,
             ErrorResponse>) BulkRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -210,8 +220,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<BulkResponse> bulk(Function<BulkRequest.Builder, ObjectBuilder<BulkRequest>> fn) throws IOException,
-        OpenSearchException {
+    public final BulkResponse bulk(Function<BulkRequest.Builder, ObjectBuilder<BulkRequest>> fn) throws IOException, OpenSearchException {
         return bulk(fn.apply(new BulkRequest.Builder()).build());
     }
 
@@ -222,8 +231,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<BulkResponse> bulk() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(new BulkRequest.Builder().build(), BulkRequest._ENDPOINT, this.transportOptions);
+    public BulkResponse bulk() throws IOException, OpenSearchException {
+        return this.transport.performRequest(new BulkRequest.Builder().build(), BulkRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: clear_scroll
@@ -234,14 +243,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<ClearScrollResponse> clearScroll(ClearScrollRequest request) throws IOException, OpenSearchException {
+    public ClearScrollResponse clearScroll(ClearScrollRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ClearScrollRequest, ClearScrollResponse, ErrorResponse> endpoint = (JsonEndpoint<
             ClearScrollRequest,
             ClearScrollResponse,
             ErrorResponse>) ClearScrollRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -253,9 +262,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<ClearScrollResponse> clearScroll(
-        Function<ClearScrollRequest.Builder, ObjectBuilder<ClearScrollRequest>> fn
-    ) throws IOException, OpenSearchException {
+    public final ClearScrollResponse clearScroll(Function<ClearScrollRequest.Builder, ObjectBuilder<ClearScrollRequest>> fn)
+        throws IOException, OpenSearchException {
         return clearScroll(fn.apply(new ClearScrollRequest.Builder()).build());
     }
 
@@ -265,12 +273,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<ClearScrollResponse> clearScroll() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(
-            new ClearScrollRequest.Builder().build(),
-            ClearScrollRequest._ENDPOINT,
-            this.transportOptions
-        );
+    public ClearScrollResponse clearScroll() throws IOException, OpenSearchException {
+        return this.transport.performRequest(new ClearScrollRequest.Builder().build(), ClearScrollRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: count
@@ -281,14 +285,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<CountResponse> count(CountRequest request) throws IOException, OpenSearchException {
+    public CountResponse count(CountRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<CountRequest, CountResponse, ErrorResponse> endpoint = (JsonEndpoint<
             CountRequest,
             CountResponse,
             ErrorResponse>) CountRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -300,7 +304,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<CountResponse> count(Function<CountRequest.Builder, ObjectBuilder<CountRequest>> fn) throws IOException,
+    public final CountResponse count(Function<CountRequest.Builder, ObjectBuilder<CountRequest>> fn) throws IOException,
         OpenSearchException {
         return count(fn.apply(new CountRequest.Builder()).build());
     }
@@ -311,8 +315,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<CountResponse> count() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(new CountRequest.Builder().build(), CountRequest._ENDPOINT, this.transportOptions);
+    public CountResponse count() throws IOException, OpenSearchException {
+        return this.transport.performRequest(new CountRequest.Builder().build(), CountRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: create
@@ -326,14 +330,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument> CompletableFuture<CreateResponse> create(CreateRequest<TDocument> request) throws IOException, OpenSearchException {
+    public <TDocument> CreateResponse create(CreateRequest<TDocument> request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<CreateRequest<?>, CreateResponse, ErrorResponse> endpoint = (JsonEndpoint<
             CreateRequest<?>,
             CreateResponse,
             ErrorResponse>) CreateRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -348,9 +352,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TDocument> CompletableFuture<CreateResponse> create(
-        Function<CreateRequest.Builder<TDocument>, ObjectBuilder<CreateRequest<TDocument>>> fn
-    ) throws IOException, OpenSearchException {
+    public final <TDocument> CreateResponse create(Function<CreateRequest.Builder<TDocument>, ObjectBuilder<CreateRequest<TDocument>>> fn)
+        throws IOException, OpenSearchException {
         return create(fn.apply(new CreateRequest.Builder<TDocument>()).build());
     }
 
@@ -363,14 +366,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<CreatePitResponse> createPit(CreatePitRequest request) throws IOException, OpenSearchException {
+    public CreatePitResponse createPit(CreatePitRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<CreatePitRequest, CreatePitResponse, ErrorResponse> endpoint = (JsonEndpoint<
             CreatePitRequest,
             CreatePitResponse,
             ErrorResponse>) CreatePitRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -383,8 +386,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<CreatePitResponse> createPit(Function<CreatePitRequest.Builder, ObjectBuilder<CreatePitRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final CreatePitResponse createPit(Function<CreatePitRequest.Builder, ObjectBuilder<CreatePitRequest>> fn) throws IOException,
+        OpenSearchException {
         return createPit(fn.apply(new CreatePitRequest.Builder()).build());
     }
 
@@ -396,14 +399,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<DeleteResponse> delete(DeleteRequest request) throws IOException, OpenSearchException {
+    public DeleteResponse delete(DeleteRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<DeleteRequest, DeleteResponse, ErrorResponse> endpoint = (JsonEndpoint<
             DeleteRequest,
             DeleteResponse,
             ErrorResponse>) DeleteRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -415,8 +418,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<DeleteResponse> delete(Function<DeleteRequest.Builder, ObjectBuilder<DeleteRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final DeleteResponse delete(Function<DeleteRequest.Builder, ObjectBuilder<DeleteRequest>> fn) throws IOException,
+        OpenSearchException {
         return delete(fn.apply(new DeleteRequest.Builder()).build());
     }
 
@@ -428,14 +431,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<DeletePitResponse> deletePit(DeletePitRequest request) throws IOException, OpenSearchException {
+    public DeletePitResponse deletePit(DeletePitRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<DeletePitRequest, DeletePitResponse, ErrorResponse> endpoint = (JsonEndpoint<
             DeletePitRequest,
             DeletePitResponse,
             ErrorResponse>) DeletePitRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -447,8 +450,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<DeletePitResponse> deletePit(Function<DeletePitRequest.Builder, ObjectBuilder<DeletePitRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final DeletePitResponse deletePit(Function<DeletePitRequest.Builder, ObjectBuilder<DeletePitRequest>> fn) throws IOException,
+        OpenSearchException {
         return deletePit(fn.apply(new DeletePitRequest.Builder()).build());
     }
 
@@ -460,14 +463,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<DeleteByQueryResponse> deleteByQuery(DeleteByQueryRequest request) throws IOException, OpenSearchException {
+    public DeleteByQueryResponse deleteByQuery(DeleteByQueryRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<DeleteByQueryRequest, DeleteByQueryResponse, ErrorResponse> endpoint = (JsonEndpoint<
             DeleteByQueryRequest,
             DeleteByQueryResponse,
             ErrorResponse>) DeleteByQueryRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -479,9 +482,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<DeleteByQueryResponse> deleteByQuery(
-        Function<DeleteByQueryRequest.Builder, ObjectBuilder<DeleteByQueryRequest>> fn
-    ) throws IOException, OpenSearchException {
+    public final DeleteByQueryResponse deleteByQuery(Function<DeleteByQueryRequest.Builder, ObjectBuilder<DeleteByQueryRequest>> fn)
+        throws IOException, OpenSearchException {
         return deleteByQuery(fn.apply(new DeleteByQueryRequest.Builder()).build());
     }
 
@@ -494,15 +496,15 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<DeleteByQueryRethrottleResponse> deleteByQueryRethrottle(DeleteByQueryRethrottleRequest request)
-        throws IOException, OpenSearchException {
+    public DeleteByQueryRethrottleResponse deleteByQueryRethrottle(DeleteByQueryRethrottleRequest request) throws IOException,
+        OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<DeleteByQueryRethrottleRequest, DeleteByQueryRethrottleResponse, ErrorResponse> endpoint = (JsonEndpoint<
             DeleteByQueryRethrottleRequest,
             DeleteByQueryRethrottleResponse,
             ErrorResponse>) DeleteByQueryRethrottleRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -515,7 +517,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<DeleteByQueryRethrottleResponse> deleteByQueryRethrottle(
+    public final DeleteByQueryRethrottleResponse deleteByQueryRethrottle(
         Function<DeleteByQueryRethrottleRequest.Builder, ObjectBuilder<DeleteByQueryRethrottleRequest>> fn
     ) throws IOException, OpenSearchException {
         return deleteByQueryRethrottle(fn.apply(new DeleteByQueryRethrottleRequest.Builder()).build());
@@ -529,14 +531,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<DeleteScriptResponse> deleteScript(DeleteScriptRequest request) throws IOException, OpenSearchException {
+    public DeleteScriptResponse deleteScript(DeleteScriptRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<DeleteScriptRequest, DeleteScriptResponse, ErrorResponse> endpoint = (JsonEndpoint<
             DeleteScriptRequest,
             DeleteScriptResponse,
             ErrorResponse>) DeleteScriptRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -548,9 +550,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<DeleteScriptResponse> deleteScript(
-        Function<DeleteScriptRequest.Builder, ObjectBuilder<DeleteScriptRequest>> fn
-    ) throws IOException, OpenSearchException {
+    public final DeleteScriptResponse deleteScript(Function<DeleteScriptRequest.Builder, ObjectBuilder<DeleteScriptRequest>> fn)
+        throws IOException, OpenSearchException {
         return deleteScript(fn.apply(new DeleteScriptRequest.Builder()).build());
     }
 
@@ -562,14 +563,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<BooleanResponse> exists(ExistsRequest request) throws IOException, OpenSearchException {
+    public BooleanResponse exists(ExistsRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ExistsRequest, BooleanResponse, ErrorResponse> endpoint = (JsonEndpoint<
             ExistsRequest,
             BooleanResponse,
             ErrorResponse>) ExistsRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -581,8 +582,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<BooleanResponse> exists(Function<ExistsRequest.Builder, ObjectBuilder<ExistsRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final BooleanResponse exists(Function<ExistsRequest.Builder, ObjectBuilder<ExistsRequest>> fn) throws IOException,
+        OpenSearchException {
         return exists(fn.apply(new ExistsRequest.Builder()).build());
     }
 
@@ -594,14 +595,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<BooleanResponse> existsSource(ExistsSourceRequest request) throws IOException, OpenSearchException {
+    public BooleanResponse existsSource(ExistsSourceRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ExistsSourceRequest, BooleanResponse, ErrorResponse> endpoint = (JsonEndpoint<
             ExistsSourceRequest,
             BooleanResponse,
             ErrorResponse>) ExistsSourceRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -613,9 +614,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<BooleanResponse> existsSource(
-        Function<ExistsSourceRequest.Builder, ObjectBuilder<ExistsSourceRequest>> fn
-    ) throws IOException, OpenSearchException {
+    public final BooleanResponse existsSource(Function<ExistsSourceRequest.Builder, ObjectBuilder<ExistsSourceRequest>> fn)
+        throws IOException, OpenSearchException {
         return existsSource(fn.apply(new ExistsSourceRequest.Builder()).build());
     }
 
@@ -627,8 +627,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument> CompletableFuture<ExplainResponse<TDocument>> explain(ExplainRequest request, Class<TDocument> tDocumentClass)
-        throws IOException, OpenSearchException {
+    public <TDocument> ExplainResponse<TDocument> explain(ExplainRequest request, Class<TDocument> tDocumentClass) throws IOException,
+        OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ExplainRequest, ExplainResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             ExplainRequest,
@@ -640,7 +640,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -652,7 +652,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TDocument> CompletableFuture<ExplainResponse<TDocument>> explain(
+    public final <TDocument> ExplainResponse<TDocument> explain(
         Function<ExplainRequest.Builder, ObjectBuilder<ExplainRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -664,16 +664,18 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
     /**
      * Returns the information about the capabilities of fields among multiple
      * indices.
+     *
+     *
      */
 
-    public CompletableFuture<FieldCapsResponse> fieldCaps(FieldCapsRequest request) throws IOException, OpenSearchException {
+    public FieldCapsResponse fieldCaps(FieldCapsRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<FieldCapsRequest, FieldCapsResponse, ErrorResponse> endpoint = (JsonEndpoint<
             FieldCapsRequest,
             FieldCapsResponse,
             ErrorResponse>) FieldCapsRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -686,8 +688,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<FieldCapsResponse> fieldCaps(Function<FieldCapsRequest.Builder, ObjectBuilder<FieldCapsRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final FieldCapsResponse fieldCaps(Function<FieldCapsRequest.Builder, ObjectBuilder<FieldCapsRequest>> fn) throws IOException,
+        OpenSearchException {
         return fieldCaps(fn.apply(new FieldCapsRequest.Builder()).build());
     }
 
@@ -698,12 +700,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<FieldCapsResponse> fieldCaps() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(
-            new FieldCapsRequest.Builder().build(),
-            FieldCapsRequest._ENDPOINT,
-            this.transportOptions
-        );
+    public FieldCapsResponse fieldCaps() throws IOException, OpenSearchException {
+        return this.transport.performRequest(new FieldCapsRequest.Builder().build(), FieldCapsRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: get
@@ -714,8 +712,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument> CompletableFuture<GetResponse<TDocument>> get(GetRequest request, Class<TDocument> tDocumentClass)
-        throws IOException, OpenSearchException {
+    public <TDocument> GetResponse<TDocument> get(GetRequest request, Class<TDocument> tDocumentClass) throws IOException,
+        OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<GetRequest, GetResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             GetRequest,
@@ -727,7 +725,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -739,7 +737,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TDocument> CompletableFuture<GetResponse<TDocument>> get(
+    public final <TDocument> GetResponse<TDocument> get(
         Function<GetRequest.Builder, ObjectBuilder<GetRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -754,14 +752,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<GetScriptResponse> getScript(GetScriptRequest request) throws IOException, OpenSearchException {
+    public GetScriptResponse getScript(GetScriptRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<GetScriptRequest, GetScriptResponse, ErrorResponse> endpoint = (JsonEndpoint<
             GetScriptRequest,
             GetScriptResponse,
             ErrorResponse>) GetScriptRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -773,8 +771,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<GetScriptResponse> getScript(Function<GetScriptRequest.Builder, ObjectBuilder<GetScriptRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final GetScriptResponse getScript(Function<GetScriptRequest.Builder, ObjectBuilder<GetScriptRequest>> fn) throws IOException,
+        OpenSearchException {
         return getScript(fn.apply(new GetScriptRequest.Builder()).build());
     }
 
@@ -785,12 +783,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      *
      */
-    public CompletableFuture<GetScriptContextResponse> getScriptContext() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(
-            GetScriptContextRequest._INSTANCE,
-            GetScriptContextRequest._ENDPOINT,
-            this.transportOptions
-        );
+    public GetScriptContextResponse getScriptContext() throws IOException, OpenSearchException {
+        return this.transport.performRequest(GetScriptContextRequest._INSTANCE, GetScriptContextRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: get_script_languages
@@ -800,8 +794,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      *
      */
-    public CompletableFuture<GetScriptLanguagesResponse> getScriptLanguages() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(
+    public GetScriptLanguagesResponse getScriptLanguages() throws IOException, OpenSearchException {
+        return this.transport.performRequest(
             GetScriptLanguagesRequest._INSTANCE,
             GetScriptLanguagesRequest._ENDPOINT,
             this.transportOptions
@@ -816,8 +810,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument> CompletableFuture<GetSourceResponse<TDocument>> getSource(GetSourceRequest request, Class<TDocument> tDocumentClass)
-        throws IOException, OpenSearchException {
+    public <TDocument> GetSourceResponse<TDocument> getSource(GetSourceRequest request, Class<TDocument> tDocumentClass) throws IOException,
+        OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<GetSourceRequest, GetSourceResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             GetSourceRequest,
@@ -829,7 +823,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -841,7 +835,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TDocument> CompletableFuture<GetSourceResponse<TDocument>> getSource(
+    public final <TDocument> GetSourceResponse<TDocument> getSource(
         Function<GetSourceRequest.Builder, ObjectBuilder<GetSourceRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -856,14 +850,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument> CompletableFuture<IndexResponse> index(IndexRequest<TDocument> request) throws IOException, OpenSearchException {
+    public <TDocument> IndexResponse index(IndexRequest<TDocument> request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<IndexRequest<?>, IndexResponse, ErrorResponse> endpoint = (JsonEndpoint<
             IndexRequest<?>,
             IndexResponse,
             ErrorResponse>) IndexRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -875,9 +869,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TDocument> CompletableFuture<IndexResponse> index(
-        Function<IndexRequest.Builder<TDocument>, ObjectBuilder<IndexRequest<TDocument>>> fn
-    ) throws IOException, OpenSearchException {
+    public final <TDocument> IndexResponse index(Function<IndexRequest.Builder<TDocument>, ObjectBuilder<IndexRequest<TDocument>>> fn)
+        throws IOException, OpenSearchException {
         return index(fn.apply(new IndexRequest.Builder<TDocument>()).build());
     }
 
@@ -889,8 +882,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<ListAllPitResponse> listAllPit() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(ListAllPitRequest._INSTANCE, ListAllPitRequest._ENDPOINT, this.transportOptions);
+    public ListAllPitResponse listAllPit() throws IOException, OpenSearchException {
+        return this.transport.performRequest(ListAllPitRequest._INSTANCE, ListAllPitRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: mget
@@ -901,8 +894,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument> CompletableFuture<MgetResponse<TDocument>> mget(MgetRequest request, Class<TDocument> tDocumentClass)
-        throws IOException, OpenSearchException {
+    public <TDocument> MgetResponse<TDocument> mget(MgetRequest request, Class<TDocument> tDocumentClass) throws IOException,
+        OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<MgetRequest, MgetResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             MgetRequest,
@@ -914,7 +907,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -926,7 +919,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TDocument> CompletableFuture<MgetResponse<TDocument>> mget(
+    public final <TDocument> MgetResponse<TDocument> mget(
         Function<MgetRequest.Builder, ObjectBuilder<MgetRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -941,8 +934,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument> CompletableFuture<MsearchResponse<TDocument>> msearch(MsearchRequest request, Class<TDocument> tDocumentClass)
-        throws IOException, OpenSearchException {
+    public <TDocument> MsearchResponse<TDocument> msearch(MsearchRequest request, Class<TDocument> tDocumentClass) throws IOException,
+        OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<MsearchRequest, MsearchResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             MsearchRequest,
@@ -954,7 +947,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -966,7 +959,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TDocument> CompletableFuture<MsearchResponse<TDocument>> msearch(
+    public final <TDocument> MsearchResponse<TDocument> msearch(
         Function<MsearchRequest.Builder, ObjectBuilder<MsearchRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -981,10 +974,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument> CompletableFuture<MsearchTemplateResponse<TDocument>> msearchTemplate(
-        MsearchTemplateRequest request,
-        Class<TDocument> tDocumentClass
-    ) throws IOException, OpenSearchException {
+    public <TDocument> MsearchTemplateResponse<TDocument> msearchTemplate(MsearchTemplateRequest request, Class<TDocument> tDocumentClass)
+        throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<MsearchTemplateRequest, MsearchTemplateResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             MsearchTemplateRequest,
@@ -996,7 +987,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1008,7 +999,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TDocument> CompletableFuture<MsearchTemplateResponse<TDocument>> msearchTemplate(
+    public final <TDocument> MsearchTemplateResponse<TDocument> msearchTemplate(
         Function<MsearchTemplateRequest.Builder, ObjectBuilder<MsearchTemplateRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -1023,14 +1014,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<MtermvectorsResponse> mtermvectors(MtermvectorsRequest request) throws IOException, OpenSearchException {
+    public MtermvectorsResponse mtermvectors(MtermvectorsRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<MtermvectorsRequest, MtermvectorsResponse, ErrorResponse> endpoint = (JsonEndpoint<
             MtermvectorsRequest,
             MtermvectorsResponse,
             ErrorResponse>) MtermvectorsRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1042,9 +1033,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<MtermvectorsResponse> mtermvectors(
-        Function<MtermvectorsRequest.Builder, ObjectBuilder<MtermvectorsRequest>> fn
-    ) throws IOException, OpenSearchException {
+    public final MtermvectorsResponse mtermvectors(Function<MtermvectorsRequest.Builder, ObjectBuilder<MtermvectorsRequest>> fn)
+        throws IOException, OpenSearchException {
         return mtermvectors(fn.apply(new MtermvectorsRequest.Builder()).build());
     }
 
@@ -1054,8 +1044,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<MtermvectorsResponse> mtermvectors() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(
+    public MtermvectorsResponse mtermvectors() throws IOException, OpenSearchException {
+        return this.transport.performRequest(
             new MtermvectorsRequest.Builder().build(),
             MtermvectorsRequest._ENDPOINT,
             this.transportOptions
@@ -1069,8 +1059,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      *
      */
-    public CompletableFuture<BooleanResponse> ping() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(PingRequest._INSTANCE, PingRequest._ENDPOINT, this.transportOptions);
+    public BooleanResponse ping() throws IOException, OpenSearchException {
+        return this.transport.performRequest(PingRequest._INSTANCE, PingRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: put_script
@@ -1081,14 +1071,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<PutScriptResponse> putScript(PutScriptRequest request) throws IOException, OpenSearchException {
+    public PutScriptResponse putScript(PutScriptRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<PutScriptRequest, PutScriptResponse, ErrorResponse> endpoint = (JsonEndpoint<
             PutScriptRequest,
             PutScriptResponse,
             ErrorResponse>) PutScriptRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1100,8 +1090,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<PutScriptResponse> putScript(Function<PutScriptRequest.Builder, ObjectBuilder<PutScriptRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final PutScriptResponse putScript(Function<PutScriptRequest.Builder, ObjectBuilder<PutScriptRequest>> fn) throws IOException,
+        OpenSearchException {
         return putScript(fn.apply(new PutScriptRequest.Builder()).build());
     }
 
@@ -1114,14 +1104,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<RankEvalResponse> rankEval(RankEvalRequest request) throws IOException, OpenSearchException {
+    public RankEvalResponse rankEval(RankEvalRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<RankEvalRequest, RankEvalResponse, ErrorResponse> endpoint = (JsonEndpoint<
             RankEvalRequest,
             RankEvalResponse,
             ErrorResponse>) RankEvalRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1134,8 +1124,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<RankEvalResponse> rankEval(Function<RankEvalRequest.Builder, ObjectBuilder<RankEvalRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final RankEvalResponse rankEval(Function<RankEvalRequest.Builder, ObjectBuilder<RankEvalRequest>> fn) throws IOException,
+        OpenSearchException {
         return rankEval(fn.apply(new RankEvalRequest.Builder()).build());
     }
 
@@ -1149,14 +1139,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<ReindexResponse> reindex(ReindexRequest request) throws IOException, OpenSearchException {
+    public ReindexResponse reindex(ReindexRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ReindexRequest, ReindexResponse, ErrorResponse> endpoint = (JsonEndpoint<
             ReindexRequest,
             ReindexResponse,
             ErrorResponse>) ReindexRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1170,8 +1160,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<ReindexResponse> reindex(Function<ReindexRequest.Builder, ObjectBuilder<ReindexRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final ReindexResponse reindex(Function<ReindexRequest.Builder, ObjectBuilder<ReindexRequest>> fn) throws IOException,
+        OpenSearchException {
         return reindex(fn.apply(new ReindexRequest.Builder()).build());
     }
 
@@ -1183,8 +1173,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<ReindexResponse> reindex() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(new ReindexRequest.Builder().build(), ReindexRequest._ENDPOINT, this.transportOptions);
+    public ReindexResponse reindex() throws IOException, OpenSearchException {
+        return this.transport.performRequest(new ReindexRequest.Builder().build(), ReindexRequest._ENDPOINT, this.transportOptions);
     }
 
     // ----- Endpoint: reindex_rethrottle
@@ -1195,15 +1185,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<ReindexRethrottleResponse> reindexRethrottle(ReindexRethrottleRequest request) throws IOException,
-        OpenSearchException {
+    public ReindexRethrottleResponse reindexRethrottle(ReindexRethrottleRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ReindexRethrottleRequest, ReindexRethrottleResponse, ErrorResponse> endpoint = (JsonEndpoint<
             ReindexRethrottleRequest,
             ReindexRethrottleResponse,
             ErrorResponse>) ReindexRethrottleRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1215,7 +1204,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<ReindexRethrottleResponse> reindexRethrottle(
+    public final ReindexRethrottleResponse reindexRethrottle(
         Function<ReindexRethrottleRequest.Builder, ObjectBuilder<ReindexRethrottleRequest>> fn
     ) throws IOException, OpenSearchException {
         return reindexRethrottle(fn.apply(new ReindexRethrottleRequest.Builder()).build());
@@ -1229,15 +1218,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<RenderSearchTemplateResponse> renderSearchTemplate(RenderSearchTemplateRequest request) throws IOException,
-        OpenSearchException {
+    public RenderSearchTemplateResponse renderSearchTemplate(RenderSearchTemplateRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<RenderSearchTemplateRequest, RenderSearchTemplateResponse, ErrorResponse> endpoint = (JsonEndpoint<
             RenderSearchTemplateRequest,
             RenderSearchTemplateResponse,
             ErrorResponse>) RenderSearchTemplateRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1249,7 +1237,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<RenderSearchTemplateResponse> renderSearchTemplate(
+    public final RenderSearchTemplateResponse renderSearchTemplate(
         Function<RenderSearchTemplateRequest.Builder, ObjectBuilder<RenderSearchTemplateRequest>> fn
     ) throws IOException, OpenSearchException {
         return renderSearchTemplate(fn.apply(new RenderSearchTemplateRequest.Builder()).build());
@@ -1261,8 +1249,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<RenderSearchTemplateResponse> renderSearchTemplate() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(
+    public RenderSearchTemplateResponse renderSearchTemplate() throws IOException, OpenSearchException {
+        return this.transport.performRequest(
             new RenderSearchTemplateRequest.Builder().build(),
             RenderSearchTemplateRequest._ENDPOINT,
             this.transportOptions
@@ -1277,7 +1265,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TResult> CompletableFuture<ScriptsPainlessExecuteResponse<TResult>> scriptsPainlessExecute(
+    public <TResult> ScriptsPainlessExecuteResponse<TResult> scriptsPainlessExecute(
         ScriptsPainlessExecuteRequest request,
         Class<TResult> tResultClass
     ) throws IOException, OpenSearchException {
@@ -1292,7 +1280,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
             getDeserializer(tResultClass)
         );
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1304,7 +1292,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TResult> CompletableFuture<ScriptsPainlessExecuteResponse<TResult>> scriptsPainlessExecute(
+    public final <TResult> ScriptsPainlessExecuteResponse<TResult> scriptsPainlessExecute(
         Function<ScriptsPainlessExecuteRequest.Builder, ObjectBuilder<ScriptsPainlessExecuteRequest>> fn,
         Class<TResult> tResultClass
     ) throws IOException, OpenSearchException {
@@ -1318,8 +1306,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument> CompletableFuture<ScrollResponse<TDocument>> scroll(ScrollRequest request, Class<TDocument> tDocumentClass)
-        throws IOException, OpenSearchException {
+    public <TDocument> ScrollResponse<TDocument> scroll(ScrollRequest request, Class<TDocument> tDocumentClass) throws IOException,
+        OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<ScrollRequest, ScrollResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             ScrollRequest,
@@ -1331,7 +1319,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1342,7 +1330,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *            {@link ScrollRequest}
      */
 
-    public final <TDocument> CompletableFuture<ScrollResponse<TDocument>> scroll(
+    public final <TDocument> ScrollResponse<TDocument> scroll(
         Function<ScrollRequest.Builder, ObjectBuilder<ScrollRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -1357,8 +1345,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument> CompletableFuture<SearchResponse<TDocument>> search(SearchRequest request, Class<TDocument> tDocumentClass)
-        throws IOException, OpenSearchException {
+    public <TDocument> SearchResponse<TDocument> search(SearchRequest request, Class<TDocument> tDocumentClass) throws IOException,
+        OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<SearchRequest, SearchResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             SearchRequest,
@@ -1370,7 +1358,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1382,7 +1370,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TDocument> CompletableFuture<SearchResponse<TDocument>> search(
+    public final <TDocument> SearchResponse<TDocument> search(
         Function<SearchRequest.Builder, ObjectBuilder<SearchRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -1398,14 +1386,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<SearchShardsResponse> searchShards(SearchShardsRequest request) throws IOException, OpenSearchException {
+    public SearchShardsResponse searchShards(SearchShardsRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<SearchShardsRequest, SearchShardsResponse, ErrorResponse> endpoint = (JsonEndpoint<
             SearchShardsRequest,
             SearchShardsResponse,
             ErrorResponse>) SearchShardsRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1418,9 +1406,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<SearchShardsResponse> searchShards(
-        Function<SearchShardsRequest.Builder, ObjectBuilder<SearchShardsRequest>> fn
-    ) throws IOException, OpenSearchException {
+    public final SearchShardsResponse searchShards(Function<SearchShardsRequest.Builder, ObjectBuilder<SearchShardsRequest>> fn)
+        throws IOException, OpenSearchException {
         return searchShards(fn.apply(new SearchShardsRequest.Builder()).build());
     }
 
@@ -1431,8 +1418,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<SearchShardsResponse> searchShards() throws IOException, OpenSearchException {
-        return this.transport.performRequestAsync(
+    public SearchShardsResponse searchShards() throws IOException, OpenSearchException {
+        return this.transport.performRequest(
             new SearchShardsRequest.Builder().build(),
             SearchShardsRequest._ENDPOINT,
             this.transportOptions
@@ -1447,10 +1434,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument> CompletableFuture<SearchTemplateResponse<TDocument>> searchTemplate(
-        SearchTemplateRequest request,
-        Class<TDocument> tDocumentClass
-    ) throws IOException, OpenSearchException {
+    public <TDocument> SearchTemplateResponse<TDocument> searchTemplate(SearchTemplateRequest request, Class<TDocument> tDocumentClass)
+        throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<SearchTemplateRequest, SearchTemplateResponse<TDocument>, ErrorResponse> endpoint = (JsonEndpoint<
             SearchTemplateRequest,
@@ -1461,8 +1446,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
             "org.opensearch.client:Deserializer:_global.search_template.TDocument",
             getDeserializer(tDocumentClass)
         );
-
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1474,7 +1458,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TDocument> CompletableFuture<SearchTemplateResponse<TDocument>> searchTemplate(
+    public final <TDocument> SearchTemplateResponse<TDocument> searchTemplate(
         Function<SearchTemplateRequest.Builder, ObjectBuilder<SearchTemplateRequest>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -1491,14 +1475,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<TermsEnumResponse> termsEnum(TermsEnumRequest request) throws IOException, OpenSearchException {
+    public TermsEnumResponse termsEnum(TermsEnumRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<TermsEnumRequest, TermsEnumResponse, ErrorResponse> endpoint = (JsonEndpoint<
             TermsEnumRequest,
             TermsEnumResponse,
             ErrorResponse>) TermsEnumRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1512,8 +1496,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<TermsEnumResponse> termsEnum(Function<TermsEnumRequest.Builder, ObjectBuilder<TermsEnumRequest>> fn)
-        throws IOException, OpenSearchException {
+    public final TermsEnumResponse termsEnum(Function<TermsEnumRequest.Builder, ObjectBuilder<TermsEnumRequest>> fn) throws IOException,
+        OpenSearchException {
         return termsEnum(fn.apply(new TermsEnumRequest.Builder()).build());
     }
 
@@ -1526,15 +1510,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument> CompletableFuture<TermvectorsResponse> termvectors(TermvectorsRequest<TDocument> request) throws IOException,
-        OpenSearchException {
+    public <TDocument> TermvectorsResponse termvectors(TermvectorsRequest<TDocument> request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<TermvectorsRequest<?>, TermvectorsResponse, ErrorResponse> endpoint = (JsonEndpoint<
             TermvectorsRequest<?>,
             TermvectorsResponse,
             ErrorResponse>) TermvectorsRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1547,7 +1530,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TDocument> CompletableFuture<TermvectorsResponse> termvectors(
+    public final <TDocument> TermvectorsResponse termvectors(
         Function<TermvectorsRequest.Builder<TDocument>, ObjectBuilder<TermvectorsRequest<TDocument>>> fn
     ) throws IOException, OpenSearchException {
         return termvectors(fn.apply(new TermvectorsRequest.Builder<TDocument>()).build());
@@ -1561,7 +1544,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public <TDocument, TPartialDocument> CompletableFuture<UpdateResponse<TDocument>> update(
+    public <TDocument, TPartialDocument> UpdateResponse<TDocument> update(
         UpdateRequest<TDocument, TPartialDocument> request,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -1576,7 +1559,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
             getDeserializer(tDocumentClass)
         );
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1588,7 +1571,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final <TDocument, TPartialDocument> CompletableFuture<UpdateResponse<TDocument>> update(
+    public final <TDocument, TPartialDocument> UpdateResponse<TDocument> update(
+
         Function<UpdateRequest.Builder<TDocument, TPartialDocument>, ObjectBuilder<UpdateRequest<TDocument, TPartialDocument>>> fn,
         Class<TDocument> tDocumentClass
     ) throws IOException, OpenSearchException {
@@ -1604,14 +1588,14 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<UpdateByQueryResponse> updateByQuery(UpdateByQueryRequest request) throws IOException, OpenSearchException {
+    public UpdateByQueryResponse updateByQuery(UpdateByQueryRequest request) throws IOException, OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<UpdateByQueryRequest, UpdateByQueryResponse, ErrorResponse> endpoint = (JsonEndpoint<
             UpdateByQueryRequest,
             UpdateByQueryResponse,
             ErrorResponse>) UpdateByQueryRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1624,9 +1608,8 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<UpdateByQueryResponse> updateByQuery(
-        Function<UpdateByQueryRequest.Builder, ObjectBuilder<UpdateByQueryRequest>> fn
-    ) throws IOException, OpenSearchException {
+    public final UpdateByQueryResponse updateByQuery(Function<UpdateByQueryRequest.Builder, ObjectBuilder<UpdateByQueryRequest>> fn)
+        throws IOException, OpenSearchException {
         return updateByQuery(fn.apply(new UpdateByQueryRequest.Builder()).build());
     }
 
@@ -1639,15 +1622,15 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public CompletableFuture<UpdateByQueryRethrottleResponse> updateByQueryRethrottle(UpdateByQueryRethrottleRequest request)
-        throws IOException, OpenSearchException {
+    public UpdateByQueryRethrottleResponse updateByQueryRethrottle(UpdateByQueryRethrottleRequest request) throws IOException,
+        OpenSearchException {
         @SuppressWarnings("unchecked")
         JsonEndpoint<UpdateByQueryRethrottleRequest, UpdateByQueryRethrottleResponse, ErrorResponse> endpoint = (JsonEndpoint<
             UpdateByQueryRethrottleRequest,
             UpdateByQueryRethrottleResponse,
             ErrorResponse>) UpdateByQueryRethrottleRequest._ENDPOINT;
 
-        return this.transport.performRequestAsync(request, endpoint, this.transportOptions);
+        return this.transport.performRequest(request, endpoint, this.transportOptions);
     }
 
     /**
@@ -1660,7 +1643,7 @@ public abstract class OpenSearchAsyncClientBase<Self extends OpenSearchAsyncClie
      *
      */
 
-    public final CompletableFuture<UpdateByQueryRethrottleResponse> updateByQueryRethrottle(
+    public final UpdateByQueryRethrottleResponse updateByQueryRethrottle(
         Function<UpdateByQueryRethrottleRequest.Builder, ObjectBuilder<UpdateByQueryRethrottleRequest>> fn
     ) throws IOException, OpenSearchException {
         return updateByQueryRethrottle(fn.apply(new UpdateByQueryRethrottleRequest.Builder()).build());

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/model/RequestShape.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/model/RequestShape.java
@@ -78,7 +78,7 @@ public class RequestShape extends ObjectShape {
     }
 
     public Type getResponseType() {
-        return Type.builder().pkg(getPackageName()).name(responseClassName(operationGroup)).build();
+        return Type.builder().withPackage(getPackageName()).withName(responseClassName(operationGroup)).build();
     }
 
     public boolean canBeSingleton() {

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/model/Shape.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/model/Shape.java
@@ -61,6 +61,10 @@ public abstract class Shape {
         return Collections.emptyList();
     }
 
+    public TypeParameterDiamond getTypeParameters() {
+        return null;
+    }
+
     public Type getExtendsType() {
         return null;
     }
@@ -70,7 +74,7 @@ public abstract class Shape {
     }
 
     public Type getType() {
-        return Type.builder().pkg(getPackageName()).name(className).build();
+        return Type.builder().withPackage(getPackageName()).withName(className).build();
     }
 
     public Namespace getParent() {

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/model/ShapeRenderingContext.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/model/ShapeRenderingContext.java
@@ -12,7 +12,6 @@ import java.io.File;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
-import org.jetbrains.annotations.NotNull;
 import org.opensearch.client.codegen.renderer.JavaCodeFormatter;
 import org.opensearch.client.codegen.renderer.TemplateLoader;
 import org.opensearch.client.codegen.renderer.TemplateRenderer;
@@ -84,7 +83,7 @@ public final class ShapeRenderingContext implements AutoCloseable {
         }
 
         @Override
-        protected @NotNull Builder self() {
+        protected @Nonnull Builder self() {
             return this;
         }
 

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/model/ShapeRenderingContext.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/model/ShapeRenderingContext.java
@@ -12,10 +12,12 @@ import java.io.File;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import org.opensearch.client.codegen.renderer.JavaCodeFormatter;
 import org.opensearch.client.codegen.renderer.TemplateLoader;
 import org.opensearch.client.codegen.renderer.TemplateRenderer;
 import org.opensearch.client.codegen.renderer.TemplateValueFormatter;
+import org.opensearch.client.codegen.utils.ObjectBuilderBase;
 import org.opensearch.client.codegen.utils.Strings;
 
 public final class ShapeRenderingContext implements AutoCloseable {
@@ -71,11 +73,20 @@ public final class ShapeRenderingContext implements AutoCloseable {
         return new Builder();
     }
 
-    public static final class Builder {
+    public static final class Builder extends ObjectBuilderBase<ShapeRenderingContext, Builder> {
         private File outputDir;
         private TemplateLoader templateLoader;
         private JavaCodeFormatter javaCodeFormatter;
         private boolean ownedJavaCodeFormatter;
+
+        private Builder() {
+            super(ShapeRenderingContext::new);
+        }
+
+        @Override
+        protected @NotNull Builder self() {
+            return this;
+        }
 
         @Nonnull
         public Builder withOutputDir(@Nonnull File outputDir) {
@@ -117,11 +128,6 @@ public final class ShapeRenderingContext implements AutoCloseable {
                 Objects.requireNonNull(configurator, "configurator must not be null").apply(JavaCodeFormatter.builder()).build(),
                 true
             );
-        }
-
-        @Nonnull
-        public ShapeRenderingContext build() {
-            return new ShapeRenderingContext(this);
         }
     }
 }

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/model/SpecTransformer.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/model/SpecTransformer.java
@@ -387,8 +387,8 @@ public class SpecTransformer {
             visit(schema);
 
             return Type.builder()
-                .pkg(Types.Client.OpenSearch.PACKAGE + "." + schema.getNamespace().orElseThrow())
-                .name(schema.getName().orElseThrow())
+                .withPackage(Types.Client.OpenSearch.PACKAGE + "." + schema.getNamespace().orElseThrow())
+                .withName(schema.getName().orElseThrow())
                 .isEnum(schema.hasEnums())
                 .build();
         }

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/model/Type.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/model/Type.java
@@ -15,7 +15,6 @@ import com.samskivert.mustache.Mustache;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.opensearch.client.codegen.renderer.lambdas.TypeIsDefinedLambda;
 import org.opensearch.client.codegen.renderer.lambdas.TypeQueryParamifyLambda;
 import org.opensearch.client.codegen.renderer.lambdas.TypeSerializerLambda;
@@ -48,7 +47,7 @@ public class Type {
     }
 
     @Nullable
-    private final String package_;
+    private final String packageName;
     @Nonnull
     private final String name;
     @Nullable
@@ -56,14 +55,14 @@ public class Type {
     private final boolean isEnum;
 
     private Type(Builder builder) {
-        this.package_ = builder.package_;
+        this.packageName = builder.packageName;
         this.name = Strings.requireNonBlank(builder.name, "name must not be blank");
         this.typeParams = builder.typeParams;
         this.isEnum = builder.isEnum;
     }
 
     public Builder toBuilder() {
-        return new Builder().withPackage(package_).withName(name).withTypeParameters(typeParams).isEnum(isEnum);
+        return new Builder().withPackage(packageName).withName(name).withTypeParameters(typeParams).isEnum(isEnum);
     }
 
     @Override
@@ -178,7 +177,7 @@ public class Type {
     }
 
     public Type getNestedType(String name) {
-        return builder().withPackage(package_).withName(this.name + "." + name).build();
+        return builder().withPackage(packageName).withName(this.name + "." + name).build();
     }
 
     public Mustache.Lambda serializer() {
@@ -190,9 +189,9 @@ public class Type {
     }
 
     public void getRequiredImports(Set<String> imports, String currentPkg) {
-        if (package_ != null && !package_.equals(Java.Lang.PACKAGE) && !package_.equals(currentPkg)) {
+        if (packageName != null && !packageName.equals(Java.Lang.PACKAGE) && !packageName.equals(currentPkg)) {
             var dotIdx = name.indexOf('.');
-            imports.add(package_ + '.' + (dotIdx > 0 ? name.substring(0, dotIdx) : name));
+            imports.add(packageName + '.' + (dotIdx > 0 ? name.substring(0, dotIdx) : name));
         }
         if (typeParams != null) {
             for (Type arg : typeParams) {
@@ -214,7 +213,7 @@ public class Type {
     }
 
     public static final class Builder extends ObjectBuilderBase<Type, Builder> {
-        private String package_;
+        private String packageName;
         private String name;
         private Type[] typeParams;
         private boolean isEnum;
@@ -224,13 +223,13 @@ public class Type {
         }
 
         @Override
-        protected @NonNull Builder self() {
+        protected @Nonnull Builder self() {
             return this;
         }
 
         @Nonnull
-        public Builder withPackage(@Nullable String package_) {
-            this.package_ = package_;
+        public Builder withPackage(@Nullable String packageName) {
+            this.packageName = packageName;
             return this;
         }
 

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/model/TypeParameterDefinition.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/model/TypeParameterDefinition.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.codegen.model;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.opensearch.client.codegen.utils.ObjectBuilderBase;
+import org.opensearch.client.codegen.utils.Strings;
+
+public final class TypeParameterDefinition {
+    @Nonnull
+    private final String name;
+    @Nullable
+    private final Type extends_;
+
+    private TypeParameterDefinition(Builder builder) {
+        this.name = Strings.requireNonBlank(builder.name, "name must not be blank");
+        this.extends_ = builder.extends_;
+    }
+
+    @Nonnull
+    public String getName() {
+        return name;
+    }
+
+    @Nullable
+    public Type getExtends() {
+        return extends_;
+    }
+
+    @Override
+    public String toString() {
+        return name + (extends_ != null ? " extends " + extends_ : "");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder extends ObjectBuilderBase<TypeParameterDefinition, Builder> {
+        private String name;
+        private Type extends_;
+
+        private Builder() {
+            super(TypeParameterDefinition::new);
+        }
+
+        @Override
+        protected @NotNull Builder self() {
+            return this;
+        }
+
+        @Nonnull
+        public Builder withName(@Nonnull String name) {
+            this.name = Strings.requireNonBlank(name, "name must not be blank");
+            return this;
+        }
+
+        @Nonnull
+        public Builder withExtends(@Nullable Type type) {
+            this.extends_ = type;
+            return this;
+        }
+    }
+}

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/model/TypeParameterDefinition.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/model/TypeParameterDefinition.java
@@ -10,7 +10,6 @@ package org.opensearch.client.codegen.model;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.jetbrains.annotations.NotNull;
 import org.opensearch.client.codegen.utils.ObjectBuilderBase;
 import org.opensearch.client.codegen.utils.Strings;
 
@@ -18,11 +17,11 @@ public final class TypeParameterDefinition {
     @Nonnull
     private final String name;
     @Nullable
-    private final Type extends_;
+    private final Type extendsType;
 
     private TypeParameterDefinition(Builder builder) {
         this.name = Strings.requireNonBlank(builder.name, "name must not be blank");
-        this.extends_ = builder.extends_;
+        this.extendsType = builder.extendsType;
     }
 
     @Nonnull
@@ -32,12 +31,12 @@ public final class TypeParameterDefinition {
 
     @Nullable
     public Type getExtends() {
-        return extends_;
+        return extendsType;
     }
 
     @Override
     public String toString() {
-        return name + (extends_ != null ? " extends " + extends_ : "");
+        return name + (extendsType != null ? " extends " + extendsType : "");
     }
 
     public static Builder builder() {
@@ -46,14 +45,14 @@ public final class TypeParameterDefinition {
 
     public static final class Builder extends ObjectBuilderBase<TypeParameterDefinition, Builder> {
         private String name;
-        private Type extends_;
+        private Type extendsType;
 
         private Builder() {
             super(TypeParameterDefinition::new);
         }
 
         @Override
-        protected @NotNull Builder self() {
+        protected @Nonnull Builder self() {
             return this;
         }
 
@@ -65,7 +64,7 @@ public final class TypeParameterDefinition {
 
         @Nonnull
         public Builder withExtends(@Nullable Type type) {
-            this.extends_ = type;
+            this.extendsType = type;
             return this;
         }
     }

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/model/TypeParameterDiamond.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/model/TypeParameterDiamond.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.codegen.model;
+
+import java.util.Objects;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import org.opensearch.client.codegen.utils.Either;
+import org.opensearch.client.codegen.utils.ObjectBuilderBase;
+
+public final class TypeParameterDiamond {
+    @Nonnull
+    private final Either<Type[], TypeParameterDefinition[]> params;
+
+    private TypeParameterDiamond(Builder builder) {
+        this.params = Objects.requireNonNull(builder.params, "params must not be null");
+    }
+
+    public void toString(@Nonnull StringBuilder out) {
+        Objects.requireNonNull(out, "out must not be null");
+        var params = this.params.fold(Function.identity(), Function.identity());
+        out.append("<");
+        for (var i = 0; i < params.length; i++) {
+            if (i > 0) {
+                out.append(", ");
+            }
+            out.append(params[i].toString());
+        }
+        out.append(">");
+    }
+
+    public Type[] getParamTypes() {
+        return params.getLeft();
+    }
+
+    @Override
+    public @Nonnull String toString() {
+        var out = new StringBuilder();
+        toString(out);
+        return out.toString();
+    }
+
+    @Nonnull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends ObjectBuilderBase<TypeParameterDiamond, Builder> {
+        private Either<Type[], TypeParameterDefinition[]> params;
+
+        private Builder() {
+            super(TypeParameterDiamond::new);
+        }
+
+        @Override
+        protected @Nonnull Builder self() {
+            return this;
+        }
+
+        @Nonnull
+        public Builder withParams(@Nonnull Type... params) {
+            this.params = Either.left(Objects.requireNonNull(params, "params must not be null"));
+            return this;
+        }
+
+        @Nonnull
+        public Builder withParams(@Nonnull TypeParameterDefinition... params) {
+            this.params = Either.right(Objects.requireNonNull(params, "params must not be null"));
+            return this;
+        }
+    }
+}

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/model/Types.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/model/Types.java
@@ -40,11 +40,11 @@ public final class Types {
     }
 
     public static final class Primitive {
-        public static final Type Boolean = Type.builder().name("boolean").build();
-        public static final Type Int = Type.builder().name("int").build();
-        public static final Type Long = Type.builder().name("long").build();
-        public static final Type Float = Type.builder().name("float").build();
-        public static final Type Double = Type.builder().name("double").build();
+        public static final Type Boolean = Type.builder().withName("boolean").build();
+        public static final Type Int = Type.builder().withName("int").build();
+        public static final Type Long = Type.builder().withName("long").build();
+        public static final Type Float = Type.builder().withName("float").build();
+        public static final Type Double = Type.builder().withName("double").build();
     }
 
     public static final class Java {
@@ -52,57 +52,57 @@ public final class Types {
 
         public static final class Io {
             public static final String PACKAGE = Java.PACKAGE + ".io";
-            public static final Type IOException = Type.builder().pkg(PACKAGE).name("IOException").build();
+            public static final Type IOException = Type.builder().withPackage(PACKAGE).withName("IOException").build();
         }
 
         public static final class Lang {
             public static final String PACKAGE = Java.PACKAGE + ".lang";
-            public static final Type String = Type.builder().pkg(PACKAGE).name("String").build();
-            public static final Type Character = Type.builder().pkg(PACKAGE).name("Character").build();
-            public static final Type Boolean = Type.builder().pkg(PACKAGE).name("Boolean").build();
-            public static final Type Byte = Type.builder().pkg(PACKAGE).name("Byte").build();
-            public static final Type Short = Type.builder().pkg(PACKAGE).name("Short").build();
-            public static final Type Integer = Type.builder().pkg(PACKAGE).name("Integer").build();
-            public static final Type Long = Type.builder().pkg(PACKAGE).name("Long").build();
-            public static final Type Float = Type.builder().pkg(PACKAGE).name("Float").build();
-            public static final Type Double = Type.builder().pkg(PACKAGE).name("Double").build();
-            public static final Type Object = Type.builder().pkg(PACKAGE).name("Object").build();
+            public static final Type String = Type.builder().withPackage(PACKAGE).withName("String").build();
+            public static final Type Character = Type.builder().withPackage(PACKAGE).withName("Character").build();
+            public static final Type Boolean = Type.builder().withPackage(PACKAGE).withName("Boolean").build();
+            public static final Type Byte = Type.builder().withPackage(PACKAGE).withName("Byte").build();
+            public static final Type Short = Type.builder().withPackage(PACKAGE).withName("Short").build();
+            public static final Type Integer = Type.builder().withPackage(PACKAGE).withName("Integer").build();
+            public static final Type Long = Type.builder().withPackage(PACKAGE).withName("Long").build();
+            public static final Type Float = Type.builder().withPackage(PACKAGE).withName("Float").build();
+            public static final Type Double = Type.builder().withPackage(PACKAGE).withName("Double").build();
+            public static final Type Object = Type.builder().withPackage(PACKAGE).withName("Object").build();
         }
 
         public static final class Util {
             public static final String PACKAGE = Java.PACKAGE + ".util";
-            public static final Type HashMap = Type.builder().pkg(PACKAGE).name("HashMap").build();
+            public static final Type HashMap = Type.builder().withPackage(PACKAGE).withName("HashMap").build();
 
             public static Type Map(Type keyType, Type valueType) {
                 return Map.withTypeParams(keyType, valueType);
             }
 
-            public static final Type Map = Type.builder().pkg(PACKAGE).name("Map").build();
+            public static final Type Map = Type.builder().withPackage(PACKAGE).withName("Map").build();
 
             public static Type MapEntry(Type keyType, Type valueType) {
-                return Type.builder().pkg(PACKAGE).name("Map.Entry").typeParams(keyType, valueType).build();
+                return Type.builder().withPackage(PACKAGE).withName("Map.Entry").withTypeParameters(keyType, valueType).build();
             }
 
             public static Type List(Type valueType) {
-                return Type.builder().pkg(PACKAGE).name("List").typeParams(valueType).build();
+                return Type.builder().withPackage(PACKAGE).withName("List").withTypeParameters(valueType).build();
             }
 
             public static final class Concurrent {
                 public static final String PACKAGE = Util.PACKAGE + ".concurrent";
-                public static final Type CompletableFuture = Type.builder().pkg(PACKAGE).name("CompletableFuture").build();
+                public static final Type CompletableFuture = Type.builder().withPackage(PACKAGE).withName("CompletableFuture").build();
             }
 
             public static final class Function {
                 public static final String PACKAGE = Util.PACKAGE + ".function";
 
                 public static Type Function(Type argType, Type returnType) {
-                    return Type.builder().pkg(PACKAGE).name("Function").typeParams(argType, returnType).build();
+                    return Type.builder().withPackage(PACKAGE).withName("Function").withTypeParameters(argType, returnType).build();
                 }
             }
 
             public static final class Stream {
                 public static final String PACKAGE = Util.PACKAGE + ".stream";
-                public static final Type Collectors = Type.builder().pkg(PACKAGE).name("Collectors").build();
+                public static final Type Collectors = Type.builder().withPackage(PACKAGE).withName("Collectors").build();
             }
         }
     }
@@ -112,8 +112,8 @@ public final class Types {
 
         public static final class Annotation {
             public static final String PACKAGE = Javax.PACKAGE + ".annotation";
-            public static final Type Generated = Type.builder().pkg(PACKAGE).name("Generated").build();
-            public static final Type Nullable = Type.builder().pkg(PACKAGE).name("Nullable").build();
+            public static final Type Generated = Type.builder().withPackage(PACKAGE).withName("Generated").build();
+            public static final Type Nullable = Type.builder().withPackage(PACKAGE).withName("Nullable").build();
         }
     }
 
@@ -124,20 +124,23 @@ public final class Types {
             return ApiClient.withTypeParams(transport, client);
         }
 
-        public static final Type ApiClient = Type.builder().pkg(PACKAGE).name("ApiClient").build();
+        public static final Type ApiClient = Type.builder().withPackage(PACKAGE).withName("ApiClient").build();
 
         public static final class Json {
             public static final String PACKAGE = Client.PACKAGE + ".json";
-            public static final Type JsonData = Type.builder().pkg(PACKAGE).name("JsonData").build();
-            public static final Type JsonpDeserializable = Type.builder().pkg(PACKAGE).name("JsonpDeserializable").build();
-            public static final Type JsonpDeserializer = Type.builder().pkg(PACKAGE).name("JsonpDeserializer").build();
-            public static final Type JsonEnum = Type.builder().pkg(PACKAGE).name("JsonEnum").build();
-            public static final Type JsonpMapper = Type.builder().pkg(PACKAGE).name("JsonpMapper").build();
-            public static final Type JsonpSerializable = Type.builder().pkg(PACKAGE).name("JsonpSerializable").build();
-            public static final Type ObjectBuilderDeserializer = Type.builder().pkg(PACKAGE).name("ObjectBuilderDeserializer").build();
-            public static final Type ObjectDeserializer = Type.builder().pkg(PACKAGE).name("ObjectDeserializer").build();
-            public static final Type PlainJsonSerializable = Type.builder().pkg(PACKAGE).name("PlainJsonSerializable").build();
-            public static final Type UnionDeserializer = Type.builder().pkg(PACKAGE).name("UnionDeserializer").build();
+            public static final Type JsonData = Type.builder().withPackage(PACKAGE).withName("JsonData").build();
+            public static final Type JsonpDeserializable = Type.builder().withPackage(PACKAGE).withName("JsonpDeserializable").build();
+            public static final Type JsonpDeserializer = Type.builder().withPackage(PACKAGE).withName("JsonpDeserializer").build();
+            public static final Type JsonEnum = Type.builder().withPackage(PACKAGE).withName("JsonEnum").build();
+            public static final Type JsonpMapper = Type.builder().withPackage(PACKAGE).withName("JsonpMapper").build();
+            public static final Type JsonpSerializable = Type.builder().withPackage(PACKAGE).withName("JsonpSerializable").build();
+            public static final Type ObjectBuilderDeserializer = Type.builder()
+                .withPackage(PACKAGE)
+                .withName("ObjectBuilderDeserializer")
+                .build();
+            public static final Type ObjectDeserializer = Type.builder().withPackage(PACKAGE).withName("ObjectDeserializer").build();
+            public static final Type PlainJsonSerializable = Type.builder().withPackage(PACKAGE).withName("PlainJsonSerializable").build();
+            public static final Type UnionDeserializer = Type.builder().withPackage(PACKAGE).withName("UnionDeserializer").build();
         }
 
         public static final class OpenSearch {
@@ -145,48 +148,48 @@ public final class Types {
 
             public static final class _Types {
                 public static final String PACKAGE = OpenSearch.PACKAGE + "._types";
-                public static final Type ErrorResponse = Type.builder().pkg(PACKAGE).name("ErrorResponse").build();
-                public static final Type OpenSearchException = Type.builder().pkg(PACKAGE).name("OpenSearchException").build();
-                public static final Type RequestBase = Type.builder().pkg(PACKAGE).name("RequestBase").build();
-                public static final Type Time = Type.builder().pkg(PACKAGE).name("Time").build();
+                public static final Type ErrorResponse = Type.builder().withPackage(PACKAGE).withName("ErrorResponse").build();
+                public static final Type OpenSearchException = Type.builder().withPackage(PACKAGE).withName("OpenSearchException").build();
+                public static final Type RequestBase = Type.builder().withPackage(PACKAGE).withName("RequestBase").build();
+                public static final Type Time = Type.builder().withPackage(PACKAGE).withName("Time").build();
             }
         }
 
         public static final class Transport {
             public static final String PACKAGE = Client.PACKAGE + ".transport";
-            public static final Type Endpoint = Type.builder().pkg(PACKAGE).name("Endpoint").build();
+            public static final Type Endpoint = Type.builder().withPackage(PACKAGE).withName("Endpoint").build();
 
             public static Type JsonEndpoint(Type requestType, Type responseType, Type errorType) {
                 return JsonEndpoint.withTypeParams(requestType, responseType, errorType);
             }
 
-            public static final Type JsonEndpoint = Type.builder().pkg(PACKAGE).name("JsonEndpoint").build();
-            public static final Type OpenSearchTransport = Type.builder().pkg(PACKAGE).name("OpenSearchTransport").build();
-            public static final Type TransportOptions = Type.builder().pkg(PACKAGE).name("TransportOptions").build();
+            public static final Type JsonEndpoint = Type.builder().withPackage(PACKAGE).withName("JsonEndpoint").build();
+            public static final Type OpenSearchTransport = Type.builder().withPackage(PACKAGE).withName("OpenSearchTransport").build();
+            public static final Type TransportOptions = Type.builder().withPackage(PACKAGE).withName("TransportOptions").build();
 
             public static final class Endpoints {
                 public static final String PACKAGE = Transport.PACKAGE + ".endpoints";
-                public static final Type SimpleEndpoint = Type.builder().pkg(PACKAGE).name("SimpleEndpoint").build();
+                public static final Type SimpleEndpoint = Type.builder().withPackage(PACKAGE).withName("SimpleEndpoint").build();
             }
         }
 
         public static final class Util {
             public static final String PACKAGE = Client.PACKAGE + ".util";
-            public static final Type ApiTypeHelper = Type.builder().pkg(PACKAGE).name("ApiTypeHelper").build();
+            public static final Type ApiTypeHelper = Type.builder().withPackage(PACKAGE).withName("ApiTypeHelper").build();
 
             public static Type ObjectBuilder(Type type) {
                 return ObjectBuilder.withTypeParams(type);
             }
 
-            public static final Type ObjectBuilder = Type.builder().pkg(PACKAGE).name("ObjectBuilder").build();
-            public static final Type ObjectBuilderBase = Type.builder().pkg(PACKAGE).name("ObjectBuilderBase").build();
+            public static final Type ObjectBuilder = Type.builder().withPackage(PACKAGE).withName("ObjectBuilder").build();
+            public static final Type ObjectBuilderBase = Type.builder().withPackage(PACKAGE).withName("ObjectBuilderBase").build();
 
             public static Type TaggedUnion(Type tagType, Type baseType) {
                 return TaggedUnion.withTypeParams(tagType, baseType);
             }
 
-            public static final Type TaggedUnion = Type.builder().pkg(PACKAGE).name("TaggedUnion").build();
-            public static final Type TaggedUnionUtils = Type.builder().pkg(PACKAGE).name("TaggedUnionUtils").build();
+            public static final Type TaggedUnion = Type.builder().withPackage(PACKAGE).withName("TaggedUnion").build();
+            public static final Type TaggedUnionUtils = Type.builder().withPackage(PACKAGE).withName("TaggedUnionUtils").build();
         }
     }
 
@@ -198,7 +201,7 @@ public final class Types {
 
             public static final class Stream {
                 public static final String PACKAGE = Json.PACKAGE + ".stream";
-                public static final Type JsonGenerator = Type.builder().pkg(PACKAGE).name("JsonGenerator").build();
+                public static final Type JsonGenerator = Type.builder().withPackage(PACKAGE).withName("JsonGenerator").build();
             }
         }
     }

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/openapi/OpenApiSchema.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/openapi/OpenApiSchema.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.jetbrains.annotations.NotNull;
 import org.opensearch.client.codegen.utils.Lists;
 import org.opensearch.client.codegen.utils.Maps;
 import org.opensearch.client.codegen.utils.ObjectBuilderBase;
@@ -360,7 +359,7 @@ public class OpenApiSchema extends OpenApiRefElement<OpenApiSchema> {
         }
 
         @Override
-        protected @NotNull Builder self() {
+        protected @Nonnull Builder self() {
             return this;
         }
 

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/openapi/OpenApiSchema.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/openapi/OpenApiSchema.java
@@ -21,8 +21,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
 import org.opensearch.client.codegen.utils.Lists;
 import org.opensearch.client.codegen.utils.Maps;
+import org.opensearch.client.codegen.utils.ObjectBuilderBase;
 import org.opensearch.client.codegen.utils.Sets;
 import org.opensearch.client.codegen.utils.Versions;
 import org.semver4j.Semver;
@@ -311,7 +313,7 @@ public class OpenApiSchema extends OpenApiRefElement<OpenApiSchema> {
         return new Builder();
     }
 
-    public static class Builder {
+    public static class Builder extends ObjectBuilderBase<OpenApiSchema, Builder> {
         @Nullable
         private OpenApiElement<?> parent;
         @Nullable
@@ -353,6 +355,15 @@ public class OpenApiSchema extends OpenApiRefElement<OpenApiSchema> {
         @Nullable
         private Semver versionRemoved;
 
+        private Builder() {
+            super(OpenApiSchema::new);
+        }
+
+        @Override
+        protected @NotNull Builder self() {
+            return this;
+        }
+
         @Nonnull
         public Builder withPointer(@Nonnull JsonPointer pointer) {
             this.pointer = Objects.requireNonNull(pointer, "pointer must not be null");
@@ -379,11 +390,6 @@ public class OpenApiSchema extends OpenApiRefElement<OpenApiSchema> {
         public Builder withAllOf(@Nullable List<OpenApiSchema> allOf) {
             this.allOf = allOf;
             return this;
-        }
-
-        @Nonnull
-        public OpenApiSchema build() {
-            return new OpenApiSchema(this);
         }
     }
 }

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/renderer/JavaCodeFormatter.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/renderer/JavaCodeFormatter.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import org.opensearch.client.codegen.exceptions.JavaFormatterException;
 import org.opensearch.client.codegen.utils.MavenArtifactResolver;
+import org.opensearch.client.codegen.utils.ObjectBuilderBase;
 
 public class JavaCodeFormatter implements AutoCloseable {
     private final Formatter formatter;
@@ -75,9 +76,18 @@ public class JavaCodeFormatter implements AutoCloseable {
         return new Builder();
     }
 
-    public static final class Builder {
+    public static final class Builder extends ObjectBuilderBase<JavaCodeFormatter, Builder> {
         private Path rootDir;
         private File eclipseFormatterConfig;
+
+        private Builder() {
+            super(JavaCodeFormatter::new);
+        }
+
+        @Override
+        protected @Nonnull Builder self() {
+            return this;
+        }
 
         @Nonnull
         public Builder withRootDir(@Nonnull Path rootDir) {
@@ -89,11 +99,6 @@ public class JavaCodeFormatter implements AutoCloseable {
         public Builder withEclipseFormatterConfig(@Nonnull File eclipseFormatterConfig) {
             this.eclipseFormatterConfig = Objects.requireNonNull(eclipseFormatterConfig, "eclipseFormatterConfig must not be null");
             return this;
-        }
-
-        @Nonnull
-        public JavaCodeFormatter build() {
-            return new JavaCodeFormatter(this);
         }
     }
 }

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/renderer/TemplateGlobalContext.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/renderer/TemplateGlobalContext.java
@@ -17,6 +17,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.text.StringEscapeUtils;
 import org.opensearch.client.codegen.model.Types;
 import org.opensearch.client.codegen.renderer.lambdas.TemplateStringLambda;
+import org.opensearch.client.codegen.utils.ObjectBuilderBase;
 import org.opensearch.client.codegen.utils.Strings;
 
 public final class TemplateGlobalContext implements Mustache.CustomContext {
@@ -53,9 +54,18 @@ public final class TemplateGlobalContext implements Mustache.CustomContext {
             .withValue("TYPES", Types.TYPES_MAP);
     }
 
-    public static final class Builder {
+    public static final class Builder extends ObjectBuilderBase<TemplateGlobalContext, Builder> {
         private final Map<String, Object> values = new HashMap<>();
         private TemplateRenderer renderer;
+
+        private Builder() {
+            super(TemplateGlobalContext::new);
+        }
+
+        @Override
+        protected @Nonnull Builder self() {
+            return this;
+        }
 
         @Nonnull
         public Builder withLambda(@Nonnull String name, @Nonnull TemplateStringLambda lambda) {
@@ -79,11 +89,6 @@ public final class TemplateGlobalContext implements Mustache.CustomContext {
         public Builder withRenderer(@Nonnull TemplateRenderer renderer) {
             this.renderer = Objects.requireNonNull(renderer, "renderer must not be null");
             return this;
-        }
-
-        @Nonnull
-        public TemplateGlobalContext build() {
-            return new TemplateGlobalContext(this);
         }
     }
 }

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/renderer/TemplateLoader.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/renderer/TemplateLoader.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import org.apache.commons.io.IOUtils;
+import org.opensearch.client.codegen.utils.ObjectBuilderBase;
 import org.opensearch.client.codegen.utils.Strings;
 
 public final class TemplateLoader implements Mustache.TemplateLoader {
@@ -57,8 +58,17 @@ public final class TemplateLoader implements Mustache.TemplateLoader {
         return new Builder();
     }
 
-    public static final class Builder {
+    public static final class Builder extends ObjectBuilderBase<TemplateLoader, Builder> {
         private String templatesResourceSubPath;
+
+        private Builder() {
+            super(TemplateLoader::new);
+        }
+
+        @Override
+        protected @Nonnull Builder self() {
+            return this;
+        }
 
         @Nonnull
         public Builder withTemplatesResourceSubPath(@Nonnull String templatesResourceSubPath) {
@@ -71,11 +81,6 @@ public final class TemplateLoader implements Mustache.TemplateLoader {
             }
             this.templatesResourceSubPath = templatesResourceSubPath;
             return this;
-        }
-
-        @Nonnull
-        public TemplateLoader build() {
-            return new TemplateLoader(this);
         }
     }
 }

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/renderer/TemplateRenderer.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/renderer/TemplateRenderer.java
@@ -23,6 +23,7 @@ import javax.annotation.Nonnull;
 import org.opensearch.client.codegen.exceptions.JavaFormatterException;
 import org.opensearch.client.codegen.exceptions.RenderException;
 import org.opensearch.client.codegen.model.Shape;
+import org.opensearch.client.codegen.utils.ObjectBuilderBase;
 
 public final class TemplateRenderer {
     @Nonnull
@@ -82,10 +83,19 @@ public final class TemplateRenderer {
         return new Builder();
     }
 
-    public static final class Builder {
+    public static final class Builder extends ObjectBuilderBase<TemplateRenderer, Builder> {
         private TemplateValueFormatter valueFormatter;
         private TemplateLoader templateLoader;
         private JavaCodeFormatter javaCodeFormatter;
+
+        private Builder() {
+            super(TemplateRenderer::new);
+        }
+
+        @Override
+        protected @Nonnull Builder self() {
+            return this;
+        }
 
         @Nonnull
         public Builder withValueFormatter(@Nonnull Function<TemplateValueFormatter.Builder, TemplateValueFormatter.Builder> configurator) {
@@ -105,11 +115,6 @@ public final class TemplateRenderer {
         public Builder withJavaCodeFormatter(@Nonnull JavaCodeFormatter javaCodeFormatter) {
             this.javaCodeFormatter = Objects.requireNonNull(javaCodeFormatter, "javaCodeFormatter must not be null");
             return this;
-        }
-
-        @Nonnull
-        public TemplateRenderer build() {
-            return new TemplateRenderer(this);
         }
     }
 }

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/renderer/TemplateValueFormatter.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/renderer/TemplateValueFormatter.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
+import org.opensearch.client.codegen.utils.ObjectBuilderBase;
 
 public final class TemplateValueFormatter implements Mustache.Formatter {
     @Nonnull
@@ -50,8 +51,17 @@ public final class TemplateValueFormatter implements Mustache.Formatter {
         return new Builder();
     }
 
-    public static final class Builder {
+    public static final class Builder extends ObjectBuilderBase<TemplateValueFormatter, Builder> {
         private final Map<Class<?>, Formatter<?>> formatters = new HashMap<>();
+
+        private Builder() {
+            super(TemplateValueFormatter::new);
+        }
+
+        @Override
+        protected @Nonnull Builder self() {
+            return this;
+        }
 
         @Nonnull
         public <T> Builder withFormatter(@Nonnull Class<T> clazz, @Nonnull Formatter<? super T> formatter) {
@@ -59,10 +69,6 @@ public final class TemplateValueFormatter implements Mustache.Formatter {
             Objects.requireNonNull(formatter, "formatter must not be null");
             formatters.put(clazz, formatter);
             return this;
-        }
-
-        public TemplateValueFormatter build() {
-            return new TemplateValueFormatter(this);
         }
     }
 }

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/utils/ObjectBuilder.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/utils/ObjectBuilder.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.codegen.utils;
+
+import javax.annotation.Nonnull;
+
+public interface ObjectBuilder<T> {
+    @Nonnull
+    T build();
+}

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/utils/ObjectBuilderBase.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/utils/ObjectBuilderBase.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.codegen.utils;
+
+import java.util.Objects;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+
+public abstract class ObjectBuilderBase<T, Self extends ObjectBuilderBase<T, Self>> implements ObjectBuilder<T> {
+    private final Function<Self, T> ctor;
+    private boolean _used = false;
+
+    protected ObjectBuilderBase(Function<Self, T> ctor) {
+        this.ctor = Objects.requireNonNull(ctor, "ctor must not be null");
+    }
+
+    @Nonnull
+    protected abstract Self self();
+
+    @Override
+    public @Nonnull T build() {
+        if (this._used) {
+            throw new IllegalStateException("Object builders can only be used once");
+        }
+        this._used = true;
+        return ctor.apply(self());
+    }
+}

--- a/java-codegen/src/main/resources/org/opensearch/client/codegen/templates/Client.mustache
+++ b/java-codegen/src/main/resources/org/opensearch/client/codegen/templates/Client.mustache
@@ -1,16 +1,20 @@
 {{>Partials/ClassDeclaration}} {
+{{^base}}
     public {{className}}({{TYPES.Client.Transport.OpenSearchTransport}} transport) {
         super(transport, null);
     }
 
+{{/base}}
     public {{className}}({{TYPES.Client.Transport.OpenSearchTransport}} transport, @{{TYPES.Javax.Annotation.Nullable}} {{TYPES.Client.Transport.TransportOptions}} transportOptions) {
         super(transport, transportOptions);
     }
+{{^base}}
 
     @Override
     public {{className}} withTransportOptions(@{{TYPES.Javax.Annotation.Nullable}} {{TYPES.Client.Transport.TransportOptions}} transportOptions) {
         return new {{className}}(this.transport, transportOptions);
     }
+{{/base}}
 {{#children}}
     {{#-first}}
 

--- a/java-codegen/src/main/resources/org/opensearch/client/codegen/templates/Partials/ClassDeclaration.mustache
+++ b/java-codegen/src/main/resources/org/opensearch/client/codegen/templates/Partials/ClassDeclaration.mustache
@@ -11,4 +11,4 @@
 @{{.}}
 {{/annotations}}
 @{{TYPES.Javax.Annotation.Generated}}("org.opensearch.client.codegen.CodeGenerator")
-public {{#abstract}}abstract {{/abstract}}{{classKind}} {{className}}{{#extendsType}} extends {{.}}{{/extendsType}}{{#implementsTypes}}{{#-first}} implements{{/-first}} {{.}}{{^-last}},{{/-last}}{{/implementsTypes}}
+public {{#abstract}}abstract {{/abstract}}{{classKind}} {{className}}{{#typeParameters}}{{.}}{{/typeParameters}}{{#extendsType}} extends {{.}}{{/extendsType}}{{#implementsTypes}}{{#-first}} implements{{/-first}} {{.}}{{^-last}},{{/-last}}{{/implementsTypes}}


### PR DESCRIPTION
### Description
Invert abstractness of generated vs "handwritten" client classes. For the client classes that are "split" between generated and not, makes the generated part the abstract/"Base" class. Moving definitions from the sub-class to the base class will be API compatible. This will make it feasible to backport the codegen to 2.x.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
