### PR TITLE
Add dependabot config to auto-update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,27 @@
 updates:
   - directory: /
-    open-pull-requests-limit: 1
     package-ecosystem: gradle
+    open-pull-requests-limit: 3
     schedule:
       interval: weekly
     labels:
       - "dependabot"
       - "dependencies"
   - directory: /java-client/
-    open-pull-requests-limit: 1
     package-ecosystem: gradle
+    open-pull-requests-limit: 3
     schedule:
       interval: weekly
     labels:
       - "dependabot"
       - "dependencies"
+  - directory: /
+    package-ecosystem: github-actions
+    open-pull-requests-limit: 3
+    schedule:
+      interval: weekly
+    labels:
+      - "dependabot"
+      - "dependencies"
+      - "github-actions"
 version: 2

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'github-actions') }}
     steps:
       - name: GitHub App token
         id: github_app_token


### PR DESCRIPTION
### Description
Add dependabot config to auto-update GitHub Actions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
