### PR TITLE
[Backport] [2.x] Bump org.apache.httpcomponents.core5:httpcore5 from 5.2.5 to 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bumps `org.junit:junit-bom` from 5.10.3 to 5.11.0
 - Bumps `org.apache.httpcomponents.core5:httpcore5-h2` from 5.2.5 to 5.3
+- Bumps `org.apache.httpcomponents.core5:httpcore5` from 5.2.5 to 5.3
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `org.junit:junit-bom` from 5.10.3 to 5.11.0
+- Bumps `org.apache.httpcomponents.core5:httpcore5-h2` from 5.2.5 to 5.3
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -210,7 +210,7 @@ dependencies {
       exclude(group = "org.apache.httpcomponents.core5")
     }
     implementation("org.apache.httpcomponents.core5", "httpcore5", "5.2.5")
-    implementation("org.apache.httpcomponents.core5", "httpcore5-h2", "5.2.5")
+    implementation("org.apache.httpcomponents.core5", "httpcore5-h2", "5.3")
 
     // For AwsSdk2Transport
     "awsSdk2SupportCompileOnly"("software.amazon.awssdk","sdk-core","[2.15,3.0)")

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -209,7 +209,7 @@ dependencies {
     implementation("org.apache.httpcomponents.client5", "httpclient5", "5.3.1") {
       exclude(group = "org.apache.httpcomponents.core5")
     }
-    implementation("org.apache.httpcomponents.core5", "httpcore5", "5.2.5")
+    implementation("org.apache.httpcomponents.core5", "httpcore5", "5.3")
     implementation("org.apache.httpcomponents.core5", "httpcore5-h2", "5.3")
 
     // For AwsSdk2Transport


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1194 and https://github.com/opensearch-project/opensearch-java/pull/1192 to `2.x`