### PR TITLE
[Backport] [2.x] Bump org.apache.httpcomponents.core5:httpcore5 from 5.3.1 to 5.3.2 (#1383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bump `org.junit:junit-bom` from 5.11.3 to 5.11.4 ([#1367](https://github.com/opensearch-project/opensearch-java/pull/1367))
+- Bumps `org.apache.httpcomponents.core5:httpcore5` from 5.3 to 5.3.2 ([#1383](https://github.com/opensearch-project/opensearch-java/pull/1383))
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -210,11 +210,11 @@ dependencies {
     testImplementation("com.fasterxml.jackson.datatype", "jackson-datatype-jakarta-jsonp", jacksonVersion)
 
     // ApacheHttpClient5Transport dependencies (optional)
-    implementation("org.apache.httpcomponents.client5", "httpclient5", "5.4") {
+    implementation("org.apache.httpcomponents.client5", "httpclient5", "5.4.1") {
       exclude(group = "org.apache.httpcomponents.core5")
     }
-    implementation("org.apache.httpcomponents.core5", "httpcore5", "5.3")
-    implementation("org.apache.httpcomponents.core5", "httpcore5-h2", "5.3.1")
+    implementation("org.apache.httpcomponents.core5", "httpcore5", "5.3.2")
+    implementation("org.apache.httpcomponents.core5", "httpcore5-h2", "5.3.2")
 
     // For AwsSdk2Transport
     "awsSdk2SupportCompileOnly"("software.amazon.awssdk", "sdk-core", "[2.21,3.0)")


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1383 to `2.x`