### PR TITLE
Fix ClassCastException in extractAndWrapCause when handling Execution…

### DIFF
--- a/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2Transport.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2Transport.java
@@ -694,7 +694,11 @@ public class AwsSdk2Transport implements OpenSearchTransport {
             if (t instanceof Error) {
                 throw (Error) t;
             }
-            exception = (Exception) t;
+            if (t instanceof Exception) {
+                exception = (Exception) t;
+            } else {
+                exception = new RuntimeException("Unexpected throwable caught in execution", t);
+            }
         }
         if (exception instanceof SocketTimeoutException) {
             SocketTimeoutException e = new SocketTimeoutException(exception.getMessage());

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Transport.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Transport.java
@@ -1107,7 +1107,11 @@ public class ApacheHttpClient5Transport implements OpenSearchTransport {
             if (t instanceof Error) {
                 throw (Error) t;
             }
-            exception = (Exception) t;
+            if (t instanceof Exception) {
+                exception = (Exception) t;
+            } else {
+                exception = new RuntimeException("Unexpected throwable caught in execution", t);
+            }
         }
         if (exception instanceof ConnectTimeoutException) {
             ConnectTimeoutException e = new ConnectTimeoutException(exception.getMessage());


### PR DESCRIPTION
### Description
When handling an ExecutionException in `extractAndWrapCause`, the code assumes that `getCause()` always returns an `Exception` or `Error`. 
However, if the cause is a `Throwable` that is neither, a `ClassCastException` occurs.

### Issues Resolved
#1480 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
