### PR TITLE
Fix serialization of nested aggregates under `SingleBucketAggregateBase`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 - Fixed don't invoke the mapper's serialize method for the RangeQuery JsonData raw value ([#1309](https://github.com/opensearch-project/opensearch-java/pull/1309))
 - Fixed `GetSnapshotResponse` deserialization ([#1299](https://github.com/opensearch-project/opensearch-java/pull/1299))
 - Fixed `CreateSnapshotResponse` deserialization when wait_for_completion is false  ([#1332](https://github.com/opensearch-project/opensearch-java/pull/1332))
+- Fixed serialization of nested aggregates under `SingleBucketAggregateBase` ([#1350](https://github.com/opensearch-project/opensearch-java/pull/1350))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/aggregations/SingleBucketAggregateBase.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/aggregations/SingleBucketAggregateBase.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import javax.annotation.Nullable;
+import org.opensearch.client.json.ExternallyTaggedUnion;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.ObjectDeserializer;
@@ -71,8 +72,10 @@ public abstract class SingleBucketAggregateBase extends AggregateBase {
     }
 
     protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
-
         super.serializeInternal(generator, mapper);
+
+        ExternallyTaggedUnion.serializeTypedKeysInner(this.aggregations, generator, mapper);
+
         generator.writeKey("doc_count");
         generator.write(this.docCount);
 

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/aggregations/FilterAggregateTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/aggregations/FilterAggregateTest.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch._types.aggregations;
+
+import org.junit.Test;
+import org.opensearch.client.opensearch.model.ModelTestCase;
+
+public class FilterAggregateTest extends ModelTestCase {
+    @Test
+    public void serializesNestedAggregates() {
+        String json = "{\"sum#l2_result\":{\"value\":1.0},\"doc_count\":1}";
+        FilterAggregate aggregate = fromJson(json, FilterAggregate._DESERIALIZER);
+        assertEquals(json, toJson(aggregate));
+    }
+}


### PR DESCRIPTION
### Description
Fixes serialization of nested aggregates which are under aggregates which extend from `SingleBucketAggregateBase`.

### Issues Resolved
Fixes #1349 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
