### PR TITLE
[Backport] [3.x] Bump com.github.jk1.dependency-license-report from 3.1.1 to 3.1.2 (#1952)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Dependencies
+- Bump `com.github.jk1.dependency-license-report` from 3.1.1 to 3.1.2 ([#1952](https://github.com/opensearch-project/opensearch-java/pull/1952))
 
 ### Changed
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -51,7 +51,7 @@ plugins {
     java
     `java-library`
     `maven-publish`
-    id("com.github.jk1.dependency-license-report") version "3.1.1"
+    id("com.github.jk1.dependency-license-report") version "3.1.2"
     id("org.owasp.dependencycheck") version "12.1.3"
 
     id("opensearch-java.spotless-conventions")

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -30,7 +30,7 @@ buildscript {
 
 plugins {
     application
-    id("com.github.jk1.dependency-license-report") version "3.1.1"
+    id("com.github.jk1.dependency-license-report") version "3.1.2"
     id("org.owasp.dependencycheck") version "12.2.0"
     id("de.undercouch.download") version "5.7.0"
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/1952 to `3.x`