### PR TITLE
[Backport 2.x] jackson `ObjectMapper`: auto-detect modules (#1643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased 2.x]
 ### Added
+- Added Jackson `ObjectMapper` module auto-detection ([#1643](https://github.com/opensearch-project/opensearch-java/pull/1643))
 
 ### Dependencies
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -65,11 +65,12 @@ OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJ
 OpenSearchClient client = new OpenSearchClient(transport);
 ```
 
-The `JacksonJsonpMapper` class (2.x versions) only supports Java 7 objects by default. [Java 8 modules](https://github.com/FasterXML/jackson-modules-java8) to support JDK8 classes such as the Date and Time API (JSR-310), `Optional`, and more can be used by including [the additional datatype dependency](https://github.com/FasterXML/jackson-modules-java8#usage) and adding the module.  For example, to include JSR-310 classes:
+The `JacksonJsonpMapper` class (2.x versions) only supports Java 7 objects by default. [Java 8 modules](https://github.com/FasterXML/jackson-modules-java8) to support JDK8 classes such as the Date and Time API (JSR-310), `Optional`, and more can be used by including [the additional datatype dependency](https://github.com/FasterXML/jackson-modules-java8#usage) and adding the module. Auto-detection for these modules is enabled, adding them to the classpath is enough.
+You can also provide your own `ObjectMapper` instance if you need to pre-configure it differently, for example:
 
 ```java
-Transport transport = new RestClientTransport(restClient,
-    new JacksonJsonpMapper(new ObjectMapper().registerModule(new JavaTimeModule()))); 
+OpenSearchTransport transport = new RestClientTransport(restClient,
+    new JacksonJsonpMapper(new ObjectMapper().findAndRegisterModules().configure(SerializationFeature.INDENT_OUTPUT, true))); 
 OpenSearchClient client = new OpenSearchClient(transport);
 ```
 

--- a/java-client/src/main/java/org/opensearch/client/json/jackson/JacksonJsonpMapper.java
+++ b/java-client/src/main/java/org/opensearch/client/json/jackson/JacksonJsonpMapper.java
@@ -63,7 +63,9 @@ public class JacksonJsonpMapper extends JsonpMapperBase {
 
     public JacksonJsonpMapper() {
         this(
-            new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false).setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .findAndRegisterModules()
         );
     }
 


### PR DESCRIPTION
(cherry picked from commit c1ae512803223204800a860f797f146871131bda)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
