### PR TITLE
[Backport 2.x] Fix queries losing inherited data when toBuilder is called. (#1181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fix queries not preserving boost and name when converted to builders ([#1181](https://github.com/opensearch-project/opensearch-java/pull/1181))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/BoolQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/BoolQuery.java
@@ -172,7 +172,7 @@ public class BoolQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().filter(filter).minimumShouldMatch(minimumShouldMatch).must(must).mustNot(mustNot).should(should);
+        return toBuilder(new Builder()).filter(filter).minimumShouldMatch(minimumShouldMatch).must(must).mustNot(mustNot).should(should);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/BoostingQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/BoostingQuery.java
@@ -111,7 +111,7 @@ public class BoostingQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().negativeBoost(negativeBoost).negative(negative).positive(positive);
+        return toBuilder(new Builder()).negativeBoost(negativeBoost).negative(negative).positive(positive);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/CombinedFieldsQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/CombinedFieldsQuery.java
@@ -174,7 +174,7 @@ public class CombinedFieldsQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().fields(fields)
+        return toBuilder(new Builder()).fields(fields)
             .query(query)
             .autoGenerateSynonymsPhraseQuery(autoGenerateSynonymsPhraseQuery)
             .operator(operator)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/CommonTermsQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/CommonTermsQuery.java
@@ -183,7 +183,7 @@ public class CommonTermsQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field)
+        return toBuilder(new Builder()).field(field)
             .analyzer(analyzer)
             .cutoffFrequency(cutoffFrequency)
             .highFreqOperator(highFreqOperator)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/ConstantScoreQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/ConstantScoreQuery.java
@@ -85,7 +85,7 @@ public class ConstantScoreQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().filter(filter);
+        return toBuilder(new Builder()).filter(filter);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/DisMaxQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/DisMaxQuery.java
@@ -112,7 +112,7 @@ public class DisMaxQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().queries(queries).tieBreaker(tieBreaker);
+        return toBuilder(new Builder()).queries(queries).tieBreaker(tieBreaker);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/DistanceFeatureQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/DistanceFeatureQuery.java
@@ -112,7 +112,7 @@ public class DistanceFeatureQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().origin(origin).pivot(pivot).field(field);
+        return toBuilder(new Builder()).origin(origin).pivot(pivot).field(field);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/ExistsQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/ExistsQuery.java
@@ -85,7 +85,7 @@ public class ExistsQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field);
+        return toBuilder(new Builder()).field(field);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/FunctionScoreQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/FunctionScoreQuery.java
@@ -178,7 +178,7 @@ public class FunctionScoreQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().boostMode(boostMode)
+        return toBuilder(new Builder()).boostMode(boostMode)
             .functions(functions)
             .maxBoost(maxBoost)
             .minScore(minScore)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/FuzzyQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/FuzzyQuery.java
@@ -186,7 +186,7 @@ public class FuzzyQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field)
+        return toBuilder(new Builder()).field(field)
             .value(value)
             .maxExpansions(maxExpansions)
             .prefixLength(prefixLength)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/GeoBoundingBoxQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/GeoBoundingBoxQuery.java
@@ -149,7 +149,7 @@ public class GeoBoundingBoxQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field)
+        return toBuilder(new Builder()).field(field)
             .boundingBox(boundingBox)
             .type(type)
             .validationMethod(validationMethod)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/GeoDistanceQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/GeoDistanceQuery.java
@@ -147,7 +147,7 @@ public class GeoDistanceQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).location(location);
+        return toBuilder(new Builder()).field(field).location(location);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/GeoShapeQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/GeoShapeQuery.java
@@ -113,7 +113,7 @@ public class GeoShapeQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).shape(shape);
+        return toBuilder(new Builder()).field(field).shape(shape);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/HasChildQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/HasChildQuery.java
@@ -184,7 +184,7 @@ public class HasChildQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().ignoreUnmapped(ignoreUnmapped)
+        return toBuilder(new Builder()).ignoreUnmapped(ignoreUnmapped)
             .innerHits(innerHits)
             .maxChildren(maxChildren)
             .minChildren(minChildren)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/HasParentQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/HasParentQuery.java
