### PR TITLE
Implement SortOptionsVariant in FieldSort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Removed
 
 ### Fixed
+- Fixed an issue where `FieldSort` was not implementing `SortOptionsVariant` ([#1323](https://github.com/opensearch-project/opensearch-java/pull/1323))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/FieldSort.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/FieldSort.java
@@ -49,7 +49,7 @@ import org.opensearch.client.util.ObjectBuilderBase;
 // typedef: _types.FieldSort
 
 @JsonpDeserializable
-public class FieldSort implements PlainJsonSerializable {
+public class FieldSort implements SortOptionsVariant, PlainJsonSerializable {
     // Single key dictionary
     private final String field;
 
@@ -92,6 +92,14 @@ public class FieldSort implements PlainJsonSerializable {
 
     public static FieldSort of(Function<Builder, ObjectBuilder<FieldSort>> fn) {
         return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * SortOptions variant kind.
+     */
+    @Override
+    public SortOptions.Kind _sortOptionsKind() {
+        return SortOptions.Kind.Field;
     }
 
     /**


### PR DESCRIPTION
### Description
Implemented `SortOptionsVariant` in `FieldSort` to make it usable with `SortOptionsBuilders`.

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-java/issues/1089

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
