### PR TITLE
Fix serialization of time_zone field in CompositeDateHistogramAggregationSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This section is for maintaining a changelog for all breaking changes for the cli
 ### Removed
 
 ### Fixed
+- Fixed serialization of `time_zone` field in `CompositeDateHistogramAggregationSource` ([#1362](https://github.com/opensearch-project/opensearch-java/pull/1362))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/aggregations/CompositeDateHistogramAggregationSource.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/aggregations/CompositeDateHistogramAggregationSource.java
@@ -29,14 +29,15 @@ public class CompositeDateHistogramAggregationSource extends CompositeValuesSour
     @Nullable
     private final Long offset;
 
-    private final String zoneId;
+    @Nullable
+    private final String timeZone;
 
     private CompositeDateHistogramAggregationSource(Builder builder) {
         super(builder);
         this.calendarInterval = builder.calendarInterval;
         this.fixedInterval = builder.fixedInterval;
         this.offset = builder.offset;
-        this.zoneId = builder.zoneId;
+        this.timeZone = builder.timeZone;
     }
 
     public static CompositeDateHistogramAggregationSource of(Function<Builder, ObjectBuilder<CompositeDateHistogramAggregationSource>> fn) {
@@ -65,14 +66,22 @@ public class CompositeDateHistogramAggregationSource extends CompositeValuesSour
     @Nullable
     public final Long offset() {
         return this.offset;
-
     }
 
     /**
-     * Required - API name: {@code zone_id}
+     * API name: {@code time_zone}
      */
+    public final String timeZone() {
+        return this.timeZone;
+    }
+
+    /**
+     * API name: {@code time_zone}
+     * @deprecated Use {@link #timeZone()} instead.
+     */
+    @Deprecated
     public final String zoneId() {
-        return this.zoneId;
+        return timeZone();
     }
 
     /**
@@ -103,8 +112,10 @@ public class CompositeDateHistogramAggregationSource extends CompositeValuesSour
 
         }
 
-        generator.writeKey("zone_id");
-        generator.write(this.zoneId);
+        if (this.timeZone != null) {
+            generator.writeKey("time_zone");
+            generator.write(this.timeZone);
+        }
     }
 
     /**
@@ -124,7 +135,8 @@ public class CompositeDateHistogramAggregationSource extends CompositeValuesSour
         @Nullable
         private Long offset;
 
-        private String zoneId;
+        @Nullable
+        private String timeZone;
 
         /**
          * API name: {@code calendar_interval}
@@ -151,12 +163,20 @@ public class CompositeDateHistogramAggregationSource extends CompositeValuesSour
         }
 
         /**
-         * Required - API name: {@code zone_id}
+         * API name: {@code time_zone}
          */
-
-        public final Builder zoneId(String value) {
-            this.zoneId = value;
+        public final Builder timeZone(String value) {
+            this.timeZone = value;
             return this;
+        }
+
+        /**
+         * API name: {@code time_zone}
+         * @deprecated Use {@link #timeZone(String)} instead.
+         */
+        @Deprecated
+        public final Builder zoneId(String value) {
+            return timeZone(value);
         }
 
         /**
@@ -192,7 +212,7 @@ public class CompositeDateHistogramAggregationSource extends CompositeValuesSour
         op.add(Builder::calendarInterval, Time._DESERIALIZER, "calendar_interval");
         op.add(Builder::fixedInterval, Time._DESERIALIZER, "fixed_interval");
         op.add(Builder::offset, JsonpDeserializer.longDeserializer(), "offset");
-        op.add(Builder::zoneId, JsonpDeserializer.stringDeserializer(), "time_zone");
+        op.add(Builder::timeZone, JsonpDeserializer.stringDeserializer(), "time_zone");
     }
 
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/aggregations/CompositeDateHistogramAggregationSourceTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/aggregations/CompositeDateHistogramAggregationSourceTest.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch._types.aggregations;
+
+import org.junit.Test;
+import org.opensearch.client.opensearch.model.ModelTestCase;
+
+public class CompositeDateHistogramAggregationSourceTest extends ModelTestCase {
+
+    @Test
+    public void testSerializeSpecificFields() {
+        String json = "{\"calendar_interval\":\"1d\",\"fixed_interval\":\"1d\",\"offset\":1,\"time_zone\":\"+01:00\"}";
+        CompositeDateHistogramAggregationSource aggregation = fromJson(json, CompositeDateHistogramAggregationSource._DESERIALIZER);
+        assertEquals(json, toJson(aggregation));
+    }
+
+}


### PR DESCRIPTION
### Description
This PR fixes the serialization of the `time_zone` field in `CompositeDateHistogramAggregationSource`. Previously, it was incorrectly serialized as `zone_id`, which does not exist server-side, and documented as required instead of optional. New `timeZone()` accessors are added for consistency with the field name, but old `zoneId()` ones are preserved with `@Deprecated` annotations for backward compatibility.

### Issues Resolved
Closes #1142

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
