### PR TITLE
Fix int overflow in ISM lastUpdatedTime field

### DIFF
--- a/java-client/src/generated/java/org/opensearch/client/opensearch/ism/IsmTemplate.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/ism/IsmTemplate.java
@@ -65,7 +65,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
     private final List<String> indexPatterns;
 
     @Nullable
-    private final Integer lastUpdatedTime;
+    private final Long lastUpdatedTime;
 
     @Nullable
     private final Number priority;
@@ -100,7 +100,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
      * </p>
      */
     @Nullable
-    public final Integer lastUpdatedTime() {
+    public final Long lastUpdatedTime() {
         return this.lastUpdatedTime;
     }
 
@@ -166,7 +166,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
         @Nullable
         private List<String> indexPatterns;
         @Nullable
-        private Integer lastUpdatedTime;
+        private Long lastUpdatedTime;
         @Nullable
         private Number priority;
 
@@ -229,7 +229,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
          * </p>
          */
         @Nonnull
-        public final Builder lastUpdatedTime(@Nullable Integer value) {
+        public final Builder lastUpdatedTime(@Nullable Long value) {
             this.lastUpdatedTime = value;
             return this;
         }
@@ -272,7 +272,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
 
     protected static void setupIsmTemplateDeserializer(ObjectDeserializer<IsmTemplate.Builder> op) {
         op.add(Builder::indexPatterns, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "index_patterns");
-        op.add(Builder::lastUpdatedTime, JsonpDeserializer.integerDeserializer(), "last_updated_time");
+        op.add(Builder::lastUpdatedTime, JsonpDeserializer.longDeserializer(), "last_updated_time");
         op.add(Builder::priority, JsonpDeserializer.numberDeserializer(), "priority");
     }
 

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/ism/Policy.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/ism/Policy.java
@@ -77,7 +77,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
     private final List<IsmTemplate> ismTemplate;
 
     @Nullable
-    private final Integer lastUpdatedTime;
+    private final Long lastUpdatedTime;
 
     @Nullable
     private final String policyId;
@@ -156,7 +156,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
      * </p>
      */
     @Nullable
-    public final Integer lastUpdatedTime() {
+    public final Long lastUpdatedTime() {
         return this.lastUpdatedTime;
     }
 
@@ -279,7 +279,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
         @Nullable
         private List<IsmTemplate> ismTemplate;
         @Nullable
-        private Integer lastUpdatedTime;
+        private Long lastUpdatedTime;
         @Nullable
         private String policyId;
         @Nullable
@@ -418,7 +418,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
          * </p>
          */
         @Nonnull
-        public final Builder lastUpdatedTime(@Nullable Integer value) {
+        public final Builder lastUpdatedTime(@Nullable Long value) {
             this.lastUpdatedTime = value;
             return this;
         }
@@ -523,7 +523,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
         op.add(Builder::description, JsonpDeserializer.stringDeserializer(), "description");
         op.add(Builder::errorNotification, ErrorNotification._DESERIALIZER, "error_notification");
         op.add(Builder::ismTemplate, JsonpDeserializer.arrayDeserializer(IsmTemplate._DESERIALIZER), "ism_template");
-        op.add(Builder::lastUpdatedTime, JsonpDeserializer.integerDeserializer(), "last_updated_time");
+        op.add(Builder::lastUpdatedTime, JsonpDeserializer.longDeserializer(), "last_updated_time");
         op.add(Builder::policyId, JsonpDeserializer.stringDeserializer(), "policy_id");
         op.add(Builder::schemaVersion, JsonpDeserializer.numberDeserializer(), "schema_version");
         op.add(Builder::states, JsonpDeserializer.arrayDeserializer(States._DESERIALIZER), "states");

--- a/java-codegen/opensearch-openapi.yaml
+++ b/java-codegen/opensearch-openapi.yaml
@@ -61710,6 +61710,7 @@ components:
           description: The priority of the ISM template.
         last_updated_time:
           type: integer
+          format: int64
           description: When the ISM template was last updated.
     ism._common___Metadata:
       type: object
@@ -61735,6 +61736,7 @@ components:
           description: The description of the policy.
         last_updated_time:
           type: integer
+          format: int64
           description: When the policy was last updated.
         schema_version:
           type: number


### PR DESCRIPTION
The lastUpdatedTime field in ISM policy and template objects was using Integer, which overflows for large timestamp values. Changed to Long to match actual usage and prevent overflow. Fixes #1898