### PR TITLE
[1887] Fix NPE in transport option conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fix NPEs while converting transport options when null options, headers, or query parameters are provided ([#1887](https://github.com/opensearch-project/opensearch-java/pull/1888))
 
 ### Security
 

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Options.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5Options.java
@@ -220,16 +220,25 @@ public class ApacheHttpClient5Options implements TransportOptions {
     }
 
     static ApacheHttpClient5Options of(TransportOptions options) {
+        if (options == null) return DEFAULT;
+
         if (options instanceof ApacheHttpClient5Options) {
             return (ApacheHttpClient5Options) options;
-
-        } else {
-            final Builder builder = new Builder(DEFAULT.toBuilder());
-            options.headers().forEach(h -> builder.addHeader(h.getKey(), h.getValue()));
-            options.queryParameters().forEach(builder::setParameter);
-            builder.onWarnings(options.onWarnings());
-            return builder.build();
         }
+
+        final Builder builder = new Builder(DEFAULT.toBuilder());
+        final Collection<Entry<String, String>> headers = options.headers();
+        if (headers != null && !headers.isEmpty()) {
+            headers.forEach(h -> builder.addHeader(h.getKey(), h.getValue()));
+        }
+
+        final Map<String, String> parameters = options.queryParameters();
+        if (parameters != null && !parameters.isEmpty()) {
+            parameters.forEach(builder::setParameter);
+        }
+
+        builder.onWarnings(options.onWarnings());
+        return builder.build();
     }
 
     /**

--- a/java-client/src/main/java/org/opensearch/client/transport/rest_client/RestClientOptions.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/rest_client/RestClientOptions.java
@@ -57,16 +57,28 @@ public class RestClientOptions implements TransportOptions {
     private final RequestOptions options;
 
     static RestClientOptions of(TransportOptions options) {
+        if (options == null) {
+            return new Builder(RequestOptions.DEFAULT.toBuilder()).build();
+        }
+
         if (options instanceof RestClientOptions) {
             return (RestClientOptions) options;
-
-        } else {
-            final Builder builder = new Builder(RequestOptions.DEFAULT.toBuilder());
-            options.headers().forEach(h -> builder.addHeader(h.getKey(), h.getValue()));
-            options.queryParameters().forEach(builder::setParameter);
-            builder.onWarnings(options.onWarnings());
-            return builder.build();
         }
+
+        final Builder builder = new Builder(RequestOptions.DEFAULT.toBuilder());
+
+        final Collection<Map.Entry<String, String>> headers = options.headers();
+        if (headers != null && !headers.isEmpty()) {
+            headers.forEach(h -> builder.addHeader(h.getKey(), h.getValue()));
+        }
+
+        final Map<String, String> parameters = options.queryParameters();
+        if (parameters != null && !parameters.isEmpty()) {
+            parameters.forEach(builder::setParameter);
+        }
+
+        builder.onWarnings(options.onWarnings());
+        return builder.build();
     }
 
     public RestClientOptions(RequestOptions options) {

--- a/java-client/src/test/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5OptionsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5OptionsTest.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.transport.httpclient5;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.client.transport.TransportOptions;
+
+public class ApacheHttpClient5OptionsTest extends Assert {
+    @Test
+    public void testOfWithNullOptions() {
+        // Null input should fall back to defaults instead of throwing.
+        ApacheHttpClient5Options options = ApacheHttpClient5Options.of(null);
+
+        assertNotNull(options);
+        assertNotNull(options.headers());
+    }
+
+    @Test
+    public void testOfWithNullHeaders() {
+        // Missing headers from source options should be treated as empty.
+        ApacheHttpClient5Options options = ApacheHttpClient5Options.of(
+            transportOptions(null, Collections.emptyMap(), warnings -> warnings != null && !warnings.isEmpty())
+        );
+
+        assertNotNull(options);
+        assertNotNull(options.headers());
+        assertTrue(options.headers().isEmpty());
+        assertNotNull(options.onWarnings());
+        assertTrue(options.onWarnings().apply(Collections.singletonList("warning")));
+    }
+
+    @Test
+    public void testOfWithNullQueryParameters() {
+        // Null query parameters should not drop other fields during conversion.
+        ApacheHttpClient5Options options = ApacheHttpClient5Options.of(
+            transportOptions(
+                Collections.singletonList(new AbstractMap.SimpleImmutableEntry<>("x-test-header", "value")),
+                null,
+                warnings -> warnings != null && !warnings.isEmpty()
+            )
+        );
+
+        assertNotNull(options);
+        assertNotNull(options.onWarnings());
+        assertTrue(options.onWarnings().apply(Collections.singletonList("warning")));
+        assertTrue(containsHeader(options.headers(), "x-test-header", "value"));
+    }
+
+    private static boolean containsHeader(Collection<Entry<String, String>> headers, String name, String value) {
+        for (Entry<String, String> header : headers) {
+            if (name.equals(header.getKey()) && value.equals(header.getValue())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static TransportOptions transportOptions(
+        Collection<Entry<String, String>> headers,
+        Map<String, String> queryParameters,
+        Function<List<String>, Boolean> warningsHandler
+    ) {
+        return new TransportOptions() {
+            @Override
+            public Collection<Entry<String, String>> headers() {
+                return headers;
+            }
+
+            @Override
+            public Map<String, String> queryParameters() {
+                return queryParameters;
+            }
+
+            @Override
+            public Function<List<String>, Boolean> onWarnings() {
+                return warningsHandler;
+            }
+
+            @Override
+            public Builder toBuilder() {
+                return new BuilderImpl(this);
+            }
+        };
+    }
+}

--- a/java-client/src/test/java/org/opensearch/client/transport/rest_client/RestClientOptionsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/transport/rest_client/RestClientOptionsTest.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.transport.rest_client;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.client.transport.TransportOptions;
+
+public class RestClientOptionsTest extends Assert {
+    @Test
+    public void testOfWithNullOptions() {
+        // Null input should fall back to defaults instead of throwing.
+        RestClientOptions options = RestClientOptions.of(null);
+
+        assertNotNull(options);
+        assertNotNull(options.headers());
+    }
+
+    @Test
+    public void testOfWithNullHeaders() {
+        // Missing headers from source options should be treated as empty.
+        RestClientOptions options = RestClientOptions.of(
+            transportOptions(null, Collections.emptyMap(), warnings -> warnings != null && !warnings.isEmpty())
+        );
+
+        assertNotNull(options);
+        assertNotNull(options.headers());
+        assertTrue(options.headers().isEmpty());
+        assertNotNull(options.onWarnings());
+        assertTrue(options.onWarnings().apply(Collections.singletonList("warning")));
+    }
+
+    @Test
+    public void testOfWithNullQueryParameters() {
+        // Null query parameters should not drop other fields during conversion.
+        RestClientOptions options = RestClientOptions.of(
+            transportOptions(
+                Collections.singletonList(new AbstractMap.SimpleImmutableEntry<>("x-test-header", "value")),
+                null,
+                warnings -> warnings != null && !warnings.isEmpty()
+            )
+        );
+
+        assertNotNull(options);
+        assertNotNull(options.onWarnings());
+        assertTrue(options.onWarnings().apply(Collections.singletonList("warning")));
+        assertTrue(containsHeader(options.headers(), "x-test-header", "value"));
+    }
+
+    private static boolean containsHeader(Collection<Entry<String, String>> headers, String name, String value) {
+        for (Entry<String, String> header : headers) {
+            if (name.equals(header.getKey()) && value.equals(header.getValue())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static TransportOptions transportOptions(
+        Collection<Entry<String, String>> headers,
+        Map<String, String> queryParameters,
+        Function<List<String>, Boolean> warningsHandler
+    ) {
+        return new TransportOptions() {
+            @Override
+            public Collection<Entry<String, String>> headers() {
+                return headers;
+            }
+
+            @Override
+            public Map<String, String> queryParameters() {
+                return queryParameters;
+            }
+
+            @Override
+            public Function<List<String>, Boolean> onWarnings() {
+                return warningsHandler;
+            }
+
+            @Override
+            public Builder toBuilder() {
+                return new BuilderImpl(this);
+            }
+        };
+    }
+}


### PR DESCRIPTION
### Description
This change prevents NullPointerException in transport option conversion.
[ApacheHttpClient5Options.of(...)](app://-/index.html#) and [RestClientOptions.of(...)](app://-/index.html#) now safely handle null input options, headers(), and queryParameters() (treated as empty).
It also adds unit tests for these null cases.

### Issues Resolved
This Pull Request resolved the issue #1887 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
