### PR TITLE
fix(ism): change lastUpdatedTime from Integer to Long to prevent epoc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Detect AWS SDK `Apache5HttpClient` in `AwsSdk2Transport` body-method guardrail ([#1903](https://github.com/opensearch-project/opensearch-java/pull/1970))
 
 ### Fixed
+- Fix ISM `lastUpdatedTime` field type from `Integer` to `Long` to prevent epoch-millisecond overflow ([#1977](https://github.com/opensearch-project/opensearch-java/pull/1977))
 
 ## [Unreleased 3.x]
 ### Added

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/ism/IsmTemplate.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/ism/IsmTemplate.java
@@ -65,7 +65,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
     private final List<String> indexPatterns;
 
     @Nullable
-    private final Integer lastUpdatedTime;
+    private final Long lastUpdatedTime;
 
     @Nullable
     private final Number priority;
@@ -100,7 +100,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
      * </p>
      */
     @Nullable
-    public final Integer lastUpdatedTime() {
+    public final Long lastUpdatedTime() {
         return this.lastUpdatedTime;
     }
 
@@ -166,7 +166,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
         @Nullable
         private List<String> indexPatterns;
         @Nullable
-        private Integer lastUpdatedTime;
+        private Long lastUpdatedTime;
         @Nullable
         private Number priority;
 
@@ -229,7 +229,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
          * </p>
          */
         @Nonnull
-        public final Builder lastUpdatedTime(@Nullable Integer value) {
+        public final Builder lastUpdatedTime(@Nullable Long value) {
             this.lastUpdatedTime = value;
             return this;
         }
@@ -272,7 +272,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
 
     protected static void setupIsmTemplateDeserializer(ObjectDeserializer<IsmTemplate.Builder> op) {
         op.add(Builder::indexPatterns, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "index_patterns");
-        op.add(Builder::lastUpdatedTime, JsonpDeserializer.integerDeserializer(), "last_updated_time");
+        op.add(Builder::lastUpdatedTime, JsonpDeserializer.longDeserializer(), "last_updated_time");
         op.add(Builder::priority, JsonpDeserializer.numberDeserializer(), "priority");
     }
 

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/ism/Policy.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/ism/Policy.java
@@ -77,7 +77,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
     private final List<IsmTemplate> ismTemplate;
 
     @Nullable
-    private final Integer lastUpdatedTime;
+    private final Long lastUpdatedTime;
 
     @Nullable
     private final String policyId;
@@ -156,7 +156,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
      * </p>
      */
     @Nullable
-    public final Integer lastUpdatedTime() {
+    public final Long lastUpdatedTime() {
         return this.lastUpdatedTime;
     }
 
@@ -279,7 +279,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
         @Nullable
         private List<IsmTemplate> ismTemplate;
         @Nullable
-        private Integer lastUpdatedTime;
+        private Long lastUpdatedTime;
         @Nullable
         private String policyId;
         @Nullable
@@ -418,7 +418,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
          * </p>
          */
         @Nonnull
-        public final Builder lastUpdatedTime(@Nullable Integer value) {
+        public final Builder lastUpdatedTime(@Nullable Long value) {
             this.lastUpdatedTime = value;
             return this;
         }
@@ -523,7 +523,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
         op.add(Builder::description, JsonpDeserializer.stringDeserializer(), "description");
         op.add(Builder::errorNotification, ErrorNotification._DESERIALIZER, "error_notification");
         op.add(Builder::ismTemplate, JsonpDeserializer.arrayDeserializer(IsmTemplate._DESERIALIZER), "ism_template");
-        op.add(Builder::lastUpdatedTime, JsonpDeserializer.integerDeserializer(), "last_updated_time");
+        op.add(Builder::lastUpdatedTime, JsonpDeserializer.longDeserializer(), "last_updated_time");
         op.add(Builder::policyId, JsonpDeserializer.stringDeserializer(), "policy_id");
         op.add(Builder::schemaVersion, JsonpDeserializer.numberDeserializer(), "schema_version");
         op.add(Builder::states, JsonpDeserializer.arrayDeserializer(States._DESERIALIZER), "states");

--- a/java-client/src/test/java/org/opensearch/client/opensearch/ism/IsmLastUpdatedTimeTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/ism/IsmLastUpdatedTimeTest.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch.ism;
+
+import jakarta.json.stream.JsonParser;
+import java.io.StringReader;
+import org.junit.Test;
+import org.opensearch.client.opensearch.model.ModelTestCase;
+
+/**
+ * Regression tests for https://github.com/opensearch-project/opensearch-java/issues/1898
+ *
+ * last_updated_time is an epoch-millisecond timestamp and must be Long, not Integer.
+ * Integer.MAX_VALUE is 2147483647 (~Jan 2038), but real timestamps like 1700000000000L
+ * (Nov 2023) already exceed it and previously caused InputCoercionException or silent overflow.
+ */
+public class IsmLastUpdatedTimeTest extends ModelTestCase {
+
+    private static final long EPOCH_MS = 1_700_000_000_000L;
+
+    @Test
+    public void policy_lastUpdatedTime_deserializesWithoutOverflow() {
+        String json = "{\"last_updated_time\":" + EPOCH_MS + "}";
+        JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
+        Policy policy = Policy._DESERIALIZER.deserialize(parser, mapper);
+        assertEquals(Long.valueOf(EPOCH_MS), policy.lastUpdatedTime());
+    }
+
+    @Test
+    public void ismTemplate_lastUpdatedTime_deserializesWithoutOverflow() {
+        String json = "{\"last_updated_time\":" + EPOCH_MS + "}";
+        JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
+        IsmTemplate template = IsmTemplate._DESERIALIZER.deserialize(parser, mapper);
+        assertEquals(Long.valueOf(EPOCH_MS), template.lastUpdatedTime());
+    }
+
+    @Test
+    public void policy_lastUpdatedTime_builderAcceptsLong() {
+        Policy policy = Policy.of(b -> b.lastUpdatedTime(EPOCH_MS));
+        assertEquals(Long.valueOf(EPOCH_MS), policy.lastUpdatedTime());
+    }
+
+    @Test
+    public void ismTemplate_lastUpdatedTime_builderAcceptsLong() {
+        IsmTemplate template = IsmTemplate.of(b -> b.lastUpdatedTime(EPOCH_MS));
+        assertEquals(Long.valueOf(EPOCH_MS), template.lastUpdatedTime());
+    }
+}

--- a/java-codegen/opensearch-openapi.yaml
+++ b/java-codegen/opensearch-openapi.yaml
@@ -61772,6 +61772,7 @@ components:
           description: The priority of the ISM template.
         last_updated_time:
           type: integer
+          format: int64
           description: When the ISM template was last updated.
     ism._common___Metadata:
       type: object
@@ -61797,6 +61798,7 @@ components:
           description: The description of the policy.
         last_updated_time:
           type: integer
+          format: int64
           description: When the policy was last updated.
         schema_version:
           type: number


### PR DESCRIPTION
### What does this change achieve?

`last_updated_time` in `Policy` and `IsmTemplate` carries epoch-millisecond timestamps. These values (e.g. `1700000000000`) exceed `Integer.MAX_VALUE` (2147483647), causing `InputCoercionException` with `JacksonJsonpMapper` and silent negative-value corruption with `JsonbJsonpMapper`.

Changes `format: int64` in the OpenAPI spec (the code generation source of truth) and updates the generated Java models accordingly. Verified against `TypeMapper.java` and the Mustache templates that the generated output is identical to what `./gradlew :java-codegen:run` would produce.

### Issues Resolved

Fixes #1898.