### PR TITLE
Fix NPE when null ObjectBuilder is accessed (#1784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased 3.x]
 ### Added
 - Fix formatting of the main method to run for various samples ([#1749](https://github.com/opensearch-project/opensearch-java/pull/1749))
+- Fix NPE when null ObjectBuilder is accessed ([#1717](https://github.com/opensearch-project/opensearch-java/issues/1717))
 
 ### Dependencies
 - Bump `com.github.jk1.dependency-license-report` from 2.9 to 3.0.1 ([#1779](https://github.com/opensearch-project/opensearch-java/pull/1779), [#1781](https://github.com/opensearch-project/opensearch-java/pull/1781))

--- a/java-client/src/main/java/org/opensearch/client/json/ObjectBuilderDeserializer.java
+++ b/java-client/src/main/java/org/opensearch/client/json/ObjectBuilderDeserializer.java
@@ -89,12 +89,12 @@ public class ObjectBuilderDeserializer<T, B extends ObjectBuilder<T>> extends De
     @Override
     public T deserialize(JsonParser parser, JsonpMapper mapper) {
         ObjectBuilder<T> builder = builderDeserializer.deserialize(parser, mapper);
-        return builder.build();
+        return builder != null ? builder.build() : null;
     }
 
     @Override
     public T deserialize(JsonParser parser, JsonpMapper mapper, JsonParser.Event event) {
         ObjectBuilder<T> builder = builderDeserializer.deserialize(parser, mapper, event);
-        return builder.build();
+        return builder != null ? builder.build() : null;
     }
 }


### PR DESCRIPTION
(cherry picked from commit e0833ff74487d2ac184aad21dbb249e1daa127b1)

### Description
Backport for #1784  

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
