### PR TITLE
[Backport] [3.x] Bump com.github.jk1.dependency-license-report from 2.9 to 3.0.1 (#1781)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
+- Bump `com.github.jk1.dependency-license-report` from 2.9 to 3.0.1 ([#1779](https://github.com/opensearch-project/opensearch-java/pull/1779), [#1781](https://github.com/opensearch-project/opensearch-java/pull/1781))
 
 ### Changed
 
@@ -375,7 +376,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix integer overflow for variables in indices stats response ([#877](https://github.com/opensearch-project/opensearch-java/pull/877))
 - Support weight function in function score query ([#880](https://github.com/opensearch-project/opensearch-java/pull/880))
 - Fix pattern replace by making flag and replacement optional as on api  ([#895](https://github.com/opensearch-project/opensearch-java/pull/895))
-- Client with Java 8 runtime and Apache HttpClient 5 Transport fails with java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer ([#920](https://github.com/opensearch-project/opensearch-java/pull/920)) 
+- Client with Java 8 runtime and Apache HttpClient 5 Transport fails with java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer ([#920](https://github.com/opensearch-project/opensearch-java/pull/920))
 - Add missed field  "filter" to NeuralQuery model class
 
 ## [2.9.0] - 02/22/2024
@@ -459,7 +460,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `org.ajoberstar.grgit:grgit-gradle` from 5.0.0 to 5.2.0
 - Bumps `com.github.jk1.dependency-license-report` from 2.4 to 2.5
 - Bumps `io.github.classgraph:classgraph` from 4.8.160 to 4.8.161
-  
+
 ### Changed
 - Moved "software.amazon.awssdk" dependencies to the compileOnly scope. ([#628](https://github.com/opensearch-project/opensearch-java/pull/628))
 - Migrated from checkstyle to spotless ([#648](https://github.com/opensearch-project/opensearch-java/pull/648))
@@ -551,7 +552,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add 1-click release workflows ([#321](https://github.com/opensearch-project/opensearch-java/pull/321))
 - Add support for OpenSearch Serverless ([#339](https://github.com/opensearch-project/opensearch-java/pull/339))
 - Add support to parse sub-aggregations from filter/nested aggregations ([#234](https://github.com/opensearch-project/opensearch-java/pull/234))
-  
+
 ### Dependencies
 - Bumps `grgit-gradle` from 4.0.1 to 5.0.0
 - Update Jackson to 2.14.0 ([#259](https://github.com/opensearch-project/opensearch-java/pull/259))
@@ -560,7 +561,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Update literature around changelog contributions in CONTRIBUTING.md ([#242](https://github.com/opensearch-project/opensearch-java/pull/242))
 - Update tests to use JUnit's Assert ([#244](https://github.com/opensearch-project/opensearch-java/pull/244))
-- Add timeout and throttle to the jenkins workflows ([#231](https://github.com/opensearch-project/opensearch-java/pull/231)) 
+- Add timeout and throttle to the jenkins workflows ([#231](https://github.com/opensearch-project/opensearch-java/pull/231))
 - Update maintainers, admins and documentation ([#248](https://github.com/opensearch-project/opensearch-java/pull/248))
 
 ### Deprecated

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -51,7 +51,7 @@ plugins {
     java
     `java-library`
     `maven-publish`
-    id("com.github.jk1.dependency-license-report") version "2.9"
+    id("com.github.jk1.dependency-license-report") version "3.0.1"
     id("org.owasp.dependencycheck") version "12.1.3"
 
     id("opensearch-java.spotless-conventions")

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -30,7 +30,7 @@ buildscript {
 
 plugins {
     application
-    id("com.github.jk1.dependency-license-report") version "2.9"
+    id("com.github.jk1.dependency-license-report") version "3.0.1"
     id("org.owasp.dependencycheck") version "12.1.2"
     id("de.undercouch.download") version "5.6.0"
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1781 and https://github.com/opensearch-project/opensearch-java/pull/1779 to 3.x