### PR TITLE
[Backport 2.x] Bump commons-logging:commons-logging from 1.3.4 to 1.3.5 in /java-client (#1418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
+- Bump `commons-logging:commons-logging` from 1.3.4 to 1.3.5 ([#1418](https://github.com/opensearch-project/opensearch-java/pull/1418))
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -180,7 +180,7 @@ dependencies {
     val jacksonDatabindVersion = "2.17.0"
 
     // Apache 2.0
-    api("commons-logging:commons-logging:1.3.4")
+    api("commons-logging:commons-logging:1.3.5")
     implementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)
     testImplementation("org.hamcrest:hamcrest:2.2")
     testImplementation("com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.8.2") {


### PR DESCRIPTION
### Description
Backport #1418 via 90a9a0a176c21e93c72c02fcdc34644e4ebdb29f

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
