### PR TITLE
Support sort _score/_doc order shorthand

### DIFF
--- a/java-client/src/main/java/org/opensearch/client/opensearch/_types/ScoreSort.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/_types/ScoreSort.java
@@ -141,7 +141,7 @@ public class ScoreSort implements SortOptionsVariant, JsonpSerializable {
     protected static void setupScoreSortDeserializer(ObjectDeserializer<ScoreSort.Builder> op) {
 
         op.add(Builder::order, SortOrder._DESERIALIZER, "order");
-
+        op.shortcutProperty("order");
     }
 
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/SortOptionsTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/SortOptionsTest.java
@@ -33,4 +33,32 @@ public class SortOptionsTest {
         assertEquals("entityId", fieldSort.field());
         assertEquals(SortOrder.Asc, fieldSort.order());
     }
+
+    @Test
+    public void testScoreSortOrderShorthand() {
+        String jsonString = "[{\"_score\":\"asc\"}]";
+        StringReader reader = new StringReader(jsonString);
+        JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        JsonParser parser = mapper.jsonProvider().createParser(reader);
+
+        List<SortOptions> sortOptions = JsonpDeserializer.arrayDeserializer(SortOptions._DESERIALIZER).deserialize(parser, mapper);
+        assertEquals(1, sortOptions.size());
+        assertEquals(SortOptions.Kind.Score, sortOptions.get(0)._kind());
+        ScoreSort scoreSort = (ScoreSort) sortOptions.get(0)._get();
+        assertEquals(SortOrder.Asc, scoreSort.order());
+    }
+
+    @Test
+    public void testDocSortOrderShorthand() {
+        String jsonString = "[{\"_doc\":\"desc\"}]";
+        StringReader reader = new StringReader(jsonString);
+        JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        JsonParser parser = mapper.jsonProvider().createParser(reader);
+
+        List<SortOptions> sortOptions = JsonpDeserializer.arrayDeserializer(SortOptions._DESERIALIZER).deserialize(parser, mapper);
+        assertEquals(1, sortOptions.size());
+        assertEquals(SortOptions.Kind.Doc, sortOptions.get(0)._kind());
+        ScoreSort scoreSort = (ScoreSort) sortOptions.get(0)._get();
+        assertEquals(SortOrder.Desc, scoreSort.order());
+    }
 }


### PR DESCRIPTION

### Description
This PR adds support for the shorthand version of `_score` and `_doc` sort order of the form:

```json
{"_score": "desc"}
```

This currently throws a JSON parsing exception, but is a valid form. This form may be generated from another system and deserialized using the java client.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
