### PR TITLE
[Forwardport] [main] Prepare 3.6.0 release (#1873)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `org.ajoberstar.grgit:grgit-gradle` from 5.3.2 to 5.3.3 ([#1723](https://github.com/opensearch-project/opensearch-java/pull/1723))
 - Bump `org.apache.httpcomponents.core5:httpcore5` from 5.3.4 to 5.4 ([#1726](https://github.com/opensearch-project/opensearch-java/pull/1726), [#1733](https://github.com/opensearch-project/opensearch-java/pull/1733), [#1815](https://github.com/opensearch-project/opensearch-java/pull/1815))
 - Bump `org.owasp.dependencycheck` from 12.1.3 to 12.2.0 ([#1735](https://github.com/opensearch-project/opensearch-java/pull/1735), [#1742](https://github.com/opensearch-project/opensearch-java/pull/1742), [#1754](https://github.com/opensearch-project/opensearch-java/pull/1754), [#1765](https://github.com/opensearch-project/opensearch-java/pull/1765), [#1796](https://github.com/opensearch-project/opensearch-java/pull/1796), [#1854](https://github.com/opensearch-project/opensearch-java/pull/1854))
-- Bump `org.apache.httpcomponents.client5:httpclient5` from 5.5 to 5.6 ([#1740](https://github.com/opensearch-project/opensearch-java/pull/1740), [#1844](https://github.com/opensearch-project/opensearch-java/pull/1844))
-- Bump `gradle-wrapper` from 9.2.0 to 9.3.1 ([#1862](https://github.com/opensearch-project/opensearch-java/pull/1862), [#1864](https://github.com/opensearch-project/opensearch-java/pull/1864))
-- Bump `de.undercouch.download` from 5.6.0 to 5.7.0 ([#1867](https://github.com/opensearch-project/opensearch-java/pull/1867))
 
 ### Added
 
@@ -39,6 +36,26 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [3.6.0] - 02/11/2026
+### Added
+
+### Dependencies
+- Bump `de.undercouch.download` from 5.6.0 to 5.7.0 ([#1867](https://github.com/opensearch-project/opensearch-java/pull/1867))
+- Bump `org.owasp.dependencycheck` from 12.1.2 to 12.2.0 ([#1735](https://github.com/opensearch-project/opensearch-java/pull/1735), [#1742](https://github.com/opensearch-project/opensearch-java/pull/1742), [#1754](https://github.com/opensearch-project/opensearch-java/pull/1754), [#1765](https://github.com/opensearch-project/opensearch-java/pull/1765), [#1796](https://github.com/opensearch-project/opensearch-java/pull/1796), [#1854](https://github.com/opensearch-project/opensearch-java/pull/1854))
+- Bump `gradle-wrapper` from 9.3.0 to 9.3.1 ([#1864](https://github.com/opensearch-project/opensearch-java/pull/1864))
+- Bump `gradle-wrapper` from 9.2.0 to 9.3.0 ([#1862](https://github.com/opensearch-project/opensearch-java/pull/1862))
+- Bump `org.apache.httpcomponents.client5:httpclient5` from 5.5 to 5.6 [#1844](https://github.com/opensearch-project/opensearch-java/pull/1844)
 
 ### Changed
 
@@ -637,8 +654,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix StoryStats numeric value out of range of int ([#489](https://github.com/opensearch-project/opensearch-java/pull/489))
 
 [Unreleased 4.x]: https://github.com/opensearch-project/opensearch-java/compare/3.x...main
-[Unreleased 3.x]: https://github.com/opensearch-project/opensearch-java/compare/v3.5.0...3.x
+[Unreleased 3.x]: https://github.com/opensearch-project/opensearch-java/compare/v3.6.0...3.x
 [Unreleased 2.x]: https://github.com/opensearch-project/opensearch-java/compare/v2.26.0...2.x
+[3.6.0]: https://github.com/opensearch-project/opensearch-java/compare/v3.5.0...v3.6.0
 [3.5.0]: https://github.com/opensearch-project/opensearch-java/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/opensearch-project/opensearch-java/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/opensearch-project/opensearch-java/compare/v3.2.0...v3.3.0


### PR DESCRIPTION
Forwardport of https://github.com/opensearch-project/opensearch-java/pull/1873 to `main`