### PR TITLE
Add `batch_size` param for `text_embedding` processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ## [Unreleased 2.x]
 
 ### Added
+- Add `batch_size` param for `text_embedding` processor [(#1298)](https://github.com/opensearch-project/opensearch-java/pull/1298)
 
 ### Dependencies
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/ingest/TextEmbeddingProcessor.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/ingest/TextEmbeddingProcessor.java
@@ -171,6 +171,9 @@ public class TextEmbeddingProcessor extends ProcessorBase implements ProcessorVa
          * API name: {@code batch_size}
          */
         public final Builder batchSize(@Nullable Integer value) {
+            if (value != null && value <= 0) {
+                throw new IllegalArgumentException("batchSize must be a positive integer");
+            }
             this.batchSize = value;
             return this;
         }

--- a/java-client/src/main/java/org/opensearch/client/opensearch/ingest/TextEmbeddingProcessor.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/ingest/TextEmbeddingProcessor.java
@@ -31,6 +31,9 @@ public class TextEmbeddingProcessor extends ProcessorBase implements ProcessorVa
     @Nullable
     private final String description;
 
+    @Nullable
+    private final Integer batchSize;
+
     // ---------------------------------------------------------------------------------------------
 
     private TextEmbeddingProcessor(Builder builder) {
@@ -39,7 +42,7 @@ public class TextEmbeddingProcessor extends ProcessorBase implements ProcessorVa
         this.modelId = ApiTypeHelper.requireNonNull(builder.modelId, this, "modelId");
         this.fieldMap = ApiTypeHelper.unmodifiableRequired(builder.fieldMap, this, "fieldMap");
         this.description = builder.description;
-
+        this.batchSize = builder.batchSize;
     }
 
     public static TextEmbeddingProcessor of(Function<Builder, ObjectBuilder<TextEmbeddingProcessor>> fn) {
@@ -76,6 +79,14 @@ public class TextEmbeddingProcessor extends ProcessorBase implements ProcessorVa
         return this.description;
     }
 
+    /**
+     * API name: {@code batch_size}
+     */
+    @Nullable
+    public final Integer batchSize() {
+        return this.batchSize;
+    }
+
     protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
         super.serializeInternal(generator, mapper);
@@ -96,7 +107,10 @@ public class TextEmbeddingProcessor extends ProcessorBase implements ProcessorVa
             generator.writeKey("description");
             generator.write(this.description);
         }
-
+        if (this.batchSize != null) {
+            generator.writeKey("batch_size");
+            generator.write(this.batchSize);
+        }
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -113,6 +127,9 @@ public class TextEmbeddingProcessor extends ProcessorBase implements ProcessorVa
 
         @Nullable
         private String description;
+
+        @Nullable
+        private Integer batchSize;
 
         /**
          * Required - API name: {@code model_id}
@@ -150,6 +167,14 @@ public class TextEmbeddingProcessor extends ProcessorBase implements ProcessorVa
             return this;
         }
 
+        /**
+         * API name: {@code batch_size}
+         */
+        public final Builder batchSize(@Nullable Integer value) {
+            this.batchSize = value;
+            return this;
+        }
+
         @Override
         protected Builder self() {
             return this;
@@ -183,6 +208,7 @@ public class TextEmbeddingProcessor extends ProcessorBase implements ProcessorVa
         op.add(Builder::modelId, JsonpDeserializer.stringDeserializer(), "model_id");
         op.add(Builder::fieldMap, JsonpDeserializer.stringMapDeserializer(JsonpDeserializer.stringDeserializer()), "field_map");
         op.add(Builder::description, JsonpDeserializer.stringDeserializer(), "description");
+        op.add(Builder::batchSize, JsonpDeserializer.integerDeserializer(), "batch_size");
     }
 
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/ingest/TextEmbeddingProcessorTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/ingest/TextEmbeddingProcessorTest.java
@@ -37,7 +37,7 @@ public class TextEmbeddingProcessorTest extends ModelTestCase {
         assertEquals(baseFieldMap, deserialized.fieldMap());
         assertEquals("processor-description", deserialized.description());
         assertEquals("some-tag", deserialized.tag());
-        assert deserialized.batchSize() != null;
+        assertNotNull(deserialized.batchSize());
         assertEquals(1, deserialized.batchSize().intValue());
     }
 
@@ -54,7 +54,7 @@ public class TextEmbeddingProcessorTest extends ModelTestCase {
         assertEquals(baseFieldMap, deserialized.fieldMap());
         assertNull(deserialized.description());
         assertEquals("some-tag", deserialized.tag());
-        assert deserialized.batchSize() != null;
+        assertNotNull(deserialized.batchSize());
         assertEquals(1, deserialized.batchSize().intValue());
     }
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/ingest/TextEmbeddingProcessorTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/ingest/TextEmbeddingProcessorTest.java
@@ -25,7 +25,41 @@ public class TextEmbeddingProcessorTest extends ModelTestCase {
     }
 
     @Test
-    public void testJsonRoundtripWithDescription() {
+    public void testJsonRoundtripWithDescriptionAndBatchSize() {
+        Processor processor = new Processor.Builder().textEmbedding(
+            baseTextEmbeddingProcessor().description("processor-description").batchSize(1).build()
+        ).build();
+        String json =
+            "{\"text_embedding\":{\"tag\":\"some-tag\",\"model_id\":\"modelId\",\"field_map\":{\"input_field\":\"vector_field\"},\"description\":\"processor-description\",\"batch_size\":1}}";
+        TextEmbeddingProcessor deserialized = checkJsonRoundtrip(processor, json).textEmbedding();
+
+        assertEquals("modelId", deserialized.modelId());
+        assertEquals(baseFieldMap, deserialized.fieldMap());
+        assertEquals("processor-description", deserialized.description());
+        assertEquals("some-tag", deserialized.tag());
+        assert deserialized.batchSize() != null;
+        assertEquals(1, deserialized.batchSize().intValue());
+    }
+
+    @Test
+    public void testJsonRoundtripWithoutDescription() {
+        Processor processor = new Processor.Builder().textEmbedding(
+            baseTextEmbeddingProcessor().batchSize(1).build()
+        ).build();
+        String json =
+            "{\"text_embedding\":{\"tag\":\"some-tag\",\"model_id\":\"modelId\",\"field_map\":{\"input_field\":\"vector_field\"},\"batch_size\":1}}";
+        TextEmbeddingProcessor deserialized = checkJsonRoundtrip(processor, json).textEmbedding();
+
+        assertEquals("modelId", deserialized.modelId());
+        assertEquals(baseFieldMap, deserialized.fieldMap());
+        assertNull(deserialized.description());
+        assertEquals("some-tag", deserialized.tag());
+        assert deserialized.batchSize() != null;
+        assertEquals(1, deserialized.batchSize().intValue());
+    }
+
+    @Test
+    public void testJsonRoundtripWithoutBatchSize() {
         Processor processor = new Processor.Builder().textEmbedding(
             baseTextEmbeddingProcessor().description("processor-description").build()
         ).build();
@@ -37,18 +71,6 @@ public class TextEmbeddingProcessorTest extends ModelTestCase {
         assertEquals(baseFieldMap, deserialized.fieldMap());
         assertEquals("processor-description", deserialized.description());
         assertEquals("some-tag", deserialized.tag());
-    }
-
-    @Test
-    public void testJsonRoundtripWithoutDescription() {
-        Processor processor = new Processor.Builder().textEmbedding(baseTextEmbeddingProcessor().build()).build();
-        String json =
-            "{\"text_embedding\":{\"tag\":\"some-tag\",\"model_id\":\"modelId\",\"field_map\":{\"input_field\":\"vector_field\"}}}";
-        TextEmbeddingProcessor deserialized = checkJsonRoundtrip(processor, json).textEmbedding();
-
-        assertEquals("modelId", deserialized.modelId());
-        assertEquals(baseFieldMap, deserialized.fieldMap());
-        assertNull(deserialized.description());
-        assertEquals("some-tag", deserialized.tag());
+        assertNull(deserialized.batchSize());
     }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/ingest/TextEmbeddingProcessorTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/ingest/TextEmbeddingProcessorTest.java
@@ -43,9 +43,7 @@ public class TextEmbeddingProcessorTest extends ModelTestCase {
 
     @Test
     public void testJsonRoundtripWithoutDescription() {
-        Processor processor = new Processor.Builder().textEmbedding(
-            baseTextEmbeddingProcessor().batchSize(1).build()
-        ).build();
+        Processor processor = new Processor.Builder().textEmbedding(baseTextEmbeddingProcessor().batchSize(1).build()).build();
         String json =
             "{\"text_embedding\":{\"tag\":\"some-tag\",\"model_id\":\"modelId\",\"field_map\":{\"input_field\":\"vector_field\"},\"batch_size\":1}}";
         TextEmbeddingProcessor deserialized = checkJsonRoundtrip(processor, json).textEmbedding();
@@ -77,16 +75,12 @@ public class TextEmbeddingProcessorTest extends ModelTestCase {
     @Test
     public void testInvalidBatchSizeThrowsException() {
         IllegalArgumentException exceptionWhenBatchSizeIsZero = assertThrows(IllegalArgumentException.class, () -> {
-            new Processor.Builder().textEmbedding(
-                    baseTextEmbeddingProcessor().batchSize(0).build()
-            ).build();
+            new Processor.Builder().textEmbedding(baseTextEmbeddingProcessor().batchSize(0).build()).build();
         });
         assertEquals("batchSize must be a positive integer", exceptionWhenBatchSizeIsZero.getMessage());
 
         IllegalArgumentException exceptionWhenBatchSizeIsNegative = assertThrows(IllegalArgumentException.class, () -> {
-            new Processor.Builder().textEmbedding(
-                    baseTextEmbeddingProcessor().batchSize(-1).build()
-            ).build();
+            new Processor.Builder().textEmbedding(baseTextEmbeddingProcessor().batchSize(-1).build()).build();
         });
         assertEquals("batchSize must be a positive integer", exceptionWhenBatchSizeIsNegative.getMessage());
     }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/ingest/TextEmbeddingProcessorTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/ingest/TextEmbeddingProcessorTest.java
@@ -73,4 +73,21 @@ public class TextEmbeddingProcessorTest extends ModelTestCase {
         assertEquals("some-tag", deserialized.tag());
         assertNull(deserialized.batchSize());
     }
+
+    @Test
+    public void testInvalidBatchSizeThrowsException() {
+        IllegalArgumentException exceptionWhenBatchSizeIsZero = assertThrows(IllegalArgumentException.class, () -> {
+            new Processor.Builder().textEmbedding(
+                    baseTextEmbeddingProcessor().batchSize(0).build()
+            ).build();
+        });
+        assertEquals("batchSize must be a positive integer", exceptionWhenBatchSizeIsZero.getMessage());
+
+        IllegalArgumentException exceptionWhenBatchSizeIsNegative = assertThrows(IllegalArgumentException.class, () -> {
+            new Processor.Builder().textEmbedding(
+                    baseTextEmbeddingProcessor().batchSize(-1).build()
+            ).build();
+        });
+        assertEquals("batchSize must be a positive integer", exceptionWhenBatchSizeIsNegative.getMessage());
+    }
 }


### PR DESCRIPTION
### Description
Unlike the [document](https://opensearch.org/docs/latest/ingest-pipelines/processors/text-embedding/#configuration-parameters) from **text_embedding** processor in ingest-pipelines describes `batch_size` parameter, interface in opensearch-java client doesn't include it. From [OpenSearch 2.16](https://opensearch.org/blog/introducing-opensearch-2-16/), it's possible to add [batch inference support](https://opensearch.org/docs/latest/ml-commons-plugin/api/model-apis/batch-predict/) in ingest processors which inherits from AbstractBatchingProcessor(https://github.com/opensearch-project/neural-search/pull/820). From now on, OpenSearch java client doesn't support batch_size parameter(optional) when defining text_embedding processor.

Since @miguel-vila's contribution by adding TextEmbeddingProcessor has been merged, there was another big change in opensearch-project/neural-search(https://github.com/opensearch-project/neural-search/pull/820). In line with this change, I attempted to modify the code of the text_embedding processor of the opensearch-java client.

### Issues Resolved
This PR is related to https://github.com/opensearch-project/opensearch-java/issues/1297

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
