### PR TITLE
Backport delete_backport_branch workflow hardening

### DIFF
--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -1,15 +1,23 @@
 name: Delete merged branch of the backport PRs
-on: 
+
+on:
   pull_request:
     types:
       - closed
-  
+
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.pull_request.head.ref,'backport/')
+    if: github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id && startsWith(github.event.pull_request.head.ref, 'backport/')
+    permissions:
+      contents: write
     steps:
       - name: Delete merged branch
-        uses: SvanBoxel/delete-merged-branch@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/${context.payload.pull_request.head.ref}`,
+            })


### PR DESCRIPTION
## Description

Backports the workflow hardening changes for `.github/workflows/delete_backport_branch.yml` to the `2.11` release branch.

This backports the workflow hardening changes from the default branch by:
- restricting workflow permissions to the minimum required (`contents: write`)
- replacing the third-party action with `actions/github-script`
- ensuring the workflow only operates on pull requests from the same repository
## Issues Resolved

Resolves #2024