### PR TITLE
[Backport] [3.x] Bump org.apache.httpcomponents.client5:httpclient5 from 5.5.1 to 5.6 (#1844)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bump `gradle-wrapper` from 9.2.0 to 9.3.0 ([#1862](https://github.com/opensearch-project/opensearch-java/pull/1862))
+- Bump `org.apache.httpcomponents.client5:httpclient5` from 5.5 to 5.6 [#1844](https://github.com/opensearch-project/opensearch-java/pull/1844)
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -176,11 +176,11 @@ val integrationTest = task<Test>("integrationTest") {
             System.getProperty("tests.awsSdk2support.domainRegion", "us-east-1"))
 }
 
-val opensearchVersion = "3.0.0-SNAPSHOT"
+val opensearchVersion = "3.5.0"
 
 dependencies {
-    val jacksonVersion = "2.18.3"
-    val jacksonDatabindVersion = "2.18.3"
+    val jacksonVersion = "2.20.1"
+    val jacksonDatabindVersion = "2.20.1"
 
     // Apache 2.0
     api("commons-logging:commons-logging:1.3.5")
@@ -191,11 +191,11 @@ dependencies {
     }
     testImplementation("org.opensearch.client", "opensearch-rest-client", opensearchVersion)
 
-    api("org.apache.httpcomponents.client5:httpclient5:5.5") {
+    api("org.apache.httpcomponents.client5:httpclient5:5.6") {
       exclude(group = "org.apache.httpcomponents.core5")
     }
-    api("org.apache.httpcomponents.core5:httpcore5:5.3.4")
-    api("org.apache.httpcomponents.core5:httpcore5-h2:5.3.4")
+    api("org.apache.httpcomponents.core5:httpcore5:5.4")
+    api("org.apache.httpcomponents.core5:httpcore5-h2:5.4")
 
     // Apache 2.0
     // https://search.maven.org/artifact/com.google.code.findbugs/jsr305
@@ -250,6 +250,10 @@ dependencies {
     testImplementation("junit", "junit" , "4.13.2") {
         exclude(group = "org.hamcrest")
     }
+    
+    // The Bouncy Castle License (MIT): https://www.bouncycastle.org/licence.html
+    testImplementation("org.bouncycastle", "bcprov-lts8on", "2.73.6")
+    testImplementation("org.bouncycastle", "bcpkix-lts8on", "2.73.6")
 }
 
 licenseReport {
@@ -399,10 +403,4 @@ if (runtimeJavaVersion >= JavaVersion.VERSION_21) {
     testClassesDirs += java21.output.classesDirs
     classpath = sourceSets["java21"].runtimeClasspath
  }
-} else {
-  dependencies {
-    // The Bouncy Castle License (MIT): https://www.bouncycastle.org/licence.html
-    testImplementation("org.bouncycastle", "bcprov-lts8on", "2.73.6")
-    testImplementation("org.bouncycastle", "bcpkix-lts8on", "2.73.6")
-  }
 }

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Transport.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Transport.java
@@ -56,7 +56,6 @@ import org.apache.hc.client5.http.auth.Credentials;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.classic.methods.HttpHead;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
-import org.apache.hc.client5.http.entity.GzipDecompressingEntity;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.auth.BasicAuthCache;
 import org.apache.hc.client5.http.impl.auth.BasicScheme;
@@ -303,12 +302,6 @@ public class ApacheHttpClient5Transport implements OpenSearchTransport {
         final WarningsHandler warningsHandler
     ) throws IOException {
         int statusCode = httpResponse.getCode();
-
-        Optional.ofNullable(httpResponse.getEntity())
-            .map(HttpEntity::getContentEncoding)
-            .filter("gzip"::equalsIgnoreCase)
-            .map(gzipHeaderValue -> new GzipDecompressingEntity(httpResponse.getEntity()))
-            .ifPresent(httpResponse::setEntity);
 
         Response response = new Response(new RequestLine(request), node.getHost(), httpResponse);
         Set<Integer> ignoreErrorCodes = getIgnoreErrorCodes("400,401,403,404,405", request.getMethod());


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1844 to `3.x`