### PR TITLE
[Backport] [2.x] Bump org.apache.httpcomponents.core5:httpcore5-h2 from 5.3 to 5.3.1 in /java-client (#1251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
+- Bumps `org.apache.httpcomponents.core5:httpcore5-h2` from 5.3 to 5.3.1
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -210,7 +210,7 @@ dependencies {
       exclude(group = "org.apache.httpcomponents.core5")
     }
     implementation("org.apache.httpcomponents.core5", "httpcore5", "5.3")
-    implementation("org.apache.httpcomponents.core5", "httpcore5-h2", "5.3")
+    implementation("org.apache.httpcomponents.core5", "httpcore5-h2", "5.3.1")
 
     // For AwsSdk2Transport
     "awsSdk2SupportCompileOnly"("software.amazon.awssdk","sdk-core","[2.15,3.0)")


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1251 to `2.x`