### PR TITLE
NodeState Getter to monitor node availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added support for the `ltr` namespace ([#1689](https://github.com/opensearch-project/opensearch-java/pull/1689))
 - Added support for the `geospatial` namespace ([#1690](https://github.com/opensearch-project/opensearch-java/pull/1690))
 - Added support for the `knn` namespace ([#1693](https://github.com/opensearch-project/opensearch-java/pull/1693))
+- Added getter for retrieve all nodes along with its state([#1698](https://github.com/opensearch-project/opensearch-java/pull/1698))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added support for the `ltr` namespace ([#1689](https://github.com/opensearch-project/opensearch-java/pull/1689))
 - Added support for the `geospatial` namespace ([#1690](https://github.com/opensearch-project/opensearch-java/pull/1690))
 - Added support for the `knn` namespace ([#1693](https://github.com/opensearch-project/opensearch-java/pull/1693))
-- Added getter for retrieve all nodes along with its state([#1698](https://github.com/opensearch-project/opensearch-java/pull/1698))
+- Added getter for retrieve all nodes along with their state ([#1698](https://github.com/opensearch-project/opensearch-java/pull/1698))
 
 ### Dependencies
 

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Transport.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Transport.java
@@ -98,6 +98,7 @@ import org.opensearch.client.transport.endpoints.BooleanResponse;
 import org.opensearch.client.transport.httpclient5.internal.HttpUriRequestProducer;
 import org.opensearch.client.transport.httpclient5.internal.Node;
 import org.opensearch.client.transport.httpclient5.internal.NodeSelector;
+import org.opensearch.client.transport.httpclient5.internal.NodeState;
 import org.opensearch.client.util.MissingRequiredPropertyException;
 
 /**

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Transport.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Transport.java
@@ -147,11 +147,6 @@ public class ApacheHttpClient5Transport implements OpenSearchTransport {
         setNodes(nodes);
     }
 
-    public enum NodeState {
-        Active,
-        Unavailable
-    }
-
     @Override
     public <RequestT, ResponseT, ErrorT> ResponseT performRequest(
         RequestT request,

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Transport.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Transport.java
@@ -1170,4 +1170,16 @@ public class ApacheHttpClient5Transport implements OpenSearchTransport {
         return new RuntimeException("error while performing request", exception);
     }
 
+    public List<HttpHost> getDenyList() {
+        List<HttpHost> denyNodeList = new ArrayList();
+
+        for(Node node : (List)this.nodeTuple.nodes) {
+            if (this.denylist.containsKey(node.getHost())) {
+                denyNodeList.add(node.getHost());
+            }
+        }
+
+        return denyNodeList;
+    }
+
 }

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Transport.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Transport.java
@@ -1171,6 +1171,15 @@ public class ApacheHttpClient5Transport implements OpenSearchTransport {
         return new RuntimeException("error while performing request", exception);
     }
 
+    /**
+     * Returns a map of all nodes managed by this transport and their current state.
+     * <p>
+     * Each node is mapped to either {@link NodeState#Active} if it is available for requests,
+     * or {@link NodeState#Unavailable} if it is currently denylisted due to previous failures.
+     * Nodes that are eligible for retry are considered active.
+     *
+     * @return an unmodifiable map of nodes to their current state
+     */
     public Map<Node, NodeState> getNodes() {
         Map<Node, NodeState> nodes = new LinkedHashMap<>();
         for (Node node : nodeTuple.nodes) {

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/internal/NodeState.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/internal/NodeState.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.transport.httpclient5.internal;
+
+public enum NodeState {
+    Active,
+    Unavailable
+}


### PR DESCRIPTION
### Description
Provides a public getter (getNodes()) to access nodes along with their states so users can integrate it with metrics systems and monitor node availability from client perspective.

### Issues Resolved
This PR addresses https://github.com/opensearch-project/opensearch-java/issues/1699

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