@@ -152,7 +152,11 @@ public class HasParentQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().ignoreUnmapped(ignoreUnmapped).innerHits(innerHits).parentType(parentType).query(query).score(score);
+        return toBuilder(new Builder()).ignoreUnmapped(ignoreUnmapped)
+            .innerHits(innerHits)
+            .parentType(parentType)
+            .query(query)
+            .score(score);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/HybridQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/HybridQuery.java
@@ -56,7 +56,7 @@ public class HybridQuery extends QueryBase implements QueryVariant {
     }
 
     public HybridQuery.Builder toBuilder() {
-        return new HybridQuery.Builder().queries(queries);
+        return toBuilder(new Builder()).queries(queries);
     }
 
     public static class Builder extends QueryBase.AbstractBuilder<HybridQuery.Builder> implements ObjectBuilder<HybridQuery> {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/IdsQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/IdsQuery.java
@@ -95,7 +95,7 @@ public class IdsQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().values(values);
+        return toBuilder(new Builder()).values(values);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsQuery.java
@@ -252,7 +252,7 @@ public class IntervalsQuery extends QueryBase implements TaggedUnion<IntervalsQu
     }
 
     public Builder toBuilder() {
-        return new Builder()._kind(_kind)._value(_value).field(field);
+        return toBuilder(new Builder())._kind(_kind)._value(_value).field(field);
     }
 
     public static class Builder extends QueryBase.AbstractBuilder<Builder> implements ObjectBuilder<IntervalsQuery> {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQuery.java
@@ -108,7 +108,7 @@ public class KnnQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).vector(vector).k(k).filter(filter);
+        return toBuilder(new Builder()).field(field).vector(vector).k(k).filter(filter);
     }
 
     /**

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/MatchBoolPrefixQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/MatchBoolPrefixQuery.java
@@ -235,7 +235,7 @@ public class MatchBoolPrefixQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field)
+        return toBuilder(new Builder()).field(field)
             .analyzer(analyzer)
             .fuzziness(fuzziness)
             .fuzzyRewrite(fuzzyRewrite)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/MatchPhrasePrefixQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/MatchPhrasePrefixQuery.java
@@ -168,7 +168,7 @@ public class MatchPhrasePrefixQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field)
+        return toBuilder(new Builder()).field(field)
             .analyzer(analyzer)
             .maxExpansions(maxExpansions)
             .query(query)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/MatchPhraseQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/MatchPhraseQuery.java
@@ -151,7 +151,7 @@ public class MatchPhraseQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).analyzer(analyzer).query(query).slop(slop).zeroTermsQuery(zeroTermsQuery);
+        return toBuilder(new Builder()).field(field).analyzer(analyzer).query(query).slop(slop).zeroTermsQuery(zeroTermsQuery);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/MatchQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/MatchQuery.java
@@ -307,7 +307,7 @@ public class MatchQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field)
+        return toBuilder(new Builder()).field(field)
             .analyzer(analyzer)
             .autoGenerateSynonymsPhraseQuery(autoGenerateSynonymsPhraseQuery)
             .cutoffFrequency(cutoffFrequency)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/MoreLikeThisQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/MoreLikeThisQuery.java
@@ -415,7 +415,7 @@ public class MoreLikeThisQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().analyzer(analyzer)
+        return toBuilder(new Builder()).analyzer(analyzer)
             .boostTerms(boostTerms)
             .failOnUnsupportedField(failOnUnsupportedField)
             .fields(fields)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/MultiMatchQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/MultiMatchQuery.java
@@ -363,7 +363,7 @@ public class MultiMatchQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().analyzer(analyzer)
+        return toBuilder(new Builder()).analyzer(analyzer)
             .autoGenerateSynonymsPhraseQuery(autoGenerateSynonymsPhraseQuery)
             .cutoffFrequency(cutoffFrequency)
             .fields(fields)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/NestedQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/NestedQuery.java
@@ -151,7 +151,7 @@ public class NestedQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().ignoreUnmapped(ignoreUnmapped).innerHits(innerHits).path(path).query(query).scoreMode(scoreMode);
+        return toBuilder(new Builder()).ignoreUnmapped(ignoreUnmapped).innerHits(innerHits).path(path).query(query).scoreMode(scoreMode);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/NeuralQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/NeuralQuery.java
@@ -152,7 +152,7 @@ public class NeuralQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).queryText(queryText).queryImage(queryImage).k(k).modelId(modelId).filter(filter);
+        return toBuilder(new Builder()).field(field).queryText(queryText).queryImage(queryImage).k(k).modelId(modelId).filter(filter);
     }
 
     /**

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/ParentIdQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/ParentIdQuery.java
@@ -124,7 +124,7 @@ public class ParentIdQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().id(id).ignoreUnmapped(ignoreUnmapped).type(type);
+        return toBuilder(new Builder()).id(id).ignoreUnmapped(ignoreUnmapped).type(type);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/PercolateQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/PercolateQuery.java
@@ -228,7 +228,7 @@ public class PercolateQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().document(document)
+        return toBuilder(new Builder()).document(document)
             .documents(documents)
             .field(field)
             .id(id)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/PinnedQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/PinnedQuery.java
@@ -197,7 +197,7 @@ public class PinnedQuery extends QueryBase implements TaggedUnion<PinnedQuery.Ki
     }
 
     public Builder toBuilder() {
-        return new Builder()._kind(_kind)._value(_value).organic(organic);
+        return toBuilder(new Builder())._kind(_kind)._value(_value).organic(organic);
     }
 
     public static class Builder extends QueryBase.AbstractBuilder<Builder> {

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/PrefixQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/PrefixQuery.java
@@ -135,7 +135,7 @@ public class PrefixQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).value(value).rewrite(rewrite).value(value).caseInsensitive(caseInsensitive);
+        return toBuilder(new Builder()).field(field).value(value).rewrite(rewrite).value(value).caseInsensitive(caseInsensitive);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/QueryBase.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/QueryBase.java
@@ -98,6 +98,10 @@ public abstract class QueryBase implements PlainJsonSerializable {
 
     }
 
+    protected <BuilderT extends AbstractBuilder<BuilderT>> BuilderT toBuilder(BuilderT builder) {
+        return builder.queryName(queryName).boost(boost);
+    }
+
     protected abstract static class AbstractBuilder<BuilderT extends AbstractBuilder<BuilderT>> extends ObjectBuilderBase {
         @Nullable
         private Float boost;

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/QueryStringQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/QueryStringQuery.java
@@ -497,7 +497,7 @@ public class QueryStringQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().allowLeadingWildcard(allowLeadingWildcard)
+        return toBuilder(new Builder()).allowLeadingWildcard(allowLeadingWildcard)
             .analyzer(analyzer)
             .analyzeWildcard(analyzeWildcard)
             .autoGenerateSynonymsPhraseQuery(autoGenerateSynonymsPhraseQuery)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/RangeQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/RangeQuery.java
@@ -225,7 +225,7 @@ public class RangeQuery extends RangeQueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).gt(gt).gte(gte).lt(lt).lte(lte).from(from).to(to).format(format).timeZone(timeZone);
+        return toBuilder(new Builder()).field(field).gt(gt).gte(gte).lt(lt).lte(lte).from(from).to(to).format(format).timeZone(timeZone);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/RankFeatureQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/RankFeatureQuery.java
@@ -155,7 +155,7 @@ public class RankFeatureQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).saturation(saturation).log(log).linear(linear).sigmoid(sigmoid);
+        return toBuilder(new Builder()).field(field).saturation(saturation).log(log).linear(linear).sigmoid(sigmoid);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/RegexpQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/RegexpQuery.java
@@ -168,7 +168,7 @@ public class RegexpQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field)
+        return toBuilder(new Builder()).field(field)
             .value(value)
             .caseInsensitive(caseInsensitive)
             .flags(flags)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/ScriptQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/ScriptQuery.java
@@ -86,7 +86,7 @@ public class ScriptQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().script(script);
+        return toBuilder(new Builder()).script(script);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/ScriptScoreQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/ScriptScoreQuery.java
@@ -117,7 +117,7 @@ public class ScriptScoreQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().minScore(minScore).query(query).script(script);
+        return toBuilder(new Builder()).minScore(minScore).query(query).script(script);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SimpleQueryStringQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SimpleQueryStringQuery.java
@@ -294,7 +294,7 @@ public class SimpleQueryStringQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().analyzer(analyzer)
+        return toBuilder(new Builder()).analyzer(analyzer)
             .analyzeWildcard(analyzeWildcard)
             .autoGenerateSynonymsPhraseQuery(autoGenerateSynonymsPhraseQuery)
             .defaultOperator(defaultOperator)

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanContainingQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanContainingQuery.java
@@ -106,7 +106,7 @@ public class SpanContainingQuery extends QueryBase implements SpanQueryVariant, 
     }
 
     public Builder toBuilder() {
-        return new Builder().big(big).little(little);
+        return toBuilder(new Builder()).big(big).little(little);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanFieldMaskingQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanFieldMaskingQuery.java
@@ -106,7 +106,7 @@ public class SpanFieldMaskingQuery extends QueryBase implements SpanQueryVariant
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).query(query);
+        return toBuilder(new Builder()).field(field).query(query);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanFirstQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanFirstQuery.java
@@ -106,7 +106,7 @@ public class SpanFirstQuery extends QueryBase implements SpanQueryVariant, Query
     }
 
     public Builder toBuilder() {
-        return new Builder().end(end).match(match);
+        return toBuilder(new Builder()).end(end).match(match);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanMultiTermQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanMultiTermQuery.java
@@ -96,7 +96,7 @@ public class SpanMultiTermQuery extends QueryBase implements SpanQueryVariant, Q
     }
 
     public Builder toBuilder() {
-        return new Builder().match(match);
+        return toBuilder(new Builder()).match(match);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanNearQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanNearQuery.java
@@ -137,7 +137,7 @@ public class SpanNearQuery extends QueryBase implements SpanQueryVariant, QueryV
     }
 
     public Builder toBuilder() {
-        return new Builder().clauses(clauses).inOrder(inOrder).slop(slop);
+        return toBuilder(new Builder()).clauses(clauses).inOrder(inOrder).slop(slop);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanNotQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanNotQuery.java
@@ -159,7 +159,7 @@ public class SpanNotQuery extends QueryBase implements SpanQueryVariant, QueryVa
     }
 
     public Builder toBuilder() {
-        return new Builder().dist(dist).exclude(exclude).include(include).post(post).pre(pre);
+        return toBuilder(new Builder()).dist(dist).exclude(exclude).include(include).post(post).pre(pre);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanOrQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanOrQuery.java
@@ -102,7 +102,7 @@ public class SpanOrQuery extends QueryBase implements SpanQueryVariant, QueryVar
     }
 
     public Builder toBuilder() {
-        return new Builder().clauses(clauses);
+        return toBuilder(new Builder()).clauses(clauses);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanTermQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanTermQuery.java
@@ -107,7 +107,7 @@ public class SpanTermQuery extends QueryBase implements SpanQueryVariant, QueryV
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).value(value);
+        return toBuilder(new Builder()).field(field).value(value);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanWithinQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/SpanWithinQuery.java
@@ -106,7 +106,7 @@ public class SpanWithinQuery extends QueryBase implements SpanQueryVariant, Quer
     }
 
     public Builder toBuilder() {
-        return new Builder().big(big).little(little);
+        return toBuilder(new Builder()).big(big).little(little);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/TermQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/TermQuery.java
@@ -119,7 +119,7 @@ public class TermQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).value(value).caseInsensitive(caseInsensitive);
+        return toBuilder(new Builder()).field(field).value(value).caseInsensitive(caseInsensitive);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/TermsQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/TermsQuery.java
@@ -94,7 +94,7 @@ public class TermsQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).terms(terms);
+        return toBuilder(new Builder()).field(field).terms(terms);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/TermsSetQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/TermsSetQuery.java
@@ -144,7 +144,7 @@ public class TermsSetQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field)
+        return toBuilder(new Builder()).field(field)
             .minimumShouldMatchField(minimumShouldMatchField)
             .minimumShouldMatchScript(minimumShouldMatchScript)
             .terms(terms);

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/TypeQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/TypeQuery.java
@@ -85,7 +85,7 @@ public class TypeQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().value(value);
+        return toBuilder(new Builder()).value(value);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/WildcardQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/WildcardQuery.java
@@ -168,7 +168,12 @@ public class WildcardQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().field(field).value(value).caseInsensitive(caseInsensitive).rewrite(rewrite).value(value).wildcard(wildcard);
+        return toBuilder(new Builder()).field(field)
+            .value(value)
+            .caseInsensitive(caseInsensitive)
+            .rewrite(rewrite)
+            .value(value)
+            .wildcard(wildcard);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/WrapperQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/WrapperQuery.java
@@ -88,7 +88,7 @@ public class WrapperQuery extends QueryBase implements QueryVariant {
     }
 
     public Builder toBuilder() {
-        return new Builder().query(query);
+        return toBuilder(new Builder()).query(query);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/XyShapeQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/XyShapeQuery.java
@@ -112,7 +112,7 @@ public class XyShapeQuery extends QueryBase implements QueryVariant {
     }
 
     public XyShapeQuery.Builder toBuilder() {
-        return new XyShapeQuery.Builder().field(field).xyShape(xyShape);
+        return toBuilder(new Builder()).field(field).xyShape(xyShape);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/BoostingQueryTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/BoostingQueryTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch.model.ModelTestCase;
 
-public class BoostringQueryTest extends ModelTestCase {
+public class BoostingQueryTest extends ModelTestCase {
     @Test
     public void toBuilder() {
         BoostingQuery origin = new BoostingQuery.Builder().negativeBoost(1.0f)

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/MatchQueryTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/MatchQueryTest.java
@@ -15,7 +15,7 @@ import org.opensearch.client.opensearch.model.ModelTestCase;
 public class MatchQueryTest extends ModelTestCase {
     @Test
     public void toBuilder() {
-        MatchQuery origin = new MatchQuery.Builder().field("field").query(FieldValue.of("1")).build();
+        MatchQuery origin = new MatchQuery.Builder().field("field").query(FieldValue.of("1")).queryName("name").boost(5f).build();
         MatchQuery copied = origin.toBuilder().build();
 
         assertEquals(toJson(copied), toJson(origin));


### PR DESCRIPTION
### Description
Backport #1181 via 020e0b053cb0d33ec44a8692a3ae558178ecc160

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
