### PR TITLE
Revert "Bump org.opensearch.gradle:build-tools from 3.0.0-alpha1-SNAPSHOT to 3.0.0-SNAPSHOT (#1420)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `org.junit:junit-bom` from 5.11.3 to 5.11.4 ([#1367](https://github.com/opensearch-project/opensearch-java/pull/1367))
 - Bump `org.owasp.dependencycheck` from 11.1.1 to 12.0.2 ([#1381](https://github.com/opensearch-project/opensearch-java/pull/1381), [#1393](https://github.com/opensearch-project/opensearch-java/pull/1393), [#1399](https://github.com/opensearch-project/opensearch-java/pull/1399), [#1404](https://github.com/opensearch-project/opensearch-java/pull/1404))
 - Bump `commons-logging:commons-logging` from 1.3.4 to 1.3.5 ([#1418](https://github.com/opensearch-project/opensearch-java/pull/1418))
-- Bump `org.opensearch.gradle:build-tools` from 3.0.0-alpha1-SNAPSHOT to 3.0.0-SNAPSHOT ([#1420](https://github.com/opensearch-project/opensearch-java/pull/1420))
 
 This section is for maintaining a changelog for all breaking changes for the client that cannot be released in the 2.x line. All other non-breaking changes should be added to [Unreleased 2.x] section.
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -43,7 +43,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        "classpath"(group = "org.opensearch.gradle", name = "build-tools", version = "3.0.0-SNAPSHOT")
+        "classpath"(group = "org.opensearch.gradle", name = "build-tools", version = "3.0.0-alpha1-SNAPSHOT")
     }
 }
 

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -24,7 +24,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        "classpath"(group = "org.opensearch.gradle", name = "build-tools", version = "3.0.0-SNAPSHOT")
+        "classpath"(group = "org.opensearch.gradle", name = "build-tools", version = "3.0.0-alpha1-SNAPSHOT")
     }
 }
 


### PR DESCRIPTION
### Description
Reverts #1420 (20f25028ede8c99f34af53b4a2e1e7402d9aeaa5).

Realised that it undid a change introduced in https://github.com/opensearch-project/opensearch-java/pull/1397 @reta 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
