### PR TITLE
Fix ISM and other timestamp fields typed as integer instead of int64 causing numeric overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Run model tests against both JSON mappers instead of picking one at random ([#2085](https://github.com/opensearch-project/opensearch-java/pull/2085))
 - Fix currentSize calculation in BulkIngester ([#2113](https://github.com/opensearch-project/opensearch-java/pull/2113))
 - Use protocol version from response (rather than request) ([#2118](https://github.com/opensearch-project/opensearch-java/pull/2118))
+- Fix ISM timestamp fields typed as `Integer` instead of `Long` causing numeric overflow for epoch-millisecond values ([#2039](https://github.com/opensearch-project/opensearch-java/pull/2039))
 
 ### Changed
 - Updated API spec download URL to `https://api-spec.opensearch.org` ([#2116](https://github.com/opensearch-project/opensearch-java/pull/2116))

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/ism/IsmTemplate.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/ism/IsmTemplate.java
@@ -65,7 +65,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
     private final List<String> indexPatterns;
 
     @Nullable
-    private final Integer lastUpdatedTime;
+    private final Long lastUpdatedTime;
 
     @Nullable
     private final Number priority;
@@ -100,7 +100,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
      * </p>
      */
     @Nullable
-    public final Integer lastUpdatedTime() {
+    public final Long lastUpdatedTime() {
         return this.lastUpdatedTime;
     }
 
@@ -166,7 +166,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
         @Nullable
         private List<String> indexPatterns;
         @Nullable
-        private Integer lastUpdatedTime;
+        private Long lastUpdatedTime;
         @Nullable
         private Number priority;
 
@@ -229,7 +229,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
          * </p>
          */
         @Nonnull
-        public final Builder lastUpdatedTime(@Nullable Integer value) {
+        public final Builder lastUpdatedTime(@Nullable Long value) {
             this.lastUpdatedTime = value;
             return this;
         }
@@ -272,7 +272,7 @@ public class IsmTemplate implements PlainJsonSerializable, ToCopyableBuilder<Ism
 
     protected static void setupIsmTemplateDeserializer(ObjectDeserializer<IsmTemplate.Builder> op) {
         op.add(Builder::indexPatterns, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "index_patterns");
-        op.add(Builder::lastUpdatedTime, JsonpDeserializer.integerDeserializer(), "last_updated_time");
+        op.add(Builder::lastUpdatedTime, JsonpDeserializer.longDeserializer(), "last_updated_time");
         op.add(Builder::priority, JsonpDeserializer.numberDeserializer(), "priority");
     }
 

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/ism/Policy.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/ism/Policy.java
@@ -77,7 +77,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
     private final List<IsmTemplate> ismTemplate;
 
     @Nullable
-    private final Integer lastUpdatedTime;
+    private final Long lastUpdatedTime;
 
     @Nullable
     private final String policyId;
@@ -156,7 +156,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
      * </p>
      */
     @Nullable
-    public final Integer lastUpdatedTime() {
+    public final Long lastUpdatedTime() {
         return this.lastUpdatedTime;
     }
 
@@ -279,7 +279,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
         @Nullable
         private List<IsmTemplate> ismTemplate;
         @Nullable
-        private Integer lastUpdatedTime;
+        private Long lastUpdatedTime;
         @Nullable
         private String policyId;
         @Nullable
@@ -418,7 +418,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
          * </p>
          */
         @Nonnull
-        public final Builder lastUpdatedTime(@Nullable Integer value) {
+        public final Builder lastUpdatedTime(@Nullable Long value) {
             this.lastUpdatedTime = value;
             return this;
         }
@@ -523,7 +523,7 @@ public class Policy implements PlainJsonSerializable, ToCopyableBuilder<Policy.B
         op.add(Builder::description, JsonpDeserializer.stringDeserializer(), "description");
         op.add(Builder::errorNotification, ErrorNotification._DESERIALIZER, "error_notification");
         op.add(Builder::ismTemplate, JsonpDeserializer.arrayDeserializer(IsmTemplate._DESERIALIZER), "ism_template");
-        op.add(Builder::lastUpdatedTime, JsonpDeserializer.integerDeserializer(), "last_updated_time");
+        op.add(Builder::lastUpdatedTime, JsonpDeserializer.longDeserializer(), "last_updated_time");
         op.add(Builder::policyId, JsonpDeserializer.stringDeserializer(), "policy_id");
         op.add(Builder::schemaVersion, JsonpDeserializer.numberDeserializer(), "schema_version");
         op.add(Builder::states, JsonpDeserializer.arrayDeserializer(States._DESERIALIZER), "states");

--- a/java-codegen/opensearch-openapi.yaml
+++ b/java-codegen/opensearch-openapi.yaml
@@ -56686,9 +56686,11 @@ components:
           $ref: '#/components/schemas/flow_framework.common___user'
         created_time:
           type: integer
+          format: int64
           description: When the workflow was created.
         last_updated_time:
           type: integer
+          format: int64
           description: When the workflow was last updated.
         last_provisioned_time:
           type: number
@@ -61772,6 +61774,7 @@ components:
           description: The priority of the ISM template.
         last_updated_time:
           type: integer
+          format: int64
           description: When the ISM template was last updated.
     ism._common___Metadata:
       type: object
@@ -61797,6 +61800,7 @@ components:
           description: The description of the policy.
         last_updated_time:
           type: integer
+          format: int64
           description: When the policy was last updated.
         schema_version:
           type: number
@@ -70265,6 +70269,7 @@ components:
           type: boolean
         last_updated_time:
           type: integer
+          format: int64
           description: When the policy was last modified.
         enabled_time:
           type: integer

--- a/java-codegen/opensearch-openapi.yaml
+++ b/java-codegen/opensearch-openapi.yaml
@@ -70273,6 +70273,7 @@ components:
           description: When the policy was last modified.
         enabled_time:
           type: integer
+          format: int64
           description: When the policy was last enabled.
       required:
         - creation


### PR DESCRIPTION
Fixes #1717, Fixes #1898

Epoch-millisecond timestamps were typed as plain `integer` in the spec with no `format: int64`, so the codegen emitted `Integer` (max ~2.1B) instead of `Long`. Any real timestamp value (e.g. `1755915614485`) overflows `int` and Jackson raises:
```
Numeric value out of range of int (-2147483648 - 2147483647)
```

**Fix:** Add `format: int64` to affected fields — `IsmTemplate.last_updated_time`, `Policy.last_updated_time`, and the same fields in `flow_framework` and SM — and update the two generated ISM Java classes from `Integer`/`integerDeserializer` to `Long`/`longDeserializer`.