### PR TITLE
[Backport] [2.x] Bump org.junit:junit-bom from 5.11.3 to 5.11.4 (#1367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
+- Bump `org.junit:junit-bom` from 5.11.3 to 5.11.4 ([#1367](https://github.com/opensearch-project/opensearch-java/pull/1367))
 
 ### Changed
 

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -175,7 +175,7 @@ dependencies {
     implementation("org.commonmark", "commonmark", "0.23.0")
 
     // EPL-2.0
-    testImplementation(platform("org.junit:junit-bom:5.11.3"))
+    testImplementation(platform("org.junit:junit-bom:5.11.4"))
     testImplementation("org.junit.jupiter", "junit-jupiter")
     testRuntimeOnly("org.junit.platform", "junit-platform-launcher")
 }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1367 to `2.x`