### PR TITLE
Fix ShardProfile.fetch typed as single FetchProfile instead of List<FetchProfile>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Run model tests against both JSON mappers instead of picking one at random ([#2085](https://github.com/opensearch-project/opensearch-java/pull/2085))
 - Fix currentSize calculation in BulkIngester ([#2113](https://github.com/opensearch-project/opensearch-java/pull/2113))
 - Use protocol version from response (rather than request) ([#2118](https://github.com/opensearch-project/opensearch-java/pull/2118))
+- Fix `ShardProfile.fetch` typed as single `FetchProfile` instead of `List<FetchProfile>` causing deserialization failure with profile API ([#2040](https://github.com/opensearch-project/opensearch-java/pull/2040))
 
 ### Changed
 - Updated API spec download URL to `https://api-spec.opensearch.org` ([#2116](https://github.com/opensearch-project/opensearch-java/pull/2116))

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/ShardProfile.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/ShardProfile.java
@@ -64,8 +64,8 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
     @Nonnull
     private final List<AggregationProfile> aggregations;
 
-    @Nullable
-    private final FetchProfile fetch;
+    @Nonnull
+    private final List<FetchProfile> fetch;
 
     @Nonnull
     private final String id;
@@ -77,7 +77,7 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
 
     private ShardProfile(Builder builder) {
         this.aggregations = ApiTypeHelper.unmodifiableRequired(builder.aggregations, this, "aggregations");
-        this.fetch = builder.fetch;
+        this.fetch = ApiTypeHelper.unmodifiable(builder.fetch);
         this.id = ApiTypeHelper.requireNonNull(builder.id, this, "id");
         this.searches = ApiTypeHelper.unmodifiableRequired(builder.searches, this, "searches");
     }
@@ -97,8 +97,8 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
     /**
      * API name: {@code fetch}
      */
-    @Nullable
-    public final FetchProfile fetch() {
+    @Nonnull
+    public final List<FetchProfile> fetch() {
         return this.fetch;
     }
 
@@ -136,9 +136,13 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
         }
         generator.writeEnd();
 
-        if (this.fetch != null) {
+        if (ApiTypeHelper.isDefined(this.fetch)) {
             generator.writeKey("fetch");
-            this.fetch.serialize(generator, mapper);
+            generator.writeStartArray();
+            for (FetchProfile item0 : this.fetch) {
+                item0.serialize(generator, mapper);
+            }
+            generator.writeEnd();
         }
 
         generator.writeKey("id");
@@ -171,7 +175,7 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
     public static class Builder extends ObjectBuilderBase implements CopyableBuilder<Builder, ShardProfile> {
         private List<AggregationProfile> aggregations;
         @Nullable
-        private FetchProfile fetch;
+        private List<FetchProfile> fetch;
         private String id;
         private List<SearchProfile> searches;
 
@@ -179,14 +183,14 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
 
         private Builder(ShardProfile o) {
             this.aggregations = _listCopy(o.aggregations);
-            this.fetch = o.fetch;
+            this.fetch = _listCopy(o.fetch);
             this.id = o.id;
             this.searches = _listCopy(o.searches);
         }
 
         private Builder(Builder o) {
             this.aggregations = _listCopy(o.aggregations);
-            this.fetch = o.fetch;
+            this.fetch = _listCopy(o.fetch);
             this.id = o.id;
             this.searches = _listCopy(o.searches);
         }
@@ -237,15 +241,36 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
 
         /**
          * API name: {@code fetch}
+         *
+         * <p>
+         * Adds all elements of <code>list</code> to <code>fetch</code>.
+         * </p>
          */
         @Nonnull
-        public final Builder fetch(@Nullable FetchProfile value) {
-            this.fetch = value;
+        public final Builder fetch(List<FetchProfile> list) {
+            this.fetch = _listAddAll(this.fetch, list);
             return this;
         }
 
         /**
          * API name: {@code fetch}
+         *
+         * <p>
+         * Adds one or more values to <code>fetch</code>.
+         * </p>
+         */
+        @Nonnull
+        public final Builder fetch(FetchProfile value, FetchProfile... values) {
+            this.fetch = _listAdd(this.fetch, value, values);
+            return this;
+        }
+
+        /**
+         * API name: {@code fetch}
+         *
+         * <p>
+         * Adds a value to <code>fetch</code> using a builder lambda.
+         * </p>
          */
         @Nonnull
         public final Builder fetch(Function<FetchProfile.Builder, ObjectBuilder<FetchProfile>> fn) {
@@ -325,7 +350,7 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
 
     protected static void setupShardProfileDeserializer(ObjectDeserializer<ShardProfile.Builder> op) {
         op.add(Builder::aggregations, JsonpDeserializer.arrayDeserializer(AggregationProfile._DESERIALIZER), "aggregations");
-        op.add(Builder::fetch, FetchProfile._DESERIALIZER, "fetch");
+        op.add(Builder::fetch, JsonpDeserializer.arrayDeserializer(FetchProfile._DESERIALIZER), "fetch");
         op.add(Builder::id, JsonpDeserializer.stringDeserializer(), "id");
         op.add(Builder::searches, JsonpDeserializer.arrayDeserializer(SearchProfile._DESERIALIZER), "searches");
     }

--- a/java-codegen/opensearch-openapi.yaml
+++ b/java-codegen/opensearch-openapi.yaml
@@ -52512,7 +52512,9 @@ components:
           items:
             $ref: '#/components/schemas/_core.search___SearchProfile'
         fetch:
-          $ref: '#/components/schemas/_core.search___FetchProfile'
+          type: array
+          items:
+            $ref: '#/components/schemas/_core.search___FetchProfile'
       required:
         - aggregations
         - id


### PR DESCRIPTION
Fixes #1965

OpenSearch returns `fetch` as a JSON array in profile responses, but the spec defined it as a single `FetchProfile` object. This caused:
```
UnexpectedJsonEventException: Unexpected JSON event 'START_ARRAY' instead of '[START_OBJECT, KEY_NAME]'
```

**Fix:** Change the spec to `type: array / items: $ref: FetchProfile` and update the generated `ShardProfile.java` to use `List<FetchProfile>` with array serialization and `arrayDeserializer`, matching the pattern already used by `aggregations` and `searches` in the same class.