### PR TITLE
Migrate Github Actions from macos-13 (deprecated / removed) to macos-14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: [ 21, 25 ]
-        os: [ubuntu-latest, windows-latest, macOS-13, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-14, macOS-latest]
     steps:
       - name: Checkout Java Client
         uses: actions/checkout@v6

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-13]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout Java Client
         uses: actions/checkout@v6


### PR DESCRIPTION
### Description
Migrate Github Actions from macos-13 (deprecated / removed) to macos-14

### Issues Resolved
See please https://github.com/actions/runner-images/issues/13046

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
