### PR TITLE
[Backport] [2.x] Bump com.carrotsearch.randomizedtesting:randomizedtesting-runner from 2.8.1 to 2.8.2 (#1343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bumps `org.junit:junit-bom` from 5.10.2 to 5.11.3
+- Bump `com.carrotsearch.randomizedtesting:randomizedtesting-runner` from 2.8.1 to 2.8.2 ([#1343](https://github.com/opensearch-project/opensearch-java/pull/1343))
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -183,7 +183,7 @@ dependencies {
     api("commons-logging:commons-logging:1.3.4")
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)
     testImplementation("org.hamcrest:hamcrest:2.2")
-    testImplementation("com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.8.1") {
+    testImplementation("com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.8.2") {
         exclude(group = "junit")
     }
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1343 to `2.x`