### PR TITLE
[Backport 3.x] Update content write permission so that release can be created

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,8 @@ jobs:
     name: Draft a release
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # trstringer/manual-approval
+      contents: write # softprops/action-gh-release
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
### Description
[Backport 3.x] Update content write permission so that release can be created

### Issues Resolved
Backport https://github.com/opensearch-project/opensearch-java/pull/1995

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
