### PR TITLE
Add support for `GeoDistanceQuery`'s `ignore_unmapped` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased 2.x]
 ### Added
+- Added support for `GeoDistanceQuery`'s `ignore_unmapped` property ([#1430](https://github.com/opensearch-project/opensearch-java/pull/1430))
 
 ### Dependencies
 - Bump `commons-logging:commons-logging` from 1.3.4 to 1.3.5 ([#1418](https://github.com/opensearch-project/opensearch-java/pull/1418))

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/GeoDistanceQuery.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/GeoDistanceQuery.java
@@ -62,6 +62,9 @@ public class GeoDistanceQuery extends QueryBase implements QueryVariant {
     @Nullable
     private final GeoValidationMethod validationMethod;
 
+    @Nullable
+    private final Boolean ignoreUnmapped;
+
     // ---------------------------------------------------------------------------------------------
 
     private GeoDistanceQuery(Builder builder) {
@@ -72,7 +75,7 @@ public class GeoDistanceQuery extends QueryBase implements QueryVariant {
         this.distance = builder.distance;
         this.distanceType = builder.distanceType;
         this.validationMethod = builder.validationMethod;
-
+        this.ignoreUnmapped = builder.ignoreUnmapped;
     }
 
     public static GeoDistanceQuery of(Function<Builder, ObjectBuilder<GeoDistanceQuery>> fn) {
@@ -125,6 +128,14 @@ public class GeoDistanceQuery extends QueryBase implements QueryVariant {
         return this.validationMethod;
     }
 
+    /**
+     * API name: {@code ignore_unmapped}
+     */
+    @Nullable
+    public final Boolean ignoreUnmapped() {
+        return this.ignoreUnmapped;
+    }
+
     protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeKey(this.field);
         this.location.serialize(generator, mapper);
@@ -144,10 +155,19 @@ public class GeoDistanceQuery extends QueryBase implements QueryVariant {
             this.validationMethod.serialize(generator, mapper);
         }
 
+        if (this.ignoreUnmapped != null) {
+            generator.writeKey("ignore_unmapped");
+            generator.write(this.ignoreUnmapped);
+        }
     }
 
     public Builder toBuilder() {
-        return toBuilder(new Builder()).field(field).location(location);
+        return toBuilder(new Builder()).field(field)
+            .location(location)
+            .distance(distance)
+            .distanceType(distanceType)
+            .validationMethod(validationMethod)
+            .ignoreUnmapped(ignoreUnmapped);
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -193,6 +213,9 @@ public class GeoDistanceQuery extends QueryBase implements QueryVariant {
         @Nullable
         private GeoValidationMethod validationMethod;
 
+        @Nullable
+        private Boolean ignoreUnmapped;
+
         /**
          * API name: {@code distance}
          */
@@ -214,6 +237,14 @@ public class GeoDistanceQuery extends QueryBase implements QueryVariant {
          */
         public final Builder validationMethod(@Nullable GeoValidationMethod value) {
             this.validationMethod = value;
+            return this;
+        }
+
+        /**
+         * API name: {@code ignore_unmapped}
+         */
+        public final Builder ignoreUnmapped(@Nullable Boolean value) {
+            this.ignoreUnmapped = value;
             return this;
         }
 
@@ -250,6 +281,7 @@ public class GeoDistanceQuery extends QueryBase implements QueryVariant {
         op.add(Builder::distance, JsonpDeserializer.stringDeserializer(), "distance");
         op.add(Builder::distanceType, GeoDistanceType._DESERIALIZER, "distance_type");
         op.add(Builder::validationMethod, GeoValidationMethod._DESERIALIZER, "validation_method");
+        op.add(Builder::ignoreUnmapped, JsonpDeserializer.booleanDeserializer(), "ignore_unmapped");
 
         op.setUnknownFieldHandler((builder, name, parser, mapper) -> {
             builder.field(name);

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/GeoDistanceQueryTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/GeoDistanceQueryTest.java
@@ -10,6 +10,7 @@ package org.opensearch.client.opensearch._types.query_dsl;
 
 import java.util.Collections;
 import org.junit.Test;
+import org.opensearch.client.opensearch._types.GeoDistanceType;
 import org.opensearch.client.opensearch._types.GeoLocation;
 import org.opensearch.client.opensearch.model.ModelTestCase;
 
@@ -18,6 +19,9 @@ public class GeoDistanceQueryTest extends ModelTestCase {
     public void toBuilder() {
         GeoDistanceQuery origin = new GeoDistanceQuery.Builder().field("field")
             .location(new GeoLocation.Builder().coords(Collections.singletonList(1.0)).build())
+            .distance("1m")
+            .distanceType(GeoDistanceType.Arc)
+            .ignoreUnmapped(true)
             .build();
         GeoDistanceQuery copied = origin.toBuilder().build();
 


### PR DESCRIPTION
### Description
Add support for `GeoDistanceQuery`'s `ignore_unmapped` property

### Issues Resolved
Closes #1425 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
