### PR TITLE
Fix serialization of `KnnQuery`'s `method_parameters` property

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -12,21 +12,18 @@ jobs:
           - { opensearch_version: 1.0.1, java: 11 }
           - { opensearch_version: 1.1.0, java: 11 }
           - { opensearch_version: 1.2.4, java: 11 }
-          - { opensearch_version: 1.3.13, java: 11 }
+          - { opensearch_version: 1.3.20, java: 11 }
           - { opensearch_version: 2.0.1, java: 11 }
-          - { opensearch_version: 2.1.0, java: 11 }
           - { opensearch_version: 2.2.1, java: 11 }
-          - { opensearch_version: 2.3.0, java: 11 }
           - { opensearch_version: 2.4.1, java: 11 }
-          - { opensearch_version: 2.5.0, java: 11 }
           - { opensearch_version: 2.6.0, java: 11 }
-          - { opensearch_version: 2.7.0, java: 11 }
           - { opensearch_version: 2.8.0, java: 11 }
-          - { opensearch_version: 2.9.0, java: 11 }
           - { opensearch_version: 2.10.0, java: 11 }
-          - { opensearch_version: 2.11.1, java: 11 }
           - { opensearch_version: 2.12.0, java: 11 }
-          - { opensearch_version: 2.13.0, java: 11 }
+          - { opensearch_version: 2.14.0, java: 11 }
+          - { opensearch_version: 2.16.0, java: 11 }
+          - { opensearch_version: 2.18.0, java: 11 }
+          - { opensearch_version: 2.19.0, java: 11 }
     steps:
       - name: Checkout Java Client
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fixed serialization of `KnnQuery`'s `method_parameters` property ([#1427](https://github.com/opensearch-project/opensearch-java/pull/1427))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQuery.java
@@ -98,7 +98,7 @@ public class KnnQuery extends QueryBase implements QueryVariant {
      * @return The minimum score allowed for the returned search results.
      */
     @Nullable
-    private final Float minScore() {
+    public final Float minScore() {
         return this.minScore;
     }
 
@@ -107,7 +107,7 @@ public class KnnQuery extends QueryBase implements QueryVariant {
      * @return The maximum distance allowed between the vector and each ofthe returned search results.
      */
     @Nullable
-    private final Float maxDistance() {
+    public final Float maxDistance() {
         return this.maxDistance;
     }
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQuery.java
@@ -166,10 +166,13 @@ public class KnnQuery extends QueryBase implements QueryVariant {
         }
 
         if (ApiTypeHelper.isDefined(this.methodParameters)) {
+            generator.writeKey("method_parameters");
+            generator.writeStartObject();
             for (Map.Entry<String, JsonData> entry : this.methodParameters.entrySet()) {
                 generator.writeKey(entry.getKey());
                 entry.getValue().serialize(generator, mapper);
             }
+            generator.writeEnd();
         }
 
         if (this.rescore != null) {

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQueryTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/KnnQueryTest.java
@@ -9,6 +9,7 @@
 package org.opensearch.client.opensearch._types.query_dsl;
 
 import org.junit.Test;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.model.ModelTestCase;
 
 public class KnnQueryTest extends ModelTestCase {
@@ -18,5 +19,25 @@ public class KnnQueryTest extends ModelTestCase {
         KnnQuery copied = origin.toBuilder().build();
 
         assertEquals(toJson(copied), toJson(origin));
+    }
+
+    @Test
+    public void roundTripJson() {
+        KnnQuery query = new KnnQuery.Builder().field("field")
+            .vector(new float[] { 1.0f })
+            .k(1)
+            .minScore(0.0f)
+            .maxDistance(1.0f)
+            .methodParameters("ef_search", JsonData.of(100))
+            .build();
+        String json =
+            "{\"field\":{\"vector\":[1.0],\"k\":1,\"min_score\":0.0,\"max_distance\":1.0,\"method_parameters\":{\"ef_search\":100}}}";
+        query = checkJsonRoundtrip(query, json);
+        assertEquals("field", query.field());
+        assertArrayEquals(new float[] { 1.0f }, query.vector(), 0.001f);
+        assertEquals((Integer) 1, query.k());
+        assertEquals((Float) 0.0f, query.minScore());
+        assertEquals((Float) 1.0f, query.maxDistance());
+        assertEquals((Integer) 100, query.methodParameters().get("ef_search").to(Integer.class));
     }
 }

--- a/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/AbstractKnnIT.java
+++ b/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/AbstractKnnIT.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.junit.Test;
+import org.opensearch.Version;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
@@ -68,6 +69,66 @@ public abstract class AbstractKnnIT extends OpenSearchJavaClientTestCase {
         assertEquals(2, hits.size());
         assertEquals(5.5f, hits.get(0).source().price, 0.01f);
         assertEquals(10.3f, hits.get(1).source().price, 0.01f);
+    }
+
+    @Test
+    public void testCanIndexAndSearchKnnWithFaissMethodParams() throws Exception {
+        assumeTrue("Certain config combinations were only added in v2.17.0", getServerVersion().onOrAfter(Version.fromString("2.17.0")));
+        assumeKnnInstalled();
+
+        final String indexName = "knn-index-and-search-faiss";
+
+        var createIndexResponse = javaClient().indices()
+            .create(
+                c -> c.index(indexName)
+                    .settings(s -> s.knn(true))
+                    .mappings(
+                        m -> m.properties(
+                            "vector",
+                            p -> p.knnVector(
+                                k -> k.dimension(2)
+                                    .spaceType("innerproduct")
+                                    .method(
+                                        km -> km.name("hnsw")
+                                            .engine("faiss")
+                                            .parameters("ef_construction", JsonData.of(128))
+                                            .parameters("m", JsonData.of(24))
+                                    )
+                            )
+                        )
+                    )
+            );
+
+        assertEquals(true, createIndexResponse.acknowledged());
+
+        var docs = new Doc[] {
+            new Doc(new float[] { 1.5f, 2.5f }, 12.2f),
+            new Doc(new float[] { 2.5f, 3.5f }, 7.1f),
+            new Doc(new float[] { 3.5f, 4.5f }, 12.9f),
+            new Doc(new float[] { 5.5f, 6.5f }, 1.2f),
+            new Doc(new float[] { 4.5f, 5.5f }, 3.7f) };
+        var bulkOps = Arrays.stream(docs).map(d -> BulkOperation.of(o -> o.index(i -> i.document(d)))).collect(Collectors.toList());
+
+        var bulkResponse = javaClient().bulk(b -> b.index(indexName).refresh(Refresh.WaitFor).operations(bulkOps));
+
+        assertFalse(bulkResponse.errors());
+
+        var searchResponse = javaClient().search(
+            s -> s.index(indexName)
+                .size(2)
+                .query(
+                    q -> q.knn(
+                        k -> k.field("vector").vector(new float[] { 2.0f, 3.0f }).k(2).methodParameters("ef_search", JsonData.of(100))
+                    )
+                ),
+            Doc.class
+        );
+
+        var hits = searchResponse.hits().hits();
+
+        assertEquals(2, hits.size());
+        assertEquals(1.2f, hits.get(0).source().price, 0.01f);
+        assertEquals(3.7f, hits.get(1).source().price, 0.01f);
     }
 
     private void assumeKnnInstalled() throws IOException {

--- a/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/OpenSearchJavaClientTestCase.java
+++ b/java-client/src/test/java11/org/opensearch/client/opensearch/integTest/OpenSearchJavaClientTestCase.java
@@ -39,7 +39,12 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
 public abstract class OpenSearchJavaClientTestCase extends OpenSearchRestTestCase implements OpenSearchTransportSupport {
-    private static final List<String> systemIndices = List.of(".opensearch-observability", ".opendistro_security", ".plugins-ml-config");
+    private static final List<String> systemIndices = List.of(
+        ".opensearch-observability",
+        ".opendistro_security",
+        ".plugins-ml-config",
+        ".ql-datasources"
+    );
     private static OpenSearchClient javaClient;
     private static OpenSearchClient adminJavaClient;
 


### PR DESCRIPTION
### Description
Fix serialization of `KnnQuery`'s `method_parameters` property

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
