### PR TITLE
Fix ShardFailure serializing wrong JSON keys (index/node/shard instead of _index/_node/_shard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Run model tests against both JSON mappers instead of picking one at random ([#2085](https://github.com/opensearch-project/opensearch-java/pull/2085))
 - Fix currentSize calculation in BulkIngester ([#2113](https://github.com/opensearch-project/opensearch-java/pull/2113))
 - Use protocol version from response (rather than request) ([#2118](https://github.com/opensearch-project/opensearch-java/pull/2118))
-- Fix `ShardFailure.shard` incorrectly marked required causing `MissingRequiredPropertyException` ([#2037](https://github.com/opensearch-project/opensearch-java/pull/2037))
+- Fix `ShardFailure` serializing/deserializing `index`/`node`/`shard` instead of the server's `_index`/`_node`/`_shard` keys, causing `MissingRequiredPropertyException` and silently dropped fields ([#2037](https://github.com/opensearch-project/opensearch-java/pull/2037))
 
 ### Changed
 - Updated API spec download URL to `https://api-spec.opensearch.org` ([#2116](https://github.com/opensearch-project/opensearch-java/pull/2116))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Run model tests against both JSON mappers instead of picking one at random ([#2085](https://github.com/opensearch-project/opensearch-java/pull/2085))
 - Fix currentSize calculation in BulkIngester ([#2113](https://github.com/opensearch-project/opensearch-java/pull/2113))
 - Use protocol version from response (rather than request) ([#2118](https://github.com/opensearch-project/opensearch-java/pull/2118))
+- Fix `ShardFailure.shard` incorrectly marked required causing `MissingRequiredPropertyException` ([#2037](https://github.com/opensearch-project/opensearch-java/pull/2037))
 
 ### Changed
 - Updated API spec download URL to `https://api-spec.opensearch.org` ([#2116](https://github.com/opensearch-project/opensearch-java/pull/2116))

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/DerivedField.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/DerivedField.java
@@ -68,9 +68,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
     @Nullable
     private final Boolean ignoreMalformed;
 
-    @Nonnull
-    private final String name;
-
     @Nullable
     private final String prefilterField;
 
@@ -88,7 +85,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
     private DerivedField(Builder builder) {
         this.format = builder.format;
         this.ignoreMalformed = builder.ignoreMalformed;
-        this.name = ApiTypeHelper.requireNonNull(builder.name, this, "name");
         this.prefilterField = builder.prefilterField;
         this.properties = ApiTypeHelper.unmodifiable(builder.properties);
         this.script = ApiTypeHelper.requireNonNull(builder.script, this, "script");
@@ -113,14 +109,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
     @Nullable
     public final Boolean ignoreMalformed() {
         return this.ignoreMalformed;
-    }
-
-    /**
-     * Required - API name: {@code name}
-     */
-    @Nonnull
-    public final String name() {
-        return this.name;
     }
 
     /**
@@ -176,9 +164,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
             generator.write(this.ignoreMalformed);
         }
 
-        generator.writeKey("name");
-        generator.write(this.name);
-
         if (this.prefilterField != null) {
             generator.writeKey("prefilter_field");
             generator.write(this.prefilterField);
@@ -222,7 +207,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         private String format;
         @Nullable
         private Boolean ignoreMalformed;
-        private String name;
         @Nullable
         private String prefilterField;
         @Nullable
@@ -235,7 +219,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         private Builder(DerivedField o) {
             this.format = o.format;
             this.ignoreMalformed = o.ignoreMalformed;
-            this.name = o.name;
             this.prefilterField = o.prefilterField;
             this.properties = _mapCopy(o.properties);
             this.script = o.script;
@@ -245,7 +228,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         private Builder(Builder o) {
             this.format = o.format;
             this.ignoreMalformed = o.ignoreMalformed;
-            this.name = o.name;
             this.prefilterField = o.prefilterField;
             this.properties = _mapCopy(o.properties);
             this.script = o.script;
@@ -273,15 +255,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         @Nonnull
         public final Builder ignoreMalformed(@Nullable Boolean value) {
             this.ignoreMalformed = value;
-            return this;
-        }
-
-        /**
-         * Required - API name: {@code name}
-         */
-        @Nonnull
-        public final Builder name(String value) {
-            this.name = value;
             return this;
         }
 
@@ -373,7 +346,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
     protected static void setupDerivedFieldDeserializer(ObjectDeserializer<DerivedField.Builder> op) {
         op.add(Builder::format, JsonpDeserializer.stringDeserializer(), "format");
         op.add(Builder::ignoreMalformed, JsonpDeserializer.booleanDeserializer(), "ignore_malformed");
-        op.add(Builder::name, JsonpDeserializer.stringDeserializer(), "name");
         op.add(Builder::prefilterField, JsonpDeserializer.stringDeserializer(), "prefilter_field");
         op.add(Builder::properties, JsonpDeserializer.stringMapDeserializer(JsonData._DESERIALIZER), "properties");
         op.add(Builder::script, Script._DESERIALIZER, "script");
@@ -385,7 +357,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         int result = 17;
         result = 31 * result + Objects.hashCode(this.format);
         result = 31 * result + Objects.hashCode(this.ignoreMalformed);
-        result = 31 * result + this.name.hashCode();
         result = 31 * result + Objects.hashCode(this.prefilterField);
         result = 31 * result + Objects.hashCode(this.properties);
         result = 31 * result + this.script.hashCode();
@@ -400,7 +371,6 @@ public class DerivedField implements PlainJsonSerializable, ToCopyableBuilder<De
         DerivedField other = (DerivedField) o;
         return Objects.equals(this.format, other.format)
             && Objects.equals(this.ignoreMalformed, other.ignoreMalformed)
-            && this.name.equals(other.name)
             && Objects.equals(this.prefilterField, other.prefilterField)
             && Objects.equals(this.properties, other.properties)
             && this.script.equals(other.script)

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/ShardFailure.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/ShardFailure.java
@@ -71,7 +71,8 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
     @Nonnull
     private final ErrorCause reason;
 
-    private final int shard;
+    @Nullable
+    private final Integer shard;
 
     @Nullable
     private final String status;
@@ -83,7 +84,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
         this.node = builder.node;
         this.primary = ApiTypeHelper.requireNonNull(builder.primary, this, "primary");
         this.reason = ApiTypeHelper.requireNonNull(builder.reason, this, "reason");
-        this.shard = ApiTypeHelper.requireNonNull(builder.shard, this, "shard");
+        this.shard = builder.shard;
         this.status = builder.status;
     }
 
@@ -123,9 +124,10 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
     }
 
     /**
-     * Required - API name: {@code shard}
+     * API name: {@code shard}
      */
-    public final int shard() {
+    @Nullable
+    public final Integer shard() {
         return this.shard;
     }
 
@@ -164,8 +166,10 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
         generator.writeKey("reason");
         this.reason.serialize(generator, mapper);
 
-        generator.writeKey("shard");
-        generator.write(this.shard);
+        if (this.shard != null) {
+            generator.writeKey("shard");
+            generator.write(this.shard);
+        }
 
         if (this.status != null) {
             generator.writeKey("status");
@@ -271,7 +275,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
         }
 
         /**
-         * Required - API name: {@code shard}
+         * API name: {@code shard}
          */
         @Nonnull
         public final Builder shard(int value) {
@@ -328,7 +332,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
         result = 31 * result + Objects.hashCode(this.node);
         result = 31 * result + Boolean.hashCode(this.primary);
         result = 31 * result + this.reason.hashCode();
-        result = 31 * result + Integer.hashCode(this.shard);
+        result = 31 * result + Objects.hashCode(this.shard);
         result = 31 * result + Objects.hashCode(this.status);
         return result;
     }
@@ -342,7 +346,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
             && Objects.equals(this.node, other.node)
             && this.primary == other.primary
             && this.reason.equals(other.reason)
-            && this.shard == other.shard
+            && Objects.equals(this.shard, other.shard)
             && Objects.equals(this.status, other.status);
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/ShardFailure.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/ShardFailure.java
@@ -71,8 +71,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
     @Nonnull
     private final ErrorCause reason;
 
-    @Nullable
-    private final Integer shard;
+    private final int shard;
 
     @Nullable
     private final String status;
@@ -84,7 +83,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
         this.node = builder.node;
         this.primary = ApiTypeHelper.requireNonNull(builder.primary, this, "primary");
         this.reason = ApiTypeHelper.requireNonNull(builder.reason, this, "reason");
-        this.shard = builder.shard;
+        this.shard = ApiTypeHelper.requireNonNull(builder.shard, this, "shard");
         this.status = builder.status;
     }
 
@@ -93,7 +92,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
     }
 
     /**
-     * API name: {@code index}
+     * API name: {@code _index}
      */
     @Nullable
     public final String index() {
@@ -101,7 +100,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
     }
 
     /**
-     * API name: {@code node}
+     * API name: {@code _node}
      */
     @Nullable
     public final String node() {
@@ -124,10 +123,9 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
     }
 
     /**
-     * API name: {@code shard}
+     * Required - API name: {@code _shard}
      */
-    @Nullable
-    public final Integer shard() {
+    public final int shard() {
         return this.shard;
     }
 
@@ -151,12 +149,12 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
 
     protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
         if (this.index != null) {
-            generator.writeKey("index");
+            generator.writeKey("_index");
             generator.write(this.index);
         }
 
         if (this.node != null) {
-            generator.writeKey("node");
+            generator.writeKey("_node");
             generator.write(this.node);
         }
 
@@ -166,10 +164,8 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
         generator.writeKey("reason");
         this.reason.serialize(generator, mapper);
 
-        if (this.shard != null) {
-            generator.writeKey("shard");
-            generator.write(this.shard);
-        }
+        generator.writeKey("_shard");
+        generator.write(this.shard);
 
         if (this.status != null) {
             generator.writeKey("status");
@@ -231,7 +227,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
         }
 
         /**
-         * API name: {@code index}
+         * API name: {@code _index}
          */
         @Nonnull
         public final Builder index(@Nullable String value) {
@@ -240,7 +236,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
         }
 
         /**
-         * API name: {@code node}
+         * API name: {@code _node}
          */
         @Nonnull
         public final Builder node(@Nullable String value) {
@@ -275,7 +271,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
         }
 
         /**
-         * API name: {@code shard}
+         * Required - API name: {@code _shard}
          */
         @Nonnull
         public final Builder shard(int value) {
@@ -317,11 +313,11 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
     );
 
     protected static void setupShardFailureDeserializer(ObjectDeserializer<ShardFailure.Builder> op) {
-        op.add(Builder::index, JsonpDeserializer.stringDeserializer(), "index");
-        op.add(Builder::node, JsonpDeserializer.stringDeserializer(), "node");
+        op.add(Builder::index, JsonpDeserializer.stringDeserializer(), "_index");
+        op.add(Builder::node, JsonpDeserializer.stringDeserializer(), "_node");
         op.add(Builder::primary, JsonpDeserializer.booleanDeserializer(), "primary");
         op.add(Builder::reason, ErrorCause._DESERIALIZER, "reason");
-        op.add(Builder::shard, JsonpDeserializer.integerDeserializer(), "shard");
+        op.add(Builder::shard, JsonpDeserializer.integerDeserializer(), "_shard");
         op.add(Builder::status, JsonpDeserializer.stringDeserializer(), "status");
     }
 
@@ -332,7 +328,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
         result = 31 * result + Objects.hashCode(this.node);
         result = 31 * result + Boolean.hashCode(this.primary);
         result = 31 * result + this.reason.hashCode();
-        result = 31 * result + Objects.hashCode(this.shard);
+        result = 31 * result + Integer.hashCode(this.shard);
         result = 31 * result + Objects.hashCode(this.status);
         return result;
     }
@@ -346,7 +342,7 @@ public class ShardFailure implements PlainJsonSerializable, ToCopyableBuilder<Sh
             && Objects.equals(this.node, other.node)
             && this.primary == other.primary
             && this.reason.equals(other.reason)
-            && Objects.equals(this.shard, other.shard)
+            && this.shard == other.shard
             && Objects.equals(this.status, other.status);
     }
 }

--- a/java-codegen/opensearch-openapi.yaml
+++ b/java-codegen/opensearch-openapi.yaml
@@ -40846,7 +40846,6 @@ components:
       required:
         - primary
         - reason
-        - shard
     _common___ShardInfo:
       type: object
       properties:

--- a/java-codegen/opensearch-openapi.yaml
+++ b/java-codegen/opensearch-openapi.yaml
@@ -38878,8 +38878,6 @@ components:
     _common___DerivedField:
       type: object
       properties:
-        name:
-          type: string
         type:
           type: string
         script:
@@ -38893,7 +38891,6 @@ components:
         format:
           type: string
       required:
-        - name
         - script
         - type
     _common___DFIIndependenceMeasure:

--- a/java-codegen/opensearch-openapi.yaml
+++ b/java-codegen/opensearch-openapi.yaml
@@ -40831,19 +40831,20 @@ components:
     _common___ShardFailure:
       type: object
       properties:
-        index:
+        _index:
           $ref: '#/components/schemas/_common___IndexName'
-        node:
+        _node:
           type: string
         reason:
           $ref: '#/components/schemas/_common___ErrorCause'
-        shard:
+        _shard:
           type: integer
         status:
           type: string
         primary:
           type: boolean
       required:
+        - _shard
         - primary
         - reason
     _common___ShardInfo:


### PR DESCRIPTION
### Description

Fixes #1799

**Problem:** When OpenSearch returns a `ShardFailure`, the Java client throws `MissingRequiredPropertyException: Missing required property 'ShardFailure.shard'`.

**Root cause:** This was originally diagnosed as `shard` being incorrectly required. That diagnosis was wrong. `ReplicationResponse.ShardInfo.Failure` on the server always writes the field — the real bug is a JSON key mismatch: the server writes `_index`, `_shard`, `_node` (underscore-prefixed), while `_common___ShardFailure` in `opensearch-openapi.yaml` and the generated `ShardFailure.java` used `index`, `shard`, `node` (no prefix). So the client looked up the wrong key: `shard` was never found under that name, producing the `MissingRequiredPropertyException`, and `index`/`node` were silently dropped since they aren't required.

This surfaced during review of the corresponding spec fix, opensearch-project/opensearch-api-specification#1194.

**Fix:**
- `java-codegen/opensearch-openapi.yaml` — rename `index`/`node`/`shard` to `_index`/`_node`/`_shard` in `_common___ShardFailure`; keep `_shard` required (reverting an earlier, incorrect attempt to make it optional).
- `java-client/src/generated/java/org/opensearch/client/opensearch/_types/ShardFailure.java` — rename the three JSON keys used in serialization/deserialization to match. Java accessor/builder names are unchanged (`index()`, `node()`, `shard()`), consistent with existing underscore-prefixed fields elsewhere (e.g. `Hit.index()` for `_index`).

### Changes

- `java-codegen/opensearch-openapi.yaml` — rename `index`/`node`/`shard` to `_index`/`_node`/`_shard`; keep `_shard` required
- `java-client/src/generated/java/org/opensearch/client/opensearch/_types/ShardFailure.java` — rename JSON keys in `serializeInternal`/`setupShardFailureDeserializer`; `shard` stays a required, non-null `int`