### PR TITLE
Fix toJsonString default mapper serialize type (#1309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fixed `IcuCollationDecomposition`'s variants to align with those supported by OpenSearch ([#]())
+- Fixed don't invoke the mapper's serialize method for the RangeQuery JsonData raw value [#1309](https://github.com/opensearch-project/opensearch-java/pull/1309)
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/json/JsonDataImpl.java
+++ b/java-client/src/main/java/org/opensearch/client/json/JsonDataImpl.java
@@ -37,6 +37,8 @@ import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
 class JsonDataImpl implements JsonData {
     private final Object value;
@@ -109,6 +111,24 @@ class JsonDataImpl implements JsonData {
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         if (value instanceof JsonValue) {
             generator.write((JsonValue) value);
+        } else if (value instanceof String) {
+            generator.write((String) value);
+        } else if (value instanceof BigDecimal) {
+            generator.write((BigDecimal) value);
+        } else if (value instanceof BigInteger) {
+            generator.write((BigInteger) value);
+        } else if (value instanceof Short) {
+            generator.write((Short) value);
+        } else if (value instanceof Integer) {
+            generator.write((Integer) value);
+        } else if (value instanceof Long) {
+            generator.write((Long) value);
+        } else if (value instanceof Float) {
+            generator.write((Float) value);
+        } else if (value instanceof Double) {
+            generator.write((Double) value);
+        } else if (value instanceof Boolean) {
+            generator.write((Boolean) value);
         } else {
             // Mapper provided at creation time has precedence
             (this.mapper != null ? this.mapper : mapper).serialize(value, generator);

--- a/java-client/src/main/java/org/opensearch/client/json/JsonpUtils.java
+++ b/java-client/src/main/java/org/opensearch/client/json/JsonpUtils.java
@@ -80,7 +80,6 @@ public class JsonpUtils {
                 ((JsonpSerializable) value).serialize(generator, this);
                 return;
             }
-
             throw new JsonException(
                 "Cannot find a serializer for type " + value.getClass().getName() + ". Consider using a full-featured JsonpMapper."
             );

--- a/java-client/src/test/java/org/opensearch/client/opensearch/json/JsonpMapperTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/json/JsonpMapperTest.java
@@ -51,11 +51,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Test;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch.IOUtils;
+import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.model.ModelTestCase;
 
 public class JsonpMapperTest extends Assert {
@@ -240,4 +242,29 @@ public class JsonpMapperTest extends Assert {
             this.children = children;
         }
     }
+
+    @Test
+    public void testRangeQuery() {
+
+        String expectedStringValue =
+            "{\"aggregations\":{},\"query\":{\"range\":{\"rangeField\":{\"gte\":10.5,\"lte\":30,\"from\":\"2024-01-01T00:00:00Z\",\"format\":\"strict_date_optional_time\"}}},\"terminate_after\":5}";
+
+        SearchRequest searchRequest = SearchRequest.of(
+            request -> request.index("index1", "index2")
+                .aggregations(Collections.emptyMap())
+                .terminateAfter(5L)
+                .query(
+                    q -> q.range(
+                        r -> r.field("rangeField")
+                            .gte(JsonData.of(10.5))
+                            .lte(JsonData.of(30))
+                            .from(JsonData.of("2024-01-01T00:00:00Z"))
+                            .format("strict_date_optional_time")
+                    )
+                )
+        );
+        String searchRequestString = searchRequest.toJsonString();
+        assertEquals(expectedStringValue, searchRequestString);
+    }
+
 }


### PR DESCRIPTION
* fix toJsonString default mapper serialize type

Signed-off-by: Leo <yggb159@gmail.com>

* test range query JsonData type value

Signed-off-by: Leo <yggb159@gmail.com>

* refactor don't invoke the mapper's serialize method for the RangeQuery JsonData raw value

Signed-off-by: Leo <yggb159@gmail.com>

* update CHANGELOG #1309 PR

Signed-off-by: Leo <yggb159@gmail.com>

* add JsonDataImpl serialize value type

Signed-off-by: Leo <yggb159@gmail.com>

---------

Signed-off-by: Leo <yggb159@gmail.com>
Signed-off-by: Thomas Farr <tsfarr@amazon.com>
Co-authored-by: Leo <yggb159@gmail.com>
Co-authored-by: Thomas Farr <tsfarr@amazon.com>
(cherry picked from commit ca3d488366e72f6d6dce33266c88a6841996332f)

### Description
BUG Fixed don't invoke the mapper's serialize method for the JsonData raw value [#1309](https://github.com/opensearch-project/opensearch-java/pull/1309)

### Issues Resolved
This PR is related to (#1171)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
