### PR TITLE
[Backport] [2.x] Bump org.junit:junit-bom from 5.11.0 to 5.11.1 (#1211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
-- Bumps `org.junit:junit-bom` from 5.10.3 to 5.11.0
+- Bumps `org.junit:junit-bom` from 5.10.3 to 5.11.1
 - Bumps `org.apache.httpcomponents.core5:httpcore5-h2` from 5.2.5 to 5.3
 - Bumps `org.apache.httpcomponents.core5:httpcore5` from 5.2.5 to 5.3
 - Bumps `org.apache.httpcomponents.client5:httpclient5` from 5.3.1 to 5.4

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -172,7 +172,7 @@ dependencies {
     implementation("org.semver4j", "semver4j", "5.3.0")
 
     // EPL-2.0
-    testImplementation(platform("org.junit:junit-bom:5.11.0"))
+    testImplementation(platform("org.junit:junit-bom:5.11.1"))
     testImplementation("org.junit.jupiter", "junit-jupiter")
     testRuntimeOnly("org.junit.platform", "junit-platform-launcher")
 }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1211 to `2.x`