### PR TITLE
[Backport 2.x] Bump org.owasp.dependencycheck from 11.1.0 to 11.1.1 (#1344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bumps `org.junit:junit-bom` from 5.10.2 to 5.11.3
 - Bump `com.carrotsearch.randomizedtesting:randomizedtesting-runner` from 2.8.1 to 2.8.2 ([#1343](https://github.com/opensearch-project/opensearch-java/pull/1343))
+- Bump `org.owasp.dependencycheck` from 11.1.0 to 11.1.1 ([#1344](https://github.com/opensearch-project/opensearch-java/pull/1344))
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -49,7 +49,7 @@ plugins {
     `java-library`
     `maven-publish`
     id("com.github.jk1.dependency-license-report") version "2.9"
-    id("org.owasp.dependencycheck") version "11.1.0"
+    id("org.owasp.dependencycheck") version "11.1.1"
 
     id("opensearch-java.spotless-conventions")
 }

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -31,7 +31,7 @@ buildscript {
 plugins {
     application
     id("com.github.jk1.dependency-license-report") version "2.9"
-    id("org.owasp.dependencycheck") version "11.1.0"
+    id("org.owasp.dependencycheck") version "11.1.1"
     id("de.undercouch.download") version "5.6.0"
 
     id("opensearch-java.spotless-conventions")


### PR DESCRIPTION
### Description
Backport #1344 via 6816e7ec26b7e97229ad4e39b674013bdf8d51b3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
