### PR TITLE
[Backport 2.x] Bump dangoslen/dependabot-changelog-helper from 3 to 4 (#1466)

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ steps.github_app_token.outputs.token }}
 
       - name: Update the changelog
-        uses: dangoslen/dependabot-changelog-helper@v1
+        uses: dangoslen/dependabot-changelog-helper@v4
         with:
           version: 'Unreleased'
 


### PR DESCRIPTION
### Description
Backport #1466 via 9520a959e7e0b542fa632c6b7fa8c59e27a0bbe9

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
