### PR TITLE
fix: Skip calling add all when the stopword list is null

### DIFF
--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/StopTokenFilter.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/StopTokenFilter.java
@@ -239,7 +239,9 @@ public class StopTokenFilter extends TokenFilterBase
          */
         @Nonnull
         public final Builder stopwords(List<String> list) {
-            this.stopwords = _listAddAll(this.stopwords, list);
+            if (Objects.nonNull(list)) {
+                this.stopwords = _listAddAll(this.stopwords, list);
+            }
             return this;
         }
 


### PR DESCRIPTION
### Description
Skip calling add all when the stopword list is null, allowing stopwordPath to be prioritized

### Issues Resolved
Fix #1534

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
