### PR TITLE
Fixed deserializing `GeoValidationMethod` enum values when uppercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fixed serialization of `KnnQuery`'s `method_parameters` property ([#1427](https://github.com/opensearch-project/opensearch-java/pull/1427))
+- Fixed deserializing `GeoValidationMethod` enum values when uppercase ([#1431](https://github.com/opensearch-project/opensearch-java/pull/1431))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/GeoValidationMethod.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/query_dsl/GeoValidationMethod.java
@@ -37,22 +37,30 @@ import org.opensearch.client.json.JsonpDeserializable;
 
 @JsonpDeserializable
 public enum GeoValidationMethod implements JsonEnum {
-    Coerce("coerce"),
+    Coerce("coerce", "COERCE"),
 
-    IgnoreMalformed("ignore_malformed"),
+    IgnoreMalformed("ignore_malformed", "IGNORE_MALFORMED"),
 
-    Strict("strict"),
+    Strict("strict", "STRICT"),
 
     ;
 
     private final String jsonValue;
+    private final String[] aliases;
 
-    GeoValidationMethod(String jsonValue) {
+    GeoValidationMethod(String jsonValue, String... aliases) {
         this.jsonValue = jsonValue;
+        this.aliases = aliases;
     }
 
+    @Override
     public String jsonValue() {
         return this.jsonValue;
+    }
+
+    @Override
+    public String[] aliases() {
+        return this.aliases;
     }
 
     public static final JsonEnum.Deserializer<GeoValidationMethod> _DESERIALIZER = new JsonEnum.Deserializer<>(


### PR DESCRIPTION
### Description
Fixed deserializing `GeoValidationMethod` enum values when uppercase

### Issues Resolved
Closes #1426 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
