### PR TITLE
[Backport 2.x] Bump org.apache.httpcomponents.client5:httpclient5 from 5.4.3 to 5.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
+- Bump `org.apache.httpcomponents.client5:httpclient5` from 5.4.3 to 5.4.4 ([#1544](https://github.com/opensearch-project/opensearch-java/pull/1544))
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -212,7 +212,7 @@ dependencies {
     testImplementation("com.fasterxml.jackson.datatype", "jackson-datatype-jakarta-jsonp", jacksonVersion)
 
     // ApacheHttpClient5Transport dependencies (optional)
-    implementation("org.apache.httpcomponents.client5", "httpclient5", "5.4.3") {
+    implementation("org.apache.httpcomponents.client5", "httpclient5", "5.4.4") {
       exclude(group = "org.apache.httpcomponents.core5")
     }
     implementation("org.apache.httpcomponents.core5", "httpcore5", "5.3.4")


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
