### PR TITLE
[BACKPORT][3.x] 1803 - [BUG] Implement equals/hashCode for JsonDataImpl (#1838)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix formatting of the main method to run for various samples ([#1749](https://github.com/opensearch-project/opensearch-java/pull/1749))
 - Fix NPE when null ObjectBuilder is accessed ([#1717](https://github.com/opensearch-project/opensearch-java/issues/1717))
 - Added BulkIngester helper for efficient bulk operations with buffering, retries, and backpressure. Ported from elasticsearch-java (commit e7120d4) ([#1809](https://github.com/opensearch-project/opensearch-java/pull/1809))
+- Added equals and hashCode implementation to JsonDataImpl ([#1803](https://github.com/opensearch-project/opensearch-java/pull/1838))
 
 ### Dependencies
 - Bump `com.github.jk1.dependency-license-report` from 2.9 to 3.0.1 ([#1779](https://github.com/opensearch-project/opensearch-java/pull/1779), [#1781](https://github.com/opensearch-project/opensearch-java/pull/1781))

--- a/java-client/src/main/java/org/opensearch/client/json/JsonDataImpl.java
+++ b/java-client/src/main/java/org/opensearch/client/json/JsonDataImpl.java
@@ -39,6 +39,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Objects;
 
 class JsonDataImpl implements JsonData {
     private final Object value;
@@ -158,5 +159,20 @@ class JsonDataImpl implements JsonData {
         generator.close();
 
         return mapper.jsonProvider().createParser(new StringReader(sw.toString()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JsonDataImpl jsonDataImpl = (JsonDataImpl) o;
+        // Compare only 'value'. Because 'mapper' is a processing utility, not part of the data identity
+        return Objects.equals(value, jsonDataImpl.value);
+    }
+
+    @Override
+    public int hashCode() {
+        // Use Objects.hashCode for a single field to avoid the array creation overhead of Objects.hash
+        return Objects.hashCode(value);
     }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/json/JsonDataTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/json/JsonDataTest.java
@@ -40,6 +40,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch.model.ModelTestCase;
 
@@ -88,5 +89,44 @@ public class JsonDataTest extends Assert {
 
         assertEquals(JsonValue.ValueType.STRING, value.getValueType());
         assertEquals("foo", ((JsonString) value).getString());
+    }
+
+    @Test
+    public void testEqualsAndHashcodeSameInstance() {
+        JsonData data = JsonData.of("value");
+
+        assertEquals(data, data);
+    }
+
+    @Test
+    public void testEqualsAndHashcodeLogicalEquality() {
+        String value = "value";
+        JsonData data1 = JsonData.of(value);
+        JsonData data2 = JsonData.of(value);
+
+        assertEquals(data1, data2);
+        assertEquals(data1.hashCode(), data2.hashCode());
+    }
+
+    @Test
+    public void testEqualsAndHashcodeRegardlessOfMapper() {
+        JacksonJsonpMapper mapper1 = new JacksonJsonpMapper();
+        JsonbJsonpMapper mapper2 = new JsonbJsonpMapper();
+
+        String value = "value";
+        JsonData data1 = JsonData.of(value, mapper1);
+        JsonData data2 = JsonData.of(value, mapper2);
+
+        assertEquals(data1, data2);
+        assertEquals(data1.hashCode(), data2.hashCode());
+    }
+
+    @Test
+    public void testEqualsAndHashcodeDifferentValues() {
+        JsonpMapper mapper = new JsonbJsonpMapper();
+        JsonData data1 = JsonData.of("value1", mapper);
+        JsonData data2 = JsonData.of("value2", mapper);
+
+        assertNotEquals(data1, data2);
     }
 }


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/opensearch-java/pull/1838 to 3.x

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
