### PR TITLE
Fix NPE in _listAddAll when server returns JSON null for a list field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix currentSize calculation in BulkIngester ([#2113](https://github.com/opensearch-project/opensearch-java/pull/2113))
 - Use protocol version from response (rather than request) ([#2118](https://github.com/opensearch-project/opensearch-java/pull/2118))
 - Fix `ShardProfile.fetch` typed as single `FetchProfile` instead of `List<FetchProfile>` causing deserialization failure with profile API ([#2040](https://github.com/opensearch-project/opensearch-java/pull/2040))
+- Fix `NullPointerException` in `_listAddAll` when server returns JSON `null` for a list field ([#2041](https://github.com/opensearch-project/opensearch-java/pull/2041))
 
 ### Changed
 - Updated API spec download URL to `https://api-spec.opensearch.org` ([#2116](https://github.com/opensearch-project/opensearch-java/pull/2116))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Run model tests against both JSON mappers instead of picking one at random ([#2085](https://github.com/opensearch-project/opensearch-java/pull/2085))
 - Fix currentSize calculation in BulkIngester ([#2113](https://github.com/opensearch-project/opensearch-java/pull/2113))
 - Use protocol version from response (rather than request) ([#2118](https://github.com/opensearch-project/opensearch-java/pull/2118))
+- Fix `ShardProfile.fetch` typed as single `FetchProfile` instead of `List<FetchProfile>` causing deserialization failure with profile API ([#2040](https://github.com/opensearch-project/opensearch-java/pull/2040))
 
 ### Changed
 - Updated API spec download URL to `https://api-spec.opensearch.org` ([#2116](https://github.com/opensearch-project/opensearch-java/pull/2116))

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/ShardProfile.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/ShardProfile.java
@@ -64,8 +64,8 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
     @Nonnull
     private final List<AggregationProfile> aggregations;
 
-    @Nullable
-    private final FetchProfile fetch;
+    @Nonnull
+    private final List<FetchProfile> fetch;
 
     @Nonnull
     private final String id;
@@ -77,7 +77,7 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
 
     private ShardProfile(Builder builder) {
         this.aggregations = ApiTypeHelper.unmodifiableRequired(builder.aggregations, this, "aggregations");
-        this.fetch = builder.fetch;
+        this.fetch = ApiTypeHelper.unmodifiable(builder.fetch);
         this.id = ApiTypeHelper.requireNonNull(builder.id, this, "id");
         this.searches = ApiTypeHelper.unmodifiableRequired(builder.searches, this, "searches");
     }
@@ -97,8 +97,8 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
     /**
      * API name: {@code fetch}
      */
-    @Nullable
-    public final FetchProfile fetch() {
+    @Nonnull
+    public final List<FetchProfile> fetch() {
         return this.fetch;
     }
 
@@ -136,9 +136,13 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
         }
         generator.writeEnd();
 
-        if (this.fetch != null) {
+        if (ApiTypeHelper.isDefined(this.fetch)) {
             generator.writeKey("fetch");
-            this.fetch.serialize(generator, mapper);
+            generator.writeStartArray();
+            for (FetchProfile item0 : this.fetch) {
+                item0.serialize(generator, mapper);
+            }
+            generator.writeEnd();
         }
 
         generator.writeKey("id");
@@ -171,7 +175,7 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
     public static class Builder extends ObjectBuilderBase implements CopyableBuilder<Builder, ShardProfile> {
         private List<AggregationProfile> aggregations;
         @Nullable
-        private FetchProfile fetch;
+        private List<FetchProfile> fetch;
         private String id;
         private List<SearchProfile> searches;
 
@@ -179,14 +183,14 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
 
         private Builder(ShardProfile o) {
             this.aggregations = _listCopy(o.aggregations);
-            this.fetch = o.fetch;
+            this.fetch = _listCopy(o.fetch);
             this.id = o.id;
             this.searches = _listCopy(o.searches);
         }
 
         private Builder(Builder o) {
             this.aggregations = _listCopy(o.aggregations);
-            this.fetch = o.fetch;
+            this.fetch = _listCopy(o.fetch);
             this.id = o.id;
             this.searches = _listCopy(o.searches);
         }
@@ -237,15 +241,36 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
 
         /**
          * API name: {@code fetch}
+         *
+         * <p>
+         * Adds all elements of <code>list</code> to <code>fetch</code>.
+         * </p>
          */
         @Nonnull
-        public final Builder fetch(@Nullable FetchProfile value) {
-            this.fetch = value;
+        public final Builder fetch(List<FetchProfile> list) {
+            this.fetch = _listAddAll(this.fetch, list);
             return this;
         }
 
         /**
          * API name: {@code fetch}
+         *
+         * <p>
+         * Adds one or more values to <code>fetch</code>.
+         * </p>
+         */
+        @Nonnull
+        public final Builder fetch(FetchProfile value, FetchProfile... values) {
+            this.fetch = _listAdd(this.fetch, value, values);
+            return this;
+        }
+
+        /**
+         * API name: {@code fetch}
+         *
+         * <p>
+         * Adds a value to <code>fetch</code> using a builder lambda.
+         * </p>
          */
         @Nonnull
         public final Builder fetch(Function<FetchProfile.Builder, ObjectBuilder<FetchProfile>> fn) {
@@ -325,7 +350,7 @@ public class ShardProfile implements PlainJsonSerializable, ToCopyableBuilder<Sh
 
     protected static void setupShardProfileDeserializer(ObjectDeserializer<ShardProfile.Builder> op) {
         op.add(Builder::aggregations, JsonpDeserializer.arrayDeserializer(AggregationProfile._DESERIALIZER), "aggregations");
-        op.add(Builder::fetch, FetchProfile._DESERIALIZER, "fetch");
+        op.add(Builder::fetch, JsonpDeserializer.arrayDeserializer(FetchProfile._DESERIALIZER), "fetch");
         op.add(Builder::id, JsonpDeserializer.stringDeserializer(), "id");
         op.add(Builder::searches, JsonpDeserializer.arrayDeserializer(SearchProfile._DESERIALIZER), "searches");
     }

--- a/java-client/src/main/java/org/opensearch/client/json/JsonpDeserializerBase.java
+++ b/java-client/src/main/java/org/opensearch/client/json/JsonpDeserializerBase.java
@@ -324,7 +324,7 @@ public abstract class JsonpDeserializerBase<V> implements JsonpDeserializer<V> {
             // Accepted events is computed lazily
             // no need for double-checked lock, we don't care about computing it several times
             if (acceptedEvents == null) {
-                acceptedEvents = EnumSet.of(Event.START_ARRAY);
+                acceptedEvents = EnumSet.of(Event.START_ARRAY, Event.VALUE_NULL);
                 acceptedEvents.addAll(itemDeserializer.acceptedEvents());
             }
             return acceptedEvents;
@@ -332,6 +332,13 @@ public abstract class JsonpDeserializerBase<V> implements JsonpDeserializer<V> {
 
         @Override
         public List<T> deserialize(JsonParser parser, JsonpMapper mapper, Event event) {
+            if (event == Event.VALUE_NULL) {
+                // The server sent JSON null for this array field (e.g. ism_template in ISM
+                // Policy). Treat it as an empty list rather than null so it can flow into
+                // builder setters the same way an absent/empty array would.
+                // See https://github.com/opensearch-project/opensearch-java/issues/1813
+                return new ArrayList<>();
+            }
             if (event == Event.START_ARRAY) {
                 List<T> result = new ArrayList<>();
                 while ((event = parser.next()) != Event.END_ARRAY) {

--- a/java-client/src/main/java/org/opensearch/client/util/ObjectBuilderBase.java
+++ b/java-client/src/main/java/org/opensearch/client/util/ObjectBuilderBase.java
@@ -95,10 +95,15 @@ public class ObjectBuilderBase {
 
     /** Add all elements of a list to a (possibly {@code null}) list */
     protected static <T> List<T> _listAddAll(List<T> list, List<T> values) {
+        if (values == null) {
+            // Server returned JSON null for a list field; treat as empty to avoid NPE.
+            // See https://github.com/opensearch-project/opensearch-java/issues/1813
+            return list;
+        }
         if (list == null) {
             // Keep the original list to avoid an unnecessary copy.
             // It will be copied if we add more values.
-            return Objects.requireNonNull(values);
+            return values;
         } else {
             list = _mutableList(list);
             list.addAll(values);

--- a/java-client/src/main/java/org/opensearch/client/util/ObjectBuilderBase.java
+++ b/java-client/src/main/java/org/opensearch/client/util/ObjectBuilderBase.java
@@ -95,15 +95,10 @@ public class ObjectBuilderBase {
 
     /** Add all elements of a list to a (possibly {@code null}) list */
     protected static <T> List<T> _listAddAll(List<T> list, List<T> values) {
-        if (values == null) {
-            // Server returned JSON null for a list field; treat as empty to avoid NPE.
-            // See https://github.com/opensearch-project/opensearch-java/issues/1813
-            return list;
-        }
         if (list == null) {
             // Keep the original list to avoid an unnecessary copy.
             // It will be copied if we add more values.
-            return values;
+            return Objects.requireNonNull(values);
         } else {
             list = _mutableList(list);
             list.addAll(values);

--- a/java-client/src/test/java/org/opensearch/client/opensearch/json/JsonpDeserializerBaseTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/json/JsonpDeserializerBaseTest.java
@@ -48,4 +48,20 @@ public class JsonpDeserializerBaseTest extends ModelTestCase {
             assertEquals("c", valueList.get(2)._get());
         }
     }
+
+    @Test
+    public void testNullArray() {
+        // A JSON null for the whole array field (as opposed to an item within it) is treated as
+        // an empty list rather than null, so it can flow into builder setters (via _listAddAll)
+        // the same way an absent/empty array would, instead of throwing a NullPointerException.
+        // See https://github.com/opensearch-project/opensearch-java/issues/1813
+        String json = "null";
+
+        JsonpDeserializer<String> stringDeser = JsonpDeserializer.stringDeserializer();
+        JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
+
+        List<String> stringList = JsonpDeserializer.arrayDeserializer(stringDeser).deserialize(parser, mapper);
+        assertNotNull(stringList);
+        assertTrue(stringList.isEmpty());
+    }
 }

--- a/java-codegen/opensearch-openapi.yaml
+++ b/java-codegen/opensearch-openapi.yaml
@@ -52512,7 +52512,9 @@ components:
           items:
             $ref: '#/components/schemas/_core.search___SearchProfile'
         fetch:
-          $ref: '#/components/schemas/_core.search___FetchProfile'
+          type: array
+          items:
+            $ref: '#/components/schemas/_core.search___FetchProfile'
       required:
         - aggregations
         - id


### PR DESCRIPTION
Fixes #1813

`_listAddAll(list, values)` threw `NullPointerException` via `Objects.requireNonNull(values)` when `values` was `null`. This happens when OpenSearch returns JSON `null` for an optional list field (e.g. `ism_template` in ISM Policy), causing deserialization to fail:
```
NullPointerException at ObjectBuilderBase._listAddAll
  at Policy$Builder.ismTemplate(Policy.java:379)
```

**Fix:** Guard against null `values` by returning the existing list unchanged when `values` is null. Same logic applied to `_mapPutAll` would follow the same pattern if similar issues arise for maps.