### PR TITLE
[Backport 2.x] Bump org.ajoberstar.grgit:grgit-gradle from 5.2.2 to 5.3.0 (#1237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
+- Bumps `org.ajoberstar.grgit:grgit-gradle` from 5.2.2 to 5.3.0
 
 ### Changed
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -42,7 +42,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.ajoberstar.grgit:grgit-gradle:5.2.2")
+    implementation("org.ajoberstar.grgit:grgit-gradle:5.3.0")
     implementation("com.diffplug.spotless", "spotless-plugin-gradle", "6.25.0")
 }
 


### PR DESCRIPTION
### Description
Backport #1237 via 48220eb01db7b2b2881b6c5697395d35c0ad77c9

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
