### PR TITLE
[Backport] [2.x] Bump org.owasp.dependencycheck from 11.1.1 to 12.0.0 (#1381)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bump `org.junit:junit-bom` from 5.11.3 to 5.11.4 ([#1367](https://github.com/opensearch-project/opensearch-java/pull/1367))
 - Bumps `org.apache.httpcomponents.core5:httpcore5` from 5.3 to 5.3.2 ([#1383](https://github.com/opensearch-project/opensearch-java/pull/1383))
+- Bump `org.owasp.dependencycheck` from 11.1.1 to 12.0.0 ([#1381](https://github.com/opensearch-project/opensearch-java/pull/1381))
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -49,7 +49,7 @@ plugins {
     `java-library`
     `maven-publish`
     id("com.github.jk1.dependency-license-report") version "2.9"
-    id("org.owasp.dependencycheck") version "11.1.1"
+    id("org.owasp.dependencycheck") version "12.0.0"
 
     id("opensearch-java.spotless-conventions")
 }

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -31,7 +31,7 @@ buildscript {
 plugins {
     application
     id("com.github.jk1.dependency-license-report") version "2.9"
-    id("org.owasp.dependencycheck") version "11.1.1"
+    id("org.owasp.dependencycheck") version "12.0.0"
     id("de.undercouch.download") version "5.6.0"
 
     id("opensearch-java.spotless-conventions")


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1381 to `2.x`