### PR TITLE
[Backport 2.x] Bump org.junit:junit-bom from 5.10.3 to 5.11.0 (#1176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
+- Bumps `org.junit:junit-bom` from 5.10.3 to 5.11.0
 
 ### Changed
 

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -171,7 +171,7 @@ dependencies {
     implementation("org.semver4j", "semver4j", "5.3.0")
 
     // EPL-2.0
-    testImplementation(platform("org.junit:junit-bom:5.10.3"))
+    testImplementation(platform("org.junit:junit-bom:5.11.0"))
     testImplementation("org.junit.jupiter", "junit-jupiter")
     testRuntimeOnly("org.junit.platform", "junit-platform-launcher")
 }


### PR DESCRIPTION
### Description
Backport #1176 via 5a9ea74b15a23c59a4ad75c6845dc3907992049b

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
