### PR TITLE
jackson `ObjectMapper`: auto-detect modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added support for Index Management plugin APIs ([#1604](https://github.com/opensearch-project/opensearch-java/pull/1604))
 - Added support for the security plugin APIs ([#1601](https://github.com/opensearch-project/opensearch-java/pull/1601))
+- Jackson `ObjectMapper` modules are now being auto-detected ([#1643](https://github.com/opensearch-project/opensearch-java/pull/1643))
 
 ### Dependencies
 - Bump `org.owasp.dependencycheck` from 12.1.1 to 12.1.3 ([#1608](https://github.com/opensearch-project/opensearch-java/pull/1608), [#1607](https://github.com/opensearch-project/opensearch-java/pull/1607), [#1623](https://github.com/opensearch-project/opensearch-java/pull/1623))

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -99,11 +99,12 @@ OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJ
 OpenSearchClient client = new OpenSearchClient(transport);
 ```
 
-The `JacksonJsonpMapper` class (2.x versions) only supports Java 7 objects by default. [Java 8 modules](https://github.com/FasterXML/jackson-modules-java8) to support JDK8 classes such as the Date and Time API (JSR-310), `Optional`, and more can be used by including [the additional datatype dependency](https://github.com/FasterXML/jackson-modules-java8#usage) and adding the module.  For example, to include JSR-310 classes:
+The `JacksonJsonpMapper` class (2.x versions) only supports Java 7 objects by default. [Java 8 modules](https://github.com/FasterXML/jackson-modules-java8) to support JDK8 classes such as the Date and Time API (JSR-310), `Optional`, and more can be used by including [the additional datatype dependency](https://github.com/FasterXML/jackson-modules-java8#usage) and adding the module. Auto-detection for these modules is enabled, adding them to the classpath is enough.
+You can also provide your own `ObjectMapper` instance if you need to pre-configure it differently, for example:
 
 ```java
 OpenSearchTransport transport = new RestClientTransport(restClient,
-    new JacksonJsonpMapper(new ObjectMapper().registerModule(new JavaTimeModule()))); 
+    new JacksonJsonpMapper(new ObjectMapper().findAndRegisterModules().configure(SerializationFeature.INDENT_OUTPUT, true))); 
 OpenSearchClient client = new OpenSearchClient(transport);
 ```
 

--- a/java-client/src/main/java/org/opensearch/client/json/jackson/JacksonJsonpMapper.java
+++ b/java-client/src/main/java/org/opensearch/client/json/jackson/JacksonJsonpMapper.java
@@ -63,7 +63,9 @@ public class JacksonJsonpMapper extends JsonpMapperBase {
 
     public JacksonJsonpMapper() {
         this(
-            new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false).setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .findAndRegisterModules()
         );
     }
 


### PR DESCRIPTION
jackson 2.x still supports java 7 and thus does not automatically support java 8 classes. this will change with jackson 3.x (see e.g. this [PR adding JSR310 date support] to 3.x).

PR #251 added documentation on how a custom `ObjectMapper` can be registered - but there's no reason why we can't just enable auto-detection centrally. the docs mention that performance should be considered, but this is IMHO not relevant here since we only construct it once and then keep the same `ObjectMapper` (which in turn the docs mention as best practices).

Signed-off-by: Ralph Ursprung <Ralph.Ursprung@avaloq.com>

[PR adding JSR310 date support]: https://github.com/FasterXML/jackson-databind/pull/5032


this is split from #1614. CC @reta & @Xtansia 

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
