### PR TITLE
Update the maven snapshot publish endpoint and credential

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -20,15 +20,15 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
       - name: publish snapshots to maven
         run: |
-          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
-          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
-          echo "::add-mask::$SONATYPE_USERNAME"
-          echo "::add-mask::$SONATYPE_PASSWORD"
           ./gradlew --no-daemon publishPublishMavenPublicationToSnapshotsRepository

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This project has adopted the [Amazon Open Source Code of Conduct](CODE_OF_CONDUC
 See [User Guide](USER_GUIDE.md).
 
 ## Snapshot Builds
-The [snapshots builds](https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/client/opensearch-java/) are published to sonatype using [publish-snapshots.yml](./.github/workflows/publish-snapshots.yml) workflow. Each `push` event to the main branch triggers this workflow.
+The [snapshots builds](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/opensearch/client/opensearch-java/) are published to sonatype using [publish-snapshots.yml](./.github/workflows/publish-snapshots.yml) workflow. Each `push` event to the main branch triggers this workflow.
 
 ## Compatibility with OpenSearch
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ allprojects {
 
     repositories {
         mavenLocal()
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
         maven(url = "https://aws.oss.sonatype.org/content/repositories/snapshots")
         mavenCentral()
         gradlePluginPortal()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -36,6 +36,7 @@ plugins {
 
 repositories {
     mavenLocal()
+    maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
     maven(url = "https://aws.oss.sonatype.org/content/repositories/snapshots")
     mavenCentral()
     gradlePluginPortal()

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -38,6 +38,7 @@ import java.io.FileWriter
 buildscript {
     repositories {
         mavenLocal()
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
         maven(url = "https://aws.oss.sonatype.org/content/repositories/snapshots")
         mavenCentral()
         gradlePluginPortal()
@@ -317,7 +318,7 @@ tasks.withType<Jar> {
 publishing {
     repositories{
         if (version.toString().endsWith("SNAPSHOT")) {
-            maven("https://aws.oss.sonatype.org/content/repositories/snapshots/") {
+            maven("https://central.sonatype.com/repository/maven-snapshots/") {
                 name = "Snapshots"
                 credentials {
                     username = System.getenv("SONATYPE_USERNAME")

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -19,6 +19,7 @@ import java.io.FileWriter
 buildscript {
     repositories {
         mavenLocal()
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
         maven(url = "https://aws.oss.sonatype.org/content/repositories/snapshots")
         mavenCentral()
         gradlePluginPortal()


### PR DESCRIPTION
### Description
Update the Maven Snapshots publish URL in accordance with the recent Sonatype migration. 
https://central.sonatype.org/publish/publish-portal-snapshots/

We have stored the `onepassword` token in this repo secrets and new credentials for Sonatypes username & password have been stored in `onepassword`.  These credentials will be exported as env variables which used by maven publish.

### Related Issues
Part of a campaign issue https://github.com/opensearch-project/opensearch-build/issues/5551

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
