### PR TITLE
[Backport] [2.x] Bump org.owasp.dependencycheck from 12.0.1 to 12.0.2 in /java-client (#1399)

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload Reports
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: java-client/build/reports/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Dependencies
 - Bump `org.junit:junit-bom` from 5.11.3 to 5.11.4 ([#1367](https://github.com/opensearch-project/opensearch-java/pull/1367))
 - Bumps `org.apache.httpcomponents.core5:httpcore5` from 5.3 to 5.3.2 ([#1383](https://github.com/opensearch-project/opensearch-java/pull/1383))
-- Bump `org.owasp.dependencycheck` from 11.1.1 to 12.0.1 ([#1381](https://github.com/opensearch-project/opensearch-java/pull/1381), [#1393](https://github.com/opensearch-project/opensearch-java/pull/1393))
+- Bump `org.owasp.dependencycheck` from 11.1.1 to 12.0.2 ([#1381](https://github.com/opensearch-project/opensearch-java/pull/1381), [#1393](https://github.com/opensearch-project/opensearch-java/pull/1393), [#1399](https://github.com/opensearch-project/opensearch-java/pull/1399))
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -49,7 +49,7 @@ plugins {
     `java-library`
     `maven-publish`
     id("com.github.jk1.dependency-license-report") version "2.9"
-    id("org.owasp.dependencycheck") version "12.0.1"
+    id("org.owasp.dependencycheck") version "12.0.2"
 
     id("opensearch-java.spotless-conventions")
 }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1399 to `2.x`