### PR TITLE
enable jackson `ObjectMapper` JDK8 & JSR310 modules + module autodetect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added support for Index Management plugin APIs ([#1604](https://github.com/opensearch-project/opensearch-java/pull/1604))
 - Added support for the security plugin APIs ([#1601](https://github.com/opensearch-project/opensearch-java/pull/1601))
 - Jackson `ObjectMapper` modules are now being auto-detected ([#1614](https://github.com/opensearch-project/opensearch-java/pull/1614))
+- Jackson `ObjectMapper` JDK8 & JSR310 modules are now always present ([#1614](https://github.com/opensearch-project/opensearch-java/pull/1614))
 
 ### Dependencies
 - Bump `org.owasp.dependencycheck` from 12.1.1 to 12.1.3 ([#1608](https://github.com/opensearch-project/opensearch-java/pull/1608), [#1607](https://github.com/opensearch-project/opensearch-java/pull/1607), [#1623](https://github.com/opensearch-project/opensearch-java/pull/1623))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added support for Index Management plugin APIs ([#1604](https://github.com/opensearch-project/opensearch-java/pull/1604))
 - Added support for the security plugin APIs ([#1601](https://github.com/opensearch-project/opensearch-java/pull/1601))
+- Jackson `ObjectMapper` modules are now being auto-detected ([#1614](https://github.com/opensearch-project/opensearch-java/pull/1614))
 
 ### Dependencies
 - Bump `org.owasp.dependencycheck` from 12.1.1 to 12.1.3 ([#1608](https://github.com/opensearch-project/opensearch-java/pull/1608), [#1607](https://github.com/opensearch-project/opensearch-java/pull/1607), [#1623](https://github.com/opensearch-project/opensearch-java/pull/1623))

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -99,7 +99,7 @@ OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJ
 OpenSearchClient client = new OpenSearchClient(transport);
 ```
 
-The `JacksonJsonpMapper` class (2.x versions) only supports Java 7 objects by default. [Java 8 modules](https://github.com/FasterXML/jackson-modules-java8) to support JDK8 classes such as the Date and Time API (JSR-310), `Optional`, and more can be used by including [the additional datatype dependency](https://github.com/FasterXML/jackson-modules-java8#usage) and adding the module. Auto-detection for these modules is enabled, adding them to the classpath is enough.
+Auto-detection for `JsonMapper` modules is enabled, adding them to the classpath is enough. JSR310 & JDK8 support are enabled by default.
 
 Upcoming OpenSearch `3.0.0` release brings HTTP/2 support and as such, the `RestClientTransport` would switch to HTTP/2 if available (for both HTTPS and/or HTTP protocols). The desired protocol could be forced using `RestClientBuilder.HttpClientConfigCallback`.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -99,13 +99,7 @@ OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJ
 OpenSearchClient client = new OpenSearchClient(transport);
 ```
 
-The `JacksonJsonpMapper` class (2.x versions) only supports Java 7 objects by default. [Java 8 modules](https://github.com/FasterXML/jackson-modules-java8) to support JDK8 classes such as the Date and Time API (JSR-310), `Optional`, and more can be used by including [the additional datatype dependency](https://github.com/FasterXML/jackson-modules-java8#usage) and adding the module.  For example, to include JSR-310 classes:
-
-```java
-OpenSearchTransport transport = new RestClientTransport(restClient,
-    new JacksonJsonpMapper(new ObjectMapper().registerModule(new JavaTimeModule()))); 
-OpenSearchClient client = new OpenSearchClient(transport);
-```
+The `JacksonJsonpMapper` class (2.x versions) only supports Java 7 objects by default. [Java 8 modules](https://github.com/FasterXML/jackson-modules-java8) to support JDK8 classes such as the Date and Time API (JSR-310), `Optional`, and more can be used by including [the additional datatype dependency](https://github.com/FasterXML/jackson-modules-java8#usage) and adding the module. Auto-detection for these modules is enabled, adding them to the classpath is enough.
 
 Upcoming OpenSearch `3.0.0` release brings HTTP/2 support and as such, the `RestClientTransport` would switch to HTTP/2 if available (for both HTTPS and/or HTTP protocols). The desired protocol could be forced using `RestClientBuilder.HttpClientConfigCallback`.
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -218,6 +218,8 @@ dependencies {
     // Apache 2.0
     implementation("com.fasterxml.jackson.core", "jackson-core", jacksonVersion)
     implementation("com.fasterxml.jackson.core", "jackson-databind", jacksonDatabindVersion)
+    implementation("com.fasterxml.jackson.datatype", "jackson-datatype-jsr310", jacksonDatabindVersion)
+    implementation("com.fasterxml.jackson.datatype", "jackson-datatype-jdk8", jacksonDatabindVersion)
     testImplementation("com.fasterxml.jackson.datatype", "jackson-datatype-jakarta-jsonp", jacksonVersion)
 
     // For AwsSdk2Transport

--- a/java-client/src/main/java/org/opensearch/client/json/jackson/JacksonJsonpMapper.java
+++ b/java-client/src/main/java/org/opensearch/client/json/jackson/JacksonJsonpMapper.java
@@ -63,7 +63,9 @@ public class JacksonJsonpMapper extends JsonpMapperBase {
 
     public JacksonJsonpMapper() {
         this(
-            new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false).setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .findAndRegisterModules()
         );
     }
 


### PR DESCRIPTION
### Description
see the individual commit messages for further details.

short summary: this makes using core java types introduced 10+ years ago possible without having to resort to manual workarounds on the client side.

with jackson 3.x this will work out of the box since they've included the modules there. jackson 3.0 will probably be released soon, since RC5 is already out; though how/when `opensearch-java` will upgrade to this is unclear to me since it's part of the public API (and you just did a major release).

### Issues Resolved
n/a

though this relates to #250 & #251

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
