### PR TITLE
[Backport] [2.x] Bump org.owasp.dependencycheck from 11.0.0 to 11.1.0 (#1258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `org.apache.httpcomponents.core5:httpcore5-h2` from 5.3 to 5.3.1
+- Bumps `org.owasp.dependencycheck` from 10.0.2 to 11.1.0
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -48,8 +48,8 @@ plugins {
     java
     `java-library`
     `maven-publish`
-    id("com.github.jk1.dependency-license-report") version "2.8"
-    id("org.owasp.dependencycheck") version "10.0.2"
+    id("com.github.jk1.dependency-license-report") version "2.9"
+    id("org.owasp.dependencycheck") version "11.1.0"
 
     id("opensearch-java.spotless-conventions")
 }

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -31,7 +31,7 @@ buildscript {
 plugins {
     application
     id("com.github.jk1.dependency-license-report") version "2.9"
-    id("org.owasp.dependencycheck") version "10.0.4"
+    id("org.owasp.dependencycheck") version "11.1.0"
     id("de.undercouch.download") version "5.6.0"
 
     id("opensearch-java.spotless-conventions")


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1258 to `2.x`