### PR TITLE
[Backport] [2.x] Bump lycheeverse/lychee-action from 2.1.0 to 2.2.0 (#1366)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: lychee Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.5.0
+        uses: lycheeverse/lychee-action@v2.2.0
         with:
           args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude-mail
           fail: true


### PR DESCRIPTION
Backport of  https://github.com/opensearch-project/opensearch-java/pull/1366 to `2.x`