### PR TITLE
Fix integer overflow issue in DocStatus by changing Integer to Long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `org.ajoberstar.grgit:grgit-gradle` from 5.3.0 to 5.3.2 ([#1621](https://github.com/opensearch-project/opensearch-java/pull/1621))
 
 ### Changed
+- Changed the type of the properties in DocStatus from integer to Long to resolve the integer overflow issue ([#1644](https://github.com/opensearch-project/opensearch-java/pull/1644))
 
 ### Deprecated
 

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/DocStatus.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/DocStatus.java
@@ -63,19 +63,19 @@ import org.opensearch.client.util.ToCopyableBuilder;
 public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocStatus.Builder, DocStatus> {
 
     @Nullable
-    private final Integer _1xx;
+    private final Long _1xx;
 
     @Nullable
-    private final Integer _2xx;
+    private final Long _2xx;
 
     @Nullable
-    private final Integer _3xx;
+    private final Long _3xx;
 
     @Nullable
-    private final Integer _4xx;
+    private final Long _4xx;
 
     @Nullable
-    private final Integer _5xx;
+    private final Long _5xx;
 
     // ---------------------------------------------------------------------------------------------
 
@@ -98,7 +98,7 @@ public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocSt
      * </p>
      */
     @Nullable
-    public final Integer _1xx() {
+    public final Long _1xx() {
         return this._1xx;
     }
 
@@ -109,7 +109,7 @@ public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocSt
      * </p>
      */
     @Nullable
-    public final Integer _2xx() {
+    public final Long _2xx() {
         return this._2xx;
     }
 
@@ -120,7 +120,7 @@ public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocSt
      * </p>
      */
     @Nullable
-    public final Integer _3xx() {
+    public final Long _3xx() {
         return this._3xx;
     }
 
@@ -131,7 +131,7 @@ public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocSt
      * </p>
      */
     @Nullable
-    public final Integer _4xx() {
+    public final Long _4xx() {
         return this._4xx;
     }
 
@@ -142,7 +142,7 @@ public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocSt
      * </p>
      */
     @Nullable
-    public final Integer _5xx() {
+    public final Long _5xx() {
         return this._5xx;
     }
 
@@ -201,15 +201,15 @@ public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocSt
      */
     public static class Builder extends ObjectBuilderBase implements CopyableBuilder<Builder, DocStatus> {
         @Nullable
-        private Integer _1xx;
+        private Long _1xx;
         @Nullable
-        private Integer _2xx;
+        private Long _2xx;
         @Nullable
-        private Integer _3xx;
+        private Long _3xx;
         @Nullable
-        private Integer _4xx;
+        private Long _4xx;
         @Nullable
-        private Integer _5xx;
+        private Long _5xx;
 
         public Builder() {}
 
@@ -242,7 +242,7 @@ public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocSt
          * </p>
          */
         @Nonnull
-        public final Builder _1xx(@Nullable Integer value) {
+        public final Builder _1xx(@Nullable Long value) {
             this._1xx = value;
             return this;
         }
@@ -254,7 +254,7 @@ public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocSt
          * </p>
          */
         @Nonnull
-        public final Builder _2xx(@Nullable Integer value) {
+        public final Builder _2xx(@Nullable Long value) {
             this._2xx = value;
             return this;
         }
@@ -266,7 +266,7 @@ public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocSt
          * </p>
          */
         @Nonnull
-        public final Builder _3xx(@Nullable Integer value) {
+        public final Builder _3xx(@Nullable Long value) {
             this._3xx = value;
             return this;
         }
@@ -278,7 +278,7 @@ public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocSt
          * </p>
          */
         @Nonnull
-        public final Builder _4xx(@Nullable Integer value) {
+        public final Builder _4xx(@Nullable Long value) {
             this._4xx = value;
             return this;
         }
@@ -290,7 +290,7 @@ public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocSt
          * </p>
          */
         @Nonnull
-        public final Builder _5xx(@Nullable Integer value) {
+        public final Builder _5xx(@Nullable Long value) {
             this._5xx = value;
             return this;
         }
@@ -320,11 +320,11 @@ public class DocStatus implements PlainJsonSerializable, ToCopyableBuilder<DocSt
     );
 
     protected static void setupDocStatusDeserializer(ObjectDeserializer<DocStatus.Builder> op) {
-        op.add(Builder::_1xx, JsonpDeserializer.integerDeserializer(), "1xx");
-        op.add(Builder::_2xx, JsonpDeserializer.integerDeserializer(), "2xx");
-        op.add(Builder::_3xx, JsonpDeserializer.integerDeserializer(), "3xx");
-        op.add(Builder::_4xx, JsonpDeserializer.integerDeserializer(), "4xx");
-        op.add(Builder::_5xx, JsonpDeserializer.integerDeserializer(), "5xx");
+        op.add(Builder::_1xx, JsonpDeserializer.longDeserializer(), "1xx");
+        op.add(Builder::_2xx, JsonpDeserializer.longDeserializer(), "2xx");
+        op.add(Builder::_3xx, JsonpDeserializer.longDeserializer(), "3xx");
+        op.add(Builder::_4xx, JsonpDeserializer.longDeserializer(), "4xx");
+        op.add(Builder::_5xx, JsonpDeserializer.longDeserializer(), "5xx");
     }
 
     @Override

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/ExistsRequest.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/ExistsRequest.java
@@ -158,7 +158,7 @@ public final class ExistsRequest extends RequestBase implements ToCopyableBuilde
     }
 
     /**
-     * If <code>true</code>, the request is real-time as opposed to near-real-time.
+     * If <code>true</code>, the request is real time as opposed to near real time.
      * <p>
      * API name: {@code realtime}
      * </p>
@@ -381,7 +381,7 @@ public final class ExistsRequest extends RequestBase implements ToCopyableBuilde
         }
 
         /**
-         * If <code>true</code>, the request is real-time as opposed to near-real-time.
+         * If <code>true</code>, the request is real time as opposed to near real time.
          * <p>
          * API name: {@code realtime}
          * </p>

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/ExistsSourceRequest.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/ExistsSourceRequest.java
@@ -154,7 +154,7 @@ public final class ExistsSourceRequest extends RequestBase implements ToCopyable
     }
 
     /**
-     * If <code>true</code>, the request is real-time as opposed to near-real-time.
+     * If <code>true</code>, the request is real time as opposed to near real time.
      * <p>
      * API name: {@code realtime}
      * </p>
@@ -361,7 +361,7 @@ public final class ExistsSourceRequest extends RequestBase implements ToCopyable
         }
 
         /**
-         * If <code>true</code>, the request is real-time as opposed to near-real-time.
+         * If <code>true</code>, the request is real time as opposed to near real time.
          * <p>
          * API name: {@code realtime}
          * </p>

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/GetRequest.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/GetRequest.java
@@ -135,7 +135,7 @@ public final class GetRequest extends RequestBase implements ToCopyableBuilder<G
     }
 
     /**
-     * Required - The name of the index that contains the document.
+     * Required - The name of the index containing the document.
      * <p>
      * API name: {@code index}
      * </p>
@@ -157,7 +157,7 @@ public final class GetRequest extends RequestBase implements ToCopyableBuilder<G
     }
 
     /**
-     * If <code>true</code>, the request is real-time as opposed to near-real-time.
+     * If <code>true</code>, the request is real time as opposed to near real time.
      * <p>
      * API name: {@code realtime}
      * </p>
@@ -357,7 +357,7 @@ public final class GetRequest extends RequestBase implements ToCopyableBuilder<G
         }
 
         /**
-         * Required - The name of the index that contains the document.
+         * Required - The name of the index containing the document.
          * <p>
          * API name: {@code index}
          * </p>
@@ -381,7 +381,7 @@ public final class GetRequest extends RequestBase implements ToCopyableBuilder<G
         }
 
         /**
-         * If <code>true</code>, the request is real-time as opposed to near-real-time.
+         * If <code>true</code>, the request is real time as opposed to near real time.
          * <p>
          * API name: {@code realtime}
          * </p>

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/GetSourceRequest.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/GetSourceRequest.java
@@ -131,7 +131,7 @@ public final class GetSourceRequest extends RequestBase implements ToCopyableBui
     }
 
     /**
-     * Required - The name of the index that contains the document.
+     * Required - The name of the index containing the document.
      * <p>
      * API name: {@code index}
      * </p>
@@ -153,7 +153,7 @@ public final class GetSourceRequest extends RequestBase implements ToCopyableBui
     }
 
     /**
-     * Boolean) If <code>true</code>, the request is real-time as opposed to near-real-time.
+     * Boolean) If <code>true</code>, the request is real time as opposed to near real time.
      * <p>
      * API name: {@code realtime}
      * </p>
@@ -337,7 +337,7 @@ public final class GetSourceRequest extends RequestBase implements ToCopyableBui
         }
 
         /**
-         * Required - The name of the index that contains the document.
+         * Required - The name of the index containing the document.
          * <p>
          * API name: {@code index}
          * </p>
@@ -361,7 +361,7 @@ public final class GetSourceRequest extends RequestBase implements ToCopyableBui
         }
 
         /**
-         * Boolean) If <code>true</code>, the request is real-time as opposed to near-real-time.
+         * Boolean) If <code>true</code>, the request is real time as opposed to near real time.
          * <p>
          * API name: {@code realtime}
          * </p>

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/MtermvectorsRequest.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/MtermvectorsRequest.java
@@ -244,7 +244,7 @@ public final class MtermvectorsRequest extends RequestBase
     }
 
     /**
-     * If <code>true</code>, the request is real-time as opposed to near-real-time.
+     * If <code>true</code>, the request is real time as opposed to near real time.
      * <p>
      * API name: {@code realtime}
      * </p>
@@ -613,7 +613,7 @@ public final class MtermvectorsRequest extends RequestBase
         }
 
         /**
-         * If <code>true</code>, the request is real-time as opposed to near-real-time.
+         * If <code>true</code>, the request is real time as opposed to near real time.
          * <p>
          * API name: {@code realtime}
          * </p>

--- a/java-codegen/opensearch-openapi.yaml
+++ b/java-codegen/opensearch-openapi.yaml
@@ -20432,7 +20432,7 @@ components:
     exists_source___query.realtime:
       in: query
       name: realtime
-      description: If `true`, the request is real-time as opposed to near-real-time.
+      description: If `true`, the request is real time as opposed to near real time.
       schema:
         type: boolean
       style: form
@@ -20518,7 +20518,7 @@ components:
     exists___query.realtime:
       in: query
       name: realtime
-      description: If `true`, the request is real-time as opposed to near-real-time.
+      description: If `true`, the request is real time as opposed to near real time.
       schema:
         type: boolean
       style: form
@@ -20893,7 +20893,7 @@ components:
     get_source___path.index:
       in: path
       name: index
-      description: The name of the index that contains the document.
+      description: The name of the index containing the document.
       required: true
       schema:
         $ref: '#/components/schemas/_common___IndexName'
@@ -20930,7 +20930,7 @@ components:
     get_source___query.realtime:
       in: query
       name: realtime
-      description: Boolean) If `true`, the request is real-time as opposed to near-real-time.
+      description: Boolean) If `true`, the request is real time as opposed to near real time.
       schema:
         type: boolean
       style: form
@@ -20973,7 +20973,7 @@ components:
     get___path.index:
       in: path
       name: index
-      description: The name of the index that contains the document.
+      description: The name of the index containing the document.
       required: true
       schema:
         $ref: '#/components/schemas/_common___IndexName'
@@ -21010,7 +21010,7 @@ components:
     get___query.realtime:
       in: query
       name: realtime
-      description: If `true`, the request is real-time as opposed to near-real-time.
+      description: If `true`, the request is real time as opposed to near real time.
       schema:
         type: boolean
       style: form
@@ -24747,7 +24747,7 @@ components:
     mget___query.realtime:
       in: query
       name: realtime
-      description: If `true`, the request is real-time as opposed to near-real-time.
+      description: If `true`, the request is real time as opposed to near real time.
       schema:
         type: boolean
       style: form
@@ -25308,7 +25308,7 @@ components:
     mtermvectors___query.realtime:
       in: query
       name: realtime
-      description: If `true`, the request is real-time as opposed to near-real-time.
+      description: If `true`, the request is real time as opposed to near real time.
       schema:
         type: boolean
         default: true
@@ -28467,7 +28467,7 @@ components:
     termvectors___path.index:
       in: path
       name: index
-      description: The name of the index that contains the document.
+      description: The name of the index containing the document.
       required: true
       schema:
         $ref: '#/components/schemas/_common___IndexName'
@@ -28523,7 +28523,7 @@ components:
     termvectors___query.realtime:
       in: query
       name: realtime
-      description: If `true`, the request is real-time as opposed to near-real-time.
+      description: If `true`, the request is real time as opposed to near real time.
       schema:
         type: boolean
         default: true
@@ -36778,23 +36778,23 @@ components:
       properties:
         1xx:
           type: integer
-          format: int32
+          format: int64
           description: The number of informational responses.
         2xx:
           type: integer
-          format: int32
+          format: int64
           description: The number of successful responses.
         3xx:
           type: integer
-          format: int32
+          format: int64
           description: The number of redirection responses.
         4xx:
           type: integer
-          format: int32
+          format: int64
           description: The number of client error responses.
         5xx:
           type: integer
-          format: int32
+          format: int64
           description: The number of server error responses.
     _common___Duration:
       description: A duration. Units can be `nanos`, `micros`, `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours) and `d` (days). Also accepts `0` without a unit and `-1` to indicate an unspecified value.


### PR DESCRIPTION
### Description

Since version 3.0.0 when calling `OpenSearchClient.nodes().stats()`, the function call fails on certain clusters with an error such as 
```
java.lang.RuntimeException: Jackson exception: Numeric value (5069719939) out of range of int (-2147483648 - 2147483647)
```
While debugging, it appears that the overflow error occurs because the `2xx` value in `doc_status` on a specific coordinator node exceeds the range of an integer.

![image](https://github.com/user-attachments/assets/53581d5a-f638-4959-88a9-e762f62f80d6)

To resolve this issue, the type of the `2xx` field was changed to `Long`.

### Issues Resolved

- https://github.com/opensearch-project/opensearch-java/issues/1645

