### PR TITLE
Fix DerivedField serializing unsupported name field causing mapper_parsing_exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add document lifecycle guide and runnable sample ([#2017](https://github.com/opensearch-project/opensearch-java/pull/2017))
 
 ### Fixed
+- Fix `DerivedField` serializing unsupported `name` field causing `mapper_parsing_exception` ([#2036](https://github.com/opensearch-project/opensearch-java/pull/2036))
 
 ## [Unreleased 3.x]
 ### Added

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/DerivedField.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/DerivedField.java
@@ -68,9 +68,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
     @Nullable
     private final Boolean ignoreMalformed;
 
-    @Nonnull
-    private final String name;
-
     @Nullable
     private final String prefilterField;
 
@@ -88,7 +85,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
     private DerivedField(Builder builder) {
         this.format = builder.format;
         this.ignoreMalformed = builder.ignoreMalformed;
-        this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
         this.prefilterField = builder.prefilterField;
         this.properties = ApiTypeHelper.unmodifiable(builder.properties);
         this.script = ApiTypeHelper.requireNonNull(builder.script, this, "script");
@@ -113,14 +109,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
     @Nullable
     public final Boolean ignoreMalformed() {
         return this.ignoreMalformed;
-    }
-
-    /**
-     * Required - API name: {@code name}
-     */
-    @Nonnull
-    public final String name() {
-        return this.name;
     }
 
     /**
@@ -176,9 +164,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
             generator.write(this.ignoreMalformed);
         }
 
-        generator.writeKey("name");
-        generator.write(this.name);
-
         if (this.prefilterField != null) {
             generator.writeKey("prefilter_field");
             generator.write(this.prefilterField);
@@ -222,7 +207,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         private String format;
         @Nullable
         private Boolean ignoreMalformed;
-        private String name;
         @Nullable
         private String prefilterField;
         @Nullable
@@ -235,7 +219,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         private Builder(DerivedField o) {
             this.format = o.format;
             this.ignoreMalformed = o.ignoreMalformed;
-            this.name = o.name;
             this.prefilterField = o.prefilterField;
             this.properties = _mapCopy(o.properties);
             this.script = o.script;
@@ -245,7 +228,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         private Builder(Builder o) {
             this.format = o.format;
             this.ignoreMalformed = o.ignoreMalformed;
-            this.name = o.name;
             this.prefilterField = o.prefilterField;
             this.properties = _mapCopy(o.properties);
             this.script = o.script;
@@ -273,15 +255,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         @Nonnull
         public final Builder ignoreMalformed(@Nullable Boolean value) {
             this.ignoreMalformed = value;
-            return this;
-        }
-
-        /**
-         * Required - API name: {@code name}
-         */
-        @Nonnull
-        public final Builder name(String value) {
-            this.name = value;
             return this;
         }
 
@@ -373,7 +346,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
     protected static void setupDerivedFieldDeserializer(ObjectDeserializer<DerivedField.Builder> op) {
         op.add(Builder::format, JsonpDeserializer.stringDeserializer(), "format");
         op.add(Builder::ignoreMalformed, JsonpDeserializer.booleanDeserializer(), "ignore_malformed");
-        op.add(Builder::name, JsonpDeserializer.stringDeserializer(), "name");
         op.add(Builder::prefilterField, JsonpDeserializer.stringDeserializer(), "prefilter_field");
         op.add(Builder::properties, JsonpDeserializer.stringMapDeserializer(JsonData._DESERIALIZER), "properties");
         op.add(Builder::script, Script._DESERIALIZER, "script");
@@ -385,7 +357,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         int result = 17;
         result = 31 * result + Objects.hashCode(this.format);
         result = 31 * result + Objects.hashCode(this.ignoreMalformed);
-        result = 31 * result + this.name.hashCode();
         result = 31 * result + Objects.hashCode(this.prefilterField);
         result = 31 * result + Objects.hashCode(this.properties);
         result = 31 * result + this.script.hashCode();
@@ -400,7 +371,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         DerivedField other = (DerivedField) o;
         return Objects.equals(this.format, other.format)
             && Objects.equals(this.ignoreMalformed, other.ignoreMalformed)
-            && this.name.equals(other.name)
             && Objects.equals(this.prefilterField, other.prefilterField)
             && Objects.equals(this.properties, other.properties)
             && this.script.equals(other.script)

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/DerivedField.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/DerivedField.java
@@ -68,6 +68,9 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
     @Nullable
     private final Boolean ignoreMalformed;
 
+    @Nonnull
+    private final String name;
+
     @Nullable
     private final String prefilterField;
 
@@ -85,6 +88,7 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
     private DerivedField(Builder builder) {
         this.format = builder.format;
         this.ignoreMalformed = builder.ignoreMalformed;
+        this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
         this.prefilterField = builder.prefilterField;
         this.properties = ApiTypeHelper.unmodifiable(builder.properties);
         this.script = ApiTypeHelper.requireNonNull(builder.script, this, "script");
@@ -109,6 +113,14 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
     @Nullable
     public final Boolean ignoreMalformed() {
         return this.ignoreMalformed;
+    }
+
+    /**
+     * Required - API name: {@code name}
+     */
+    @Nonnull
+    public final String name() {
+        return this.name;
     }
 
     /**
@@ -164,6 +176,9 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
             generator.write(this.ignoreMalformed);
         }
 
+        generator.writeKey("name");
+        generator.write(this.name);
+
         if (this.prefilterField != null) {
             generator.writeKey("prefilter_field");
             generator.write(this.prefilterField);
@@ -207,6 +222,7 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         private String format;
         @Nullable
         private Boolean ignoreMalformed;
+        private String name;
         @Nullable
         private String prefilterField;
         @Nullable
@@ -219,6 +235,7 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         private Builder(DerivedField o) {
             this.format = o.format;
             this.ignoreMalformed = o.ignoreMalformed;
+            this.name = o.name;
             this.prefilterField = o.prefilterField;
             this.properties = _mapCopy(o.properties);
             this.script = o.script;
@@ -228,6 +245,7 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         private Builder(Builder o) {
             this.format = o.format;
             this.ignoreMalformed = o.ignoreMalformed;
+            this.name = o.name;
             this.prefilterField = o.prefilterField;
             this.properties = _mapCopy(o.properties);
             this.script = o.script;
@@ -255,6 +273,15 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         @Nonnull
         public final Builder ignoreMalformed(@Nullable Boolean value) {
             this.ignoreMalformed = value;
+            return this;
+        }
+
+        /**
+         * Required - API name: {@code name}
+         */
+        @Nonnull
+        public final Builder name(String value) {
+            this.name = value;
             return this;
         }
 
@@ -346,6 +373,7 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
     protected static void setupDerivedFieldDeserializer(ObjectDeserializer<DerivedField.Builder> op) {
         op.add(Builder::format, JsonpDeserializer.stringDeserializer(), "format");
         op.add(Builder::ignoreMalformed, JsonpDeserializer.booleanDeserializer(), "ignore_malformed");
+        op.add(Builder::name, JsonpDeserializer.stringDeserializer(), "name");
         op.add(Builder::prefilterField, JsonpDeserializer.stringDeserializer(), "prefilter_field");
         op.add(Builder::properties, JsonpDeserializer.stringMapDeserializer(JsonData._DESERIALIZER), "properties");
         op.add(Builder::script, Script._DESERIALIZER, "script");
@@ -357,6 +385,7 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         int result = 17;
         result = 31 * result + Objects.hashCode(this.format);
         result = 31 * result + Objects.hashCode(this.ignoreMalformed);
+        result = 31 * result + this.name.hashCode();
         result = 31 * result + Objects.hashCode(this.prefilterField);
         result = 31 * result + Objects.hashCode(this.properties);
         result = 31 * result + this.script.hashCode();
@@ -371,6 +400,7 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         DerivedField other = (DerivedField) o;
         return Objects.equals(this.format, other.format)
             && Objects.equals(this.ignoreMalformed, other.ignoreMalformed)
+            && this.name.equals(other.name)
             && Objects.equals(this.prefilterField, other.prefilterField)
             && Objects.equals(this.properties, other.properties)
             && this.script.equals(other.script)

--- a/java-codegen/opensearch-openapi.yaml
+++ b/java-codegen/opensearch-openapi.yaml
@@ -38878,8 +38878,6 @@ components:
     _common___DerivedField:
       type: object
       properties:
-        name:
-          type: string
         type:
           type: string
         script:
@@ -38893,7 +38891,6 @@ components:
         format:
           type: string
       required:
-        - name
         - script
         - type
     _common___DFIIndependenceMeasure:


### PR DESCRIPTION
### Description

Fixes #1937

**Problem:** Creating a `DerivedField` via the Java client produces a mapping that includes a `name` key inside the field definition:

```json
{
  "derived": {
    "derivedFieldName": {
      "format": "yyyy-MM-dd",
      "name": "derivedFieldName",  // ← unexpected by OpenSearch
      "script": { ... },
      "type": "date"
    }
  }
}
```

OpenSearch rejects this with `mapper_parsing_exception: unknown parameter [name] on mapper [derivedField] of type [date]`.

**Root cause:** The `_common___DerivedField` schema in `opensearch-openapi.yaml` included `name` as a required property. The code generator then created a mandatory `name` field in `DerivedField.java` and serialized it unconditionally. In the OpenSearch derived fields API, the field's name is expressed as the **map key** in the parent `derived` object — it is not a property inside the field definition itself.

**Fix:** Remove `name` from `_common___DerivedField.properties` and `required` in the spec, and update the generated `DerivedField.java` accordingly (field declaration, constructor, getter, serialization, builder, deserializer, `hashCode`, `equals`).

### Changes

- `java-codegen/opensearch-openapi.yaml` — remove `name` from `_common___DerivedField`
- `java-client/src/generated/java/org/opensearch/client/opensearch/_types/DerivedField.java` — regenerated to remove all `name` references (33 lines deleted)

### Testing

Manually verified the diff removes all 9 occurrences of `name` from `DerivedField.java` with no other changes. The generated mapping no longer includes `name` inside the field definition.