### PR TITLE
Update content write permission so that release can be created

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,8 @@ jobs:
     name: Draft a release
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # trstringer/manual-approval
+      contents: write # softprops/action-gh-release
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
### Description
Update content write permission so that release can be created

### Issues Resolved

https://github.com/opensearch-project/opensearch-java/actions/runs/27048988235/job/79840679771

```
Run softprops/action-gh-release@v3
👩‍🏭 Creating new GitHub release for tag v3.9.0...
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release","status":"403"}
Skip retry — your GitHub token/PAT does not have the required permission to create a release
⚠️ Unexpected error fetching GitHub release for tag refs/tags/v3.9.0: HttpError: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release
Error: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
