### PR TITLE
[Backport] [2.x] Bump io.github.classgraph:classgraph from 4.8.175 to 4.8.176 in /java-client (#1203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `org.apache.httpcomponents.core5:httpcore5-h2` from 5.2.5 to 5.3
 - Bumps `org.apache.httpcomponents.core5:httpcore5` from 5.2.5 to 5.3
 - Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.3.1 to 5.4
+- Bumps `io.github.classgraph:classgraph` from 4.8.175 to 4.8.176
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -228,7 +228,7 @@ dependencies {
     implementation("org.eclipse", "yasson", "2.0.2")
 
     // https://github.com/classgraph/classgraph
-    testImplementation("io.github.classgraph:classgraph:4.8.175")
+    testImplementation("io.github.classgraph:classgraph:4.8.176")
 
     // Eclipse 1.0
     testImplementation("junit", "junit" , "4.13.2") {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1203 to `2.x`