### PR TITLE
Bump org.apache.httpcomponents.core5:httpcore5 from 5.2.5 to 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `org.hamcrest:hamcrest` from 2.2 to 3.0
 - Bumps `com.github.jk1.dependency-license-report` from 2.8 to 2.9
 - Bumps `org.apache.httpcomponents.core5:httpcore5-h2` from 5.2.5 to 5.3
+- Bumps `org.apache.httpcomponents.core5:httpcore5` from 5.2.5 to 5.3
 
 This section is for maintaining a changelog for all breaking changes for the client that cannot be released in the 2.x line. All other non-breaking changes should be added to [Unreleased 2.x] section.
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -189,7 +189,7 @@ dependencies {
     api("org.apache.httpcomponents.client5:httpclient5:5.3.1") {
       exclude(group = "org.apache.httpcomponents.core5")
     }
-    api("org.apache.httpcomponents.core5:httpcore5:5.2.5")
+    api("org.apache.httpcomponents.core5:httpcore5:5.3")
     api("org.apache.httpcomponents.core5:httpcore5-h2:5.3")
 
     // Apache 2.0


### PR DESCRIPTION
### Description
Bump org.apache.httpcomponents.core5:httpcore5 from 5.2.5 to 5.3

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
