### PR TITLE
[Backport] [2.x] Bump org.owasp.dependencycheck from 12.1.0 to 12.1.1 (#1514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
+- Bump `org.owasp.dependencycheck` from 12.0.2 to 12.1.1 ([#1440](https://github.com/opensearch-project/opensearch-java/pull/1440), [#1514](https://github.com/opensearch-project/opensearch-java/pull/1514))
 - Bump `org.apache.httpcomponents.client5:httpclient5` from 5.4.2 to 5.4.3 ([#1506](https://github.com/opensearch-project/opensearch-java/pull/1506))
 - Bump `org.apache.httpcomponents.core5:httpcore5-h2` from 5.3.3 to 5.3.4 ([#1498](https://github.com/opensearch-project/opensearch-java/pull/1498))
 - Bump `org.apache.httpcomponents.core5:httpcore5` from 5.3.3 to 5.3.4 ([#1497](https://github.com/opensearch-project/opensearch-java/pull/1497))

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -49,7 +49,7 @@ plugins {
     `java-library`
     `maven-publish`
     id("com.github.jk1.dependency-license-report") version "2.9"
-    id("org.owasp.dependencycheck") version "12.0.2"
+    id("org.owasp.dependencycheck") version "12.1.1"
 
     id("opensearch-java.spotless-conventions")
 }

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -31,7 +31,7 @@ buildscript {
 plugins {
     application
     id("com.github.jk1.dependency-license-report") version "2.9"
-    id("org.owasp.dependencycheck") version "12.0.1"
+    id("org.owasp.dependencycheck") version "12.1.1"
     id("de.undercouch.download") version "5.6.0"
 
     id("opensearch-java.spotless-conventions")


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1514 to `2.x`