### PR TITLE
Specify head ref to checkout in dependabot PR workflow

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.github_app_token.outputs.token }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - id: version
         run: |


### PR DESCRIPTION
### Description
See failure here: https://github.com/opensearch-project/opensearch-java/actions/runs/15971868643/job/45044679254?pr=1650
Following suggested workarounds here: https://github.com/stefanzweifel/git-auto-commit-action/issues/383

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
