### PR TITLE
[Backport] [2.x] Bump org.apache.httpcomponents.client5:httpclient5 from 5.3.1 to 5.4 (#1204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `org.junit:junit-bom` from 5.10.3 to 5.11.0
 - Bumps `org.apache.httpcomponents.core5:httpcore5-h2` from 5.2.5 to 5.3
 - Bumps `org.apache.httpcomponents.core5:httpcore5` from 5.2.5 to 5.3
+- Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.3.1 to 5.4
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -206,7 +206,7 @@ dependencies {
     testImplementation("com.fasterxml.jackson.datatype", "jackson-datatype-jakarta-jsonp", jacksonVersion)
 
     // ApacheHttpClient5Transport dependencies (optional)
-    implementation("org.apache.httpcomponents.client5", "httpclient5", "5.3.1") {
+    implementation("org.apache.httpcomponents.client5", "httpclient5", "5.4") {
       exclude(group = "org.apache.httpcomponents.core5")
     }
     implementation("org.apache.httpcomponents.core5", "httpcore5", "5.3")


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1204 to `2.x`