### PR TITLE
Feat/add support for custom kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `org.apache.httpcomponents.client5:httpclient5` from 5.6 to 5.6.1 ([#1967](https://github.com/opensearch-project/opensearch-java/pull/1967))
 
 ### Added
+- Add `_Custom` variant kind to all discriminated tagged unions (e.g. `Aggregate`, `Suggest`, `Query`, `Property`, `Processor`) to gracefully handle plugin-provided types without deserialization failures
 - Run Java client integration tests with a Testcontainers-managed OpenSearch instance by default ([#2033](https://github.com/opensearch-project/opensearch-java/pull/2033))
 - Detect AWS SDK `Apache5HttpClient` in `AwsSdk2Transport` body-method guardrail ([#1903](https://github.com/opensearch-project/opensearch-java/pull/1970))
 - Support Jackson 3.x release line ([#1810](https://github.com/opensearch-project/opensearch-java/pull/1810))
@@ -25,6 +26,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add transparent gRPC transport with HybridTransport (bulk over gRPC, REST fallback), translation layer, TLS, basic auth, AWS SigV4, and JWT support ([#2062](https://github.com/opensearch-project/opensearch-java/pull/2062))
 
 ### Fixed
+- Fix `JsonData._DESERIALIZER` to correctly handle a pre-consumed parser event in the three-argument `deserialize` overload
 
 ## [Unreleased 3.x]
 ### Added

--- a/guides/json.md
+++ b/guides/json.md
@@ -5,6 +5,9 @@
   - [Deserialization](#deserialization)
     - [Using withJson](#using-withjson)
     - [Using static _DESERIALIZER](#using-static-_deserializer)
+  - [Custom (Plugin-Provided) Variant Types](#custom-plugin-provided-variant-types)
+    - [Reading a custom variant](#reading-a-custom-variant)
+    - [Building a custom variant](#building-a-custom-variant)
  
 
 # Working With JSON
@@ -110,3 +113,37 @@ private IndexTemplateMapping getInstance(String templateJsonString) {
   }
 }
 ```
+
+## Custom (Plugin-Provided) Variant Types
+
+All discriminated tagged unions in this client — both externally-tagged (e.g. `Aggregate`, `Suggest`) and internally-tagged (e.g. `Query`, `Property`, `Processor`, `Analyzer`, `TokenFilterDefinition`) — support a `_Custom` variant kind.
+
+When the server returns a discriminator value that isn't natively modeled (for example, a type introduced by a plugin), the client captures it as `Kind._Custom` with the raw JSON preserved as `JsonData`, rather than throwing a deserialization error.
+
+### Reading a custom variant
+
+```java
+SearchResponse<IndexData> response = client.search(searchRequest, IndexData.class);
+
+for (Map.Entry<String, Aggregate> entry : response.aggregations().entrySet()) {
+    Aggregate agg = entry.getValue();
+    if (agg._isCustom()) {
+        // _customKind() returns the type name from the server (e.g. "my_plugin_agg")
+        String typeName = agg._customKind();
+        // _custom() returns the raw JSON body as JsonData
+        JsonData rawData = agg._custom();
+        System.out.printf("Custom aggregation '%s' of type '%s': %s%n",
+            entry.getKey(), typeName, rawData.toJson());
+    }
+}
+```
+
+### Building a custom variant
+
+```java
+Aggregate custom = new Aggregate.Builder()
+    ._custom("my_plugin_agg", JsonData.of(Map.of("score", 42)))
+    .build();
+```
+
+The same `_isCustom()`, `_customKind()`, `_custom()`, and `Builder._custom(type, data)` methods are available on every discriminated tagged union type.

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/aggregations/Aggregate.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/aggregations/Aggregate.java
@@ -44,6 +44,7 @@ import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 import org.opensearch.client.json.ExternallyTaggedUnion;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
@@ -122,7 +123,9 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
         Umterms("umterms"),
         ValueCount("value_count"),
         VariableWidthHistogram("variable_width_histogram"),
-        WeightedAvg("weighted_avg");
+        WeightedAvg("weighted_avg"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -138,6 +141,7 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
 
     private final Kind _kind;
     private final AggregateVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -149,14 +153,23 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public Aggregate(AggregateVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._aggregateKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private Aggregate(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static Aggregate of(Function<Aggregate.Builder, ObjectBuilder<Aggregate>> fn) {
@@ -1139,6 +1152,25 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
         return TaggedUnionUtils.get(this, Kind.WeightedAvg);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         mapper.serialize(_value, generator);
@@ -1157,12 +1189,14 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Aggregate> {
         private Kind _kind;
         private AggregateVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(Aggregate o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<Aggregate> adjacencyMatrix(AdjacencyMatrixAggregate v) {
@@ -1809,6 +1843,19 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
             return this.weightedAvg(fn.apply(new WeightedAvgAggregate.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<Aggregate> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public Aggregate build() {
             _checkSingleUse();
@@ -1817,6 +1864,10 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
     }
 
     public static final ExternallyTaggedUnion.TypedKeysDeserializer<Aggregate> _TYPED_KEYS_DESERIALIZER;
+
+    private static Aggregate _buildCustom(String type, JsonData data) {
+        return new Builder()._custom(type, data).build();
+    }
 
     static {
         Map<String, JsonpDeserializer<? extends AggregateVariant>> deserializers = new HashMap<>();
@@ -1882,7 +1933,8 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
         deserializers.put("variable_width_histogram", VariableWidthHistogramAggregate._DESERIALIZER);
         deserializers.put("weighted_avg", WeightedAvgAggregate._DESERIALIZER);
 
-        _TYPED_KEYS_DESERIALIZER = new ExternallyTaggedUnion.Deserializer<>(deserializers, Aggregate::new).typedKeys();
+        _TYPED_KEYS_DESERIALIZER = new ExternallyTaggedUnion.Deserializer<>(deserializers, Aggregate::new, Aggregate::_buildCustom)
+            .typedKeys();
     }
 
     @Override
@@ -1890,6 +1942,7 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -1898,6 +1951,41 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Aggregate other = (Aggregate) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements AggregateVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _aggregateKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/aggregations/Aggregate.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/aggregations/Aggregate.java
@@ -1951,7 +1951,9 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Aggregate other = (Aggregate) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/aggregations/Aggregation.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/aggregations/Aggregation.java
@@ -132,7 +132,9 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, AggregationVar
         TopHits("top_hits"),
         ValueCount("value_count"),
         VariableWidthHistogram("variable_width_histogram"),
-        WeightedAvg("weighted_avg");
+        WeightedAvg("weighted_avg"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -148,6 +150,7 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, AggregationVar
 
     private final Kind _kind;
     private final AggregationVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -159,12 +162,20 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, AggregationVar
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     @Nonnull
     private final Map<String, JsonData> meta;
 
     public Aggregation(AggregationVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._aggregationKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
         this.meta = null;
     }
 
@@ -172,6 +183,7 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, AggregationVar
         this.meta = ApiTypeHelper.unmodifiable(builder.meta);
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static Aggregation of(Function<Aggregation.Builder, ObjectBuilder<Aggregation>> fn) {
@@ -1226,6 +1238,25 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, AggregationVar
         return TaggedUnionUtils.get(this, Kind.WeightedAvg);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
@@ -1238,7 +1269,7 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, AggregationVar
             }
             generator.writeEnd();
         }
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         }
@@ -1258,6 +1289,7 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, AggregationVar
     public static class Builder extends ObjectBuilderBase {
         private Kind _kind;
         private AggregationVariant _value;
+        private String _customKind;
         @Nullable
         private Map<String, JsonData> meta;
 
@@ -1267,6 +1299,7 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, AggregationVar
             this.meta = _mapCopy(o.meta);
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         /**
@@ -1971,6 +2004,19 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, AggregationVar
             return this.weightedAvg(fn.apply(new WeightedAverageAggregation.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ContainerBuilder _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return new ContainerBuilder();
+        }
+
         protected Aggregation build() {
             _checkSingleUse();
             return new Aggregation(this);
@@ -2079,6 +2125,9 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, AggregationVar
         op.add(Builder::valueCount, ValueCountAggregation._DESERIALIZER, "value_count");
         op.add(Builder::variableWidthHistogram, VariableWidthHistogramAggregation._DESERIALIZER, "variable_width_histogram");
         op.add(Builder::weightedAvg, WeightedAverageAggregation._DESERIALIZER, "weighted_avg");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<Aggregation> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -2092,6 +2141,7 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, AggregationVar
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         result = 31 * result + Objects.hashCode(this.meta);
         return result;
     }
@@ -2103,6 +2153,42 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, AggregationVar
         Aggregation other = (Aggregation) o;
         return Objects.equals(this._kind, other._kind)
             && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind)
             && Objects.equals(this.meta, other.meta);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements AggregationVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _aggregationKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/aggregations/MovingAverageAggregation.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/aggregations/MovingAverageAggregation.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -71,7 +72,9 @@ public class MovingAverageAggregation
         Holt("holt"),
         HoltWinters("holt_winters"),
         Linear("linear"),
-        Simple("simple");
+        Simple("simple"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -95,6 +98,7 @@ public class MovingAverageAggregation
 
     private final Kind _kind;
     private final MovingAverageAggregationVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -106,14 +110,23 @@ public class MovingAverageAggregation
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public MovingAverageAggregation(MovingAverageAggregationVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._movingAverageAggregationKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private MovingAverageAggregation(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static MovingAverageAggregation of(Function<MovingAverageAggregation.Builder, ObjectBuilder<MovingAverageAggregation>> fn) {
@@ -200,6 +213,25 @@ public class MovingAverageAggregation
         return TaggedUnionUtils.get(this, Kind.Simple);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         mapper.serialize(_value, generator);
@@ -218,12 +250,14 @@ public class MovingAverageAggregation
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<MovingAverageAggregation> {
         private Kind _kind;
         private MovingAverageAggregationVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(MovingAverageAggregation o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<MovingAverageAggregation> ewma(EwmaMovingAverageAggregation v) {
@@ -286,6 +320,19 @@ public class MovingAverageAggregation
             return this.simple(fn.apply(new SimpleMovingAverageAggregation.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<MovingAverageAggregation> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public MovingAverageAggregation build() {
             _checkSingleUse();
@@ -300,6 +347,9 @@ public class MovingAverageAggregation
         op.add(Builder::linear, LinearMovingAverageAggregation._DESERIALIZER, "linear");
         op.add(Builder::simple, SimpleMovingAverageAggregation._DESERIALIZER, "simple");
         op.setTypeProperty("model", null);
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<MovingAverageAggregation> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -313,6 +363,7 @@ public class MovingAverageAggregation
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -321,6 +372,41 @@ public class MovingAverageAggregation
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         MovingAverageAggregation other = (MovingAverageAggregation) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements MovingAverageAggregationVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _movingAverageAggregationKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/aggregations/MovingAverageAggregation.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/aggregations/MovingAverageAggregation.java
@@ -372,7 +372,9 @@ public class MovingAverageAggregation
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         MovingAverageAggregation other = (MovingAverageAggregation) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/Analyzer.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/Analyzer.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -80,7 +81,9 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Pl
         Snowball("snowball"),
         Standard("standard"),
         Stop("stop"),
-        Whitespace("whitespace");
+        Whitespace("whitespace"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -96,6 +99,7 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Pl
 
     private final Kind _kind;
     private final AnalyzerVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -107,14 +111,23 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Pl
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public Analyzer(AnalyzerVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._analyzerKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private Analyzer(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static Analyzer of(Function<Analyzer.Builder, ObjectBuilder<Analyzer>> fn) {
@@ -409,6 +422,25 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Pl
         return TaggedUnionUtils.get(this, Kind.Whitespace);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         mapper.serialize(_value, generator);
@@ -427,12 +459,14 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Pl
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Analyzer> {
         private Kind _kind;
         private AnalyzerVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(Analyzer o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<Analyzer> cjk(CjkAnalyzer v) {
@@ -615,6 +649,19 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Pl
             return this.whitespace(fn.apply(new WhitespaceAnalyzer.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<Analyzer> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public Analyzer build() {
             _checkSingleUse();
@@ -642,6 +689,9 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Pl
         op.add(Builder::stop, StopAnalyzer._DESERIALIZER, "stop");
         op.add(Builder::whitespace, WhitespaceAnalyzer._DESERIALIZER, "whitespace");
         op.setTypeProperty("type", Kind.Custom.jsonValue());
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<Analyzer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -655,6 +705,7 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Pl
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -663,6 +714,41 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Pl
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Analyzer other = (Analyzer) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements AnalyzerVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _analyzerKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/Analyzer.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/Analyzer.java
@@ -714,7 +714,9 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Pl
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Analyzer other = (Analyzer) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/CharFilterDefinition.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/CharFilterDefinition.java
@@ -356,7 +356,9 @@ public class CharFilterDefinition implements TaggedUnion<CharFilterDefinition.Ki
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         CharFilterDefinition other = (CharFilterDefinition) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/CharFilterDefinition.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/CharFilterDefinition.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -67,7 +68,9 @@ public class CharFilterDefinition implements TaggedUnion<CharFilterDefinition.Ki
         IcuNormalizer("icu_normalizer"),
         KuromojiIterationMark("kuromoji_iteration_mark"),
         Mapping("mapping"),
-        PatternReplace("pattern_replace");
+        PatternReplace("pattern_replace"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -83,6 +86,7 @@ public class CharFilterDefinition implements TaggedUnion<CharFilterDefinition.Ki
 
     private final Kind _kind;
     private final CharFilterDefinitionVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -94,14 +98,23 @@ public class CharFilterDefinition implements TaggedUnion<CharFilterDefinition.Ki
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public CharFilterDefinition(CharFilterDefinitionVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._charFilterDefinitionKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private CharFilterDefinition(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static CharFilterDefinition of(Function<CharFilterDefinition.Builder, ObjectBuilder<CharFilterDefinition>> fn) {
@@ -188,6 +201,25 @@ public class CharFilterDefinition implements TaggedUnion<CharFilterDefinition.Ki
         return TaggedUnionUtils.get(this, Kind.PatternReplace);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         mapper.serialize(_value, generator);
@@ -206,12 +238,14 @@ public class CharFilterDefinition implements TaggedUnion<CharFilterDefinition.Ki
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CharFilterDefinition> {
         private Kind _kind;
         private CharFilterDefinitionVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(CharFilterDefinition o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<CharFilterDefinition> htmlStrip(HtmlStripCharFilter v) {
@@ -270,6 +304,19 @@ public class CharFilterDefinition implements TaggedUnion<CharFilterDefinition.Ki
             return this.patternReplace(fn.apply(new PatternReplaceCharFilter.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<CharFilterDefinition> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public CharFilterDefinition build() {
             _checkSingleUse();
@@ -284,6 +331,9 @@ public class CharFilterDefinition implements TaggedUnion<CharFilterDefinition.Ki
         op.add(Builder::mapping, MappingCharFilter._DESERIALIZER, "mapping");
         op.add(Builder::patternReplace, PatternReplaceCharFilter._DESERIALIZER, "pattern_replace");
         op.setTypeProperty("type", null);
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<CharFilterDefinition> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -297,6 +347,7 @@ public class CharFilterDefinition implements TaggedUnion<CharFilterDefinition.Ki
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -305,6 +356,41 @@ public class CharFilterDefinition implements TaggedUnion<CharFilterDefinition.Ki
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         CharFilterDefinition other = (CharFilterDefinition) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements CharFilterDefinitionVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _charFilterDefinitionKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/Normalizer.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/Normalizer.java
@@ -266,7 +266,9 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Normalizer other = (Normalizer) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/Normalizer.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/Normalizer.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -64,7 +65,9 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
      */
     public enum Kind implements JsonEnum {
         Custom("custom"),
-        Lowercase("lowercase");
+        Lowercase("lowercase"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -80,6 +83,7 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
 
     private final Kind _kind;
     private final NormalizerVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -91,14 +95,23 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public Normalizer(NormalizerVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._normalizerKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private Normalizer(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static Normalizer of(Function<Normalizer.Builder, ObjectBuilder<Normalizer>> fn) {
@@ -137,6 +150,25 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
         return TaggedUnionUtils.get(this, Kind.Lowercase);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         mapper.serialize(_value, generator);
@@ -155,12 +187,14 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Normalizer> {
         private Kind _kind;
         private NormalizerVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(Normalizer o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<Normalizer> custom(CustomNormalizer v) {
@@ -183,6 +217,19 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
             return this.lowercase(fn.apply(new LowercaseNormalizer.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<Normalizer> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public Normalizer build() {
             _checkSingleUse();
@@ -194,6 +241,9 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
         op.add(Builder::custom, CustomNormalizer._DESERIALIZER, "custom");
         op.add(Builder::lowercase, LowercaseNormalizer._DESERIALIZER, "lowercase");
         op.setTypeProperty("type", Kind.Custom.jsonValue());
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<Normalizer> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -207,6 +257,7 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -215,6 +266,41 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Normalizer other = (Normalizer) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements NormalizerVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _normalizerKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/TokenFilterDefinition.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/TokenFilterDefinition.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -112,7 +113,9 @@ public class TokenFilterDefinition implements TaggedUnion<TokenFilterDefinition.
         Unique("unique"),
         Uppercase("uppercase"),
         WordDelimiter("word_delimiter"),
-        WordDelimiterGraph("word_delimiter_graph");
+        WordDelimiterGraph("word_delimiter_graph"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -128,6 +131,7 @@ public class TokenFilterDefinition implements TaggedUnion<TokenFilterDefinition.
 
     private final Kind _kind;
     private final TokenFilterDefinitionVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -139,14 +143,23 @@ public class TokenFilterDefinition implements TaggedUnion<TokenFilterDefinition.
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public TokenFilterDefinition(TokenFilterDefinitionVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._tokenFilterDefinitionKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private TokenFilterDefinition(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static TokenFilterDefinition of(Function<TokenFilterDefinition.Builder, ObjectBuilder<TokenFilterDefinition>> fn) {
@@ -953,6 +966,25 @@ public class TokenFilterDefinition implements TaggedUnion<TokenFilterDefinition.
         return TaggedUnionUtils.get(this, Kind.WordDelimiterGraph);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         mapper.serialize(_value, generator);
@@ -971,12 +1003,14 @@ public class TokenFilterDefinition implements TaggedUnion<TokenFilterDefinition.
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TokenFilterDefinition> {
         private Kind _kind;
         private TokenFilterDefinitionVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(TokenFilterDefinition o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<TokenFilterDefinition> asciifolding(AsciiFoldingTokenFilter v) {
@@ -1545,6 +1579,19 @@ public class TokenFilterDefinition implements TaggedUnion<TokenFilterDefinition.
             return this.wordDelimiterGraph(fn.apply(new WordDelimiterGraphTokenFilter.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<TokenFilterDefinition> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public TokenFilterDefinition build() {
             _checkSingleUse();
@@ -1604,6 +1651,9 @@ public class TokenFilterDefinition implements TaggedUnion<TokenFilterDefinition.
         op.add(Builder::wordDelimiter, WordDelimiterTokenFilter._DESERIALIZER, "word_delimiter");
         op.add(Builder::wordDelimiterGraph, WordDelimiterGraphTokenFilter._DESERIALIZER, "word_delimiter_graph");
         op.setTypeProperty("type", null);
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<TokenFilterDefinition> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -1617,6 +1667,7 @@ public class TokenFilterDefinition implements TaggedUnion<TokenFilterDefinition.
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -1625,6 +1676,41 @@ public class TokenFilterDefinition implements TaggedUnion<TokenFilterDefinition.
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         TokenFilterDefinition other = (TokenFilterDefinition) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements TokenFilterDefinitionVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _tokenFilterDefinitionKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/TokenFilterDefinition.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/TokenFilterDefinition.java
@@ -1676,7 +1676,9 @@ public class TokenFilterDefinition implements TaggedUnion<TokenFilterDefinition.
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         TokenFilterDefinition other = (TokenFilterDefinition) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/TokenizerDefinition.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/TokenizerDefinition.java
@@ -696,7 +696,9 @@ public class TokenizerDefinition implements TaggedUnion<TokenizerDefinition.Kind
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         TokenizerDefinition other = (TokenizerDefinition) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/TokenizerDefinition.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/analysis/TokenizerDefinition.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -79,7 +80,9 @@ public class TokenizerDefinition implements TaggedUnion<TokenizerDefinition.Kind
         SmartcnTokenizer("smartcn_tokenizer"),
         Standard("standard"),
         UaxUrlEmail("uax_url_email"),
-        Whitespace("whitespace");
+        Whitespace("whitespace"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -95,6 +98,7 @@ public class TokenizerDefinition implements TaggedUnion<TokenizerDefinition.Kind
 
     private final Kind _kind;
     private final TokenizerDefinitionVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -106,14 +110,23 @@ public class TokenizerDefinition implements TaggedUnion<TokenizerDefinition.Kind
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public TokenizerDefinition(TokenizerDefinitionVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._tokenizerDefinitionKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private TokenizerDefinition(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static TokenizerDefinition of(Function<TokenizerDefinition.Builder, ObjectBuilder<TokenizerDefinition>> fn) {
@@ -392,6 +405,25 @@ public class TokenizerDefinition implements TaggedUnion<TokenizerDefinition.Kind
         return TaggedUnionUtils.get(this, Kind.Whitespace);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         mapper.serialize(_value, generator);
@@ -410,12 +442,14 @@ public class TokenizerDefinition implements TaggedUnion<TokenizerDefinition.Kind
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TokenizerDefinition> {
         private Kind _kind;
         private TokenizerDefinitionVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(TokenizerDefinition o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<TokenizerDefinition> charGroup(CharGroupTokenizer v) {
@@ -598,6 +632,19 @@ public class TokenizerDefinition implements TaggedUnion<TokenizerDefinition.Kind
             return this.whitespace(fn.apply(new WhitespaceTokenizer.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<TokenizerDefinition> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public TokenizerDefinition build() {
             _checkSingleUse();
@@ -624,6 +671,9 @@ public class TokenizerDefinition implements TaggedUnion<TokenizerDefinition.Kind
         op.add(Builder::uaxUrlEmail, UaxEmailUrlTokenizer._DESERIALIZER, "uax_url_email");
         op.add(Builder::whitespace, WhitespaceTokenizer._DESERIALIZER, "whitespace");
         op.setTypeProperty("type", null);
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<TokenizerDefinition> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -637,6 +687,7 @@ public class TokenizerDefinition implements TaggedUnion<TokenizerDefinition.Kind
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -645,6 +696,41 @@ public class TokenizerDefinition implements TaggedUnion<TokenizerDefinition.Kind
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         TokenizerDefinition other = (TokenizerDefinition) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements TokenizerDefinitionVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _tokenizerDefinitionKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/mapping/Property.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/mapping/Property.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -109,7 +110,9 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Pl
         Version("version"),
         Wildcard("wildcard"),
         XyPoint("xy_point"),
-        XyShape("xy_shape");
+        XyShape("xy_shape"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -125,6 +128,7 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Pl
 
     private final Kind _kind;
     private final PropertyVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -136,14 +140,23 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Pl
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public Property(PropertyVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._propertyKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private Property(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static Property of(Function<Property.Builder, ObjectBuilder<Property>> fn) {
@@ -902,6 +915,25 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Pl
         return TaggedUnionUtils.get(this, Kind.XyShape);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         mapper.serialize(_value, generator);
@@ -920,12 +952,14 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Pl
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Property> {
         private Kind _kind;
         private PropertyVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(Property o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<Property> aggregateMetricDouble(AggregateMetricDoubleProperty v) {
@@ -1410,6 +1444,19 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Pl
             return this.xyShape(fn.apply(new XyShapeProperty.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<Property> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public Property build() {
             _checkSingleUse();
@@ -1466,6 +1513,9 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Pl
         op.add(Builder::xyPoint, XyPointProperty._DESERIALIZER, "xy_point");
         op.add(Builder::xyShape, XyShapeProperty._DESERIALIZER, "xy_shape");
         op.setTypeProperty("type", Kind.Object.jsonValue());
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<Property> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -1479,6 +1529,7 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Pl
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -1487,6 +1538,41 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Pl
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Property other = (Property) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements PropertyVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _propertyKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/mapping/Property.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/mapping/Property.java
@@ -1538,7 +1538,9 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Pl
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Property other = (Property) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/FunctionScore.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/FunctionScore.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -70,7 +71,9 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
         Gauss("gauss"),
         Linear("linear"),
         RandomScore("random_score"),
-        ScriptScore("script_score");
+        ScriptScore("script_score"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -86,6 +89,7 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
 
     private final Kind _kind;
     private final FunctionScoreVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -95,6 +99,13 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
     @Override
     public final FunctionScoreVariant _get() {
         return _value;
+    }
+
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
     }
 
     @Nullable
@@ -111,6 +122,7 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
             this._kind = null;
             this._value = null;
         }
+        this._customKind = null;
         this.filter = null;
         this.weight = null;
     }
@@ -125,6 +137,7 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
             this._kind = null;
             this._value = null;
         }
+        this._customKind = builder._customKind;
     }
 
     public static FunctionScore of(Function<FunctionScore.Builder, ObjectBuilder<FunctionScore>> fn) {
@@ -243,6 +256,25 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
         return TaggedUnionUtils.get(this, Kind.ScriptScore);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
@@ -256,7 +288,7 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
             generator.write(this.weight);
         }
         if (_kind != null) {
-            generator.writeKey(_kind.jsonValue());
+            generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
             if (_value instanceof JsonpSerializable) {
                 ((JsonpSerializable) _value).serialize(generator, mapper);
             }
@@ -277,6 +309,7 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<FunctionScore> {
         private Kind _kind;
         private FunctionScoreVariant _value;
+        private String _customKind;
         @Nullable
         private Query filter;
         @Nullable
@@ -289,6 +322,7 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
             this.weight = o.weight;
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         /**
@@ -379,6 +413,19 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
             return this.scriptScore(fn.apply(new ScriptScoreFunction.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ContainerBuilder _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return new ContainerBuilder();
+        }
+
         public FunctionScore build() {
             _checkSingleUse();
             return new FunctionScore(this);
@@ -429,6 +476,9 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
         op.add(Builder::linear, DecayFunction._DESERIALIZER, "linear");
         op.add(Builder::randomScore, RandomScoreFunction._DESERIALIZER, "random_score");
         op.add(Builder::scriptScore, ScriptScoreFunction._DESERIALIZER, "script_score");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<FunctionScore> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -442,6 +492,7 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         result = 31 * result + Objects.hashCode(this.filter);
         result = 31 * result + Objects.hashCode(this.weight);
         return result;
@@ -454,7 +505,43 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, FunctionSc
         FunctionScore other = (FunctionScore) o;
         return Objects.equals(this._kind, other._kind)
             && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind)
             && Objects.equals(this.filter, other.filter)
             && Objects.equals(this.weight, other.weight);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements FunctionScoreVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _functionScoreKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/Intervals.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/Intervals.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -69,7 +70,9 @@ public class Intervals implements TaggedUnion<Intervals.Kind, IntervalsVariant>,
         Fuzzy("fuzzy"),
         Match("match"),
         Prefix("prefix"),
-        Wildcard("wildcard");
+        Wildcard("wildcard"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -93,6 +96,7 @@ public class Intervals implements TaggedUnion<Intervals.Kind, IntervalsVariant>,
 
     private final Kind _kind;
     private final IntervalsVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -104,14 +108,23 @@ public class Intervals implements TaggedUnion<Intervals.Kind, IntervalsVariant>,
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public Intervals(IntervalsVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._intervalsKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private Intervals(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static Intervals of(Function<Intervals.Builder, ObjectBuilder<Intervals>> fn) {
@@ -214,10 +227,29 @@ public class Intervals implements TaggedUnion<Intervals.Kind, IntervalsVariant>,
         return TaggedUnionUtils.get(this, Kind.Wildcard);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         }
@@ -237,12 +269,14 @@ public class Intervals implements TaggedUnion<Intervals.Kind, IntervalsVariant>,
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Intervals> {
         private Kind _kind;
         private IntervalsVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(Intervals o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<Intervals> allOf(IntervalsAllOf v) {
@@ -305,6 +339,19 @@ public class Intervals implements TaggedUnion<Intervals.Kind, IntervalsVariant>,
             return this.wildcard(fn.apply(new IntervalsWildcard.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<Intervals> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public Intervals build() {
             _checkSingleUse();
@@ -319,6 +366,9 @@ public class Intervals implements TaggedUnion<Intervals.Kind, IntervalsVariant>,
         op.add(Builder::match, IntervalsMatch._DESERIALIZER, "match");
         op.add(Builder::prefix, IntervalsPrefix._DESERIALIZER, "prefix");
         op.add(Builder::wildcard, IntervalsWildcard._DESERIALIZER, "wildcard");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<Intervals> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -332,6 +382,7 @@ public class Intervals implements TaggedUnion<Intervals.Kind, IntervalsVariant>,
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -340,6 +391,41 @@ public class Intervals implements TaggedUnion<Intervals.Kind, IntervalsVariant>,
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Intervals other = (Intervals) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements IntervalsVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _intervalsKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/Intervals.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/Intervals.java
@@ -391,7 +391,9 @@ public class Intervals implements TaggedUnion<Intervals.Kind, IntervalsVariant>,
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Intervals other = (Intervals) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsFilter.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsFilter.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -73,7 +74,9 @@ public class IntervalsFilter implements TaggedUnion<IntervalsFilter.Kind, Interv
         NotContaining("not_containing"),
         NotOverlapping("not_overlapping"),
         Overlapping("overlapping"),
-        Script("script");
+        Script("script"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -89,6 +92,7 @@ public class IntervalsFilter implements TaggedUnion<IntervalsFilter.Kind, Interv
 
     private final Kind _kind;
     private final IntervalsFilterVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -100,14 +104,23 @@ public class IntervalsFilter implements TaggedUnion<IntervalsFilter.Kind, Interv
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public IntervalsFilter(IntervalsFilterVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._intervalsFilterKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private IntervalsFilter(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static IntervalsFilter of(Function<IntervalsFilter.Builder, ObjectBuilder<IntervalsFilter>> fn) {
@@ -258,10 +271,29 @@ public class IntervalsFilter implements TaggedUnion<IntervalsFilter.Kind, Interv
         return TaggedUnionUtils.get(this, Kind.Script);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         }
@@ -281,12 +313,14 @@ public class IntervalsFilter implements TaggedUnion<IntervalsFilter.Kind, Interv
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<IntervalsFilter> {
         private Kind _kind;
         private IntervalsFilterVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(IntervalsFilter o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<IntervalsFilter> after(Intervals v) {
@@ -379,6 +413,19 @@ public class IntervalsFilter implements TaggedUnion<IntervalsFilter.Kind, Interv
             return this.script(fn.apply(new Script.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<IntervalsFilter> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public IntervalsFilter build() {
             _checkSingleUse();
@@ -396,6 +443,9 @@ public class IntervalsFilter implements TaggedUnion<IntervalsFilter.Kind, Interv
         op.add(Builder::notOverlapping, Intervals._DESERIALIZER, "not_overlapping");
         op.add(Builder::overlapping, Intervals._DESERIALIZER, "overlapping");
         op.add(Builder::script, Script._DESERIALIZER, "script");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<IntervalsFilter> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -409,6 +459,7 @@ public class IntervalsFilter implements TaggedUnion<IntervalsFilter.Kind, Interv
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -417,6 +468,41 @@ public class IntervalsFilter implements TaggedUnion<IntervalsFilter.Kind, Interv
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         IntervalsFilter other = (IntervalsFilter) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements IntervalsFilterVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _intervalsFilterKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsFilter.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsFilter.java
@@ -468,7 +468,9 @@ public class IntervalsFilter implements TaggedUnion<IntervalsFilter.Kind, Interv
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         IntervalsFilter other = (IntervalsFilter) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsQuery.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsQuery.java
@@ -412,23 +412,26 @@ public class IntervalsQuery extends QueryBase
 
     @Override
     public int hashCode() {
-        int result = 17;
+        int result = super.hashCode();
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
         result = 31 * result + Objects.hashCode(this._customKind);
-        result = 31 * result + Objects.hashCode(this.field);
+        result = 31 * result + this.field.hashCode();
         return result;
     }
 
     @Override
     public boolean equals(Object o) {
+        if (!super.equals(o)) {
+            return false;
+        }
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         IntervalsQuery other = (IntervalsQuery) o;
         return Objects.equals(this._kind, other._kind)
             && Objects.equals(this._value, other._value)
             && Objects.equals(this._customKind, other._customKind)
-            && Objects.equals(this.field, other.field);
+            && this.field.equals(other.field);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsQuery.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsQuery.java
@@ -428,7 +428,10 @@ public class IntervalsQuery extends QueryBase
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         IntervalsQuery other = (IntervalsQuery) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind) && this.field.equals(other.field);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind)
+            && this.field.equals(other.field);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsQuery.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsQuery.java
@@ -412,26 +412,23 @@ public class IntervalsQuery extends QueryBase
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
+        int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
         result = 31 * result + Objects.hashCode(this._customKind);
-        result = 31 * result + this.field.hashCode();
+        result = 31 * result + Objects.hashCode(this.field);
         return result;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (!super.equals(o)) {
-            return false;
-        }
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         IntervalsQuery other = (IntervalsQuery) o;
         return Objects.equals(this._kind, other._kind)
             && Objects.equals(this._value, other._value)
             && Objects.equals(this._customKind, other._customKind)
-            && this.field.equals(other.field);
+            && Objects.equals(this.field, other.field);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsQuery.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/IntervalsQuery.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -72,7 +73,9 @@ public class IntervalsQuery extends QueryBase
         Fuzzy("fuzzy"),
         Match("match"),
         Prefix("prefix"),
-        Wildcard("wildcard");
+        Wildcard("wildcard"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -96,6 +99,7 @@ public class IntervalsQuery extends QueryBase
 
     private final Kind _kind;
     private final IntervalsQueryVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -107,6 +111,13 @@ public class IntervalsQuery extends QueryBase
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     @Nonnull
     private final String field;
 
@@ -115,6 +126,7 @@ public class IntervalsQuery extends QueryBase
         this.field = ApiTypeHelper.requireNonNull(builder.field, this, "field");
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static IntervalsQuery of(Function<IntervalsQuery.Builder, ObjectBuilder<IntervalsQuery>> fn) {
@@ -225,12 +237,31 @@ public class IntervalsQuery extends QueryBase
         return TaggedUnionUtils.get(this, Kind.Wildcard);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
         generator.writeStartObject(this.field);
         super.serializeInternal(generator, mapper);
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         }
@@ -251,6 +282,7 @@ public class IntervalsQuery extends QueryBase
     public static class Builder extends QueryBase.AbstractBuilder<Builder> implements ObjectBuilder<IntervalsQuery> {
         private Kind _kind;
         private IntervalsQueryVariant _value;
+        private String _customKind;
         private String field;
 
         public Builder() {}
@@ -260,6 +292,7 @@ public class IntervalsQuery extends QueryBase
             this.field = o.field;
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         @Override
@@ -337,6 +370,19 @@ public class IntervalsQuery extends QueryBase
             return this.wildcard(fn.apply(new IntervalsWildcard.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<IntervalsQuery> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public IntervalsQuery build() {
             _checkSingleUse();
@@ -353,6 +399,9 @@ public class IntervalsQuery extends QueryBase
         op.add(Builder::prefix, IntervalsPrefix._DESERIALIZER, "prefix");
         op.add(Builder::wildcard, IntervalsWildcard._DESERIALIZER, "wildcard");
         op.setKey(Builder::field, JsonpDeserializer.stringDeserializer());
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<IntervalsQuery> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -366,6 +415,7 @@ public class IntervalsQuery extends QueryBase
         int result = super.hashCode();
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         result = 31 * result + this.field.hashCode();
         return result;
     }
@@ -378,6 +428,41 @@ public class IntervalsQuery extends QueryBase
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         IntervalsQuery other = (IntervalsQuery) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && this.field.equals(other.field);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind) && this.field.equals(other.field);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements IntervalsQueryVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _intervalsQueryKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/Query.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/Query.java
@@ -1857,7 +1857,9 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Query other = (Query) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/Query.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/Query.java
@@ -125,7 +125,9 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
         Type("type"),
         Wildcard("wildcard"),
         Wrapper("wrapper"),
-        XyShape("xy_shape");
+        XyShape("xy_shape"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -149,6 +151,7 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 
     private final Kind _kind;
     private final Object _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -160,14 +163,23 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public Query(QueryVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._queryKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private Query(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static Query of(Function<Query.Builder, ObjectBuilder<Query>> fn) {
@@ -1102,10 +1114,29 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
         return TaggedUnionUtils.get(this, Kind.XyShape);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         } else {
@@ -1136,12 +1167,14 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Query> {
         private Kind _kind;
         private Object _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(Query o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<Query> agentic(AgenticQuery v) {
@@ -1720,6 +1753,19 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
             return this.xyShape(fn.apply(new XyShapeQuery.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<Query> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public Query build() {
             _checkSingleUse();
@@ -1786,6 +1832,9 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
         op.add(Builder::wildcard, WildcardQuery._DESERIALIZER, "wildcard");
         op.add(Builder::wrapper, WrapperQuery._DESERIALIZER, "wrapper");
         op.add(Builder::xyShape, XyShapeQuery._DESERIALIZER, "xy_shape");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<Query> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -1799,6 +1848,7 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -1807,6 +1857,41 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Query other = (Query) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements QueryVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _queryKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/SpanQuery.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/SpanQuery.java
@@ -495,7 +495,9 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, SpanQueryVariant>,
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         SpanQuery other = (SpanQuery) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/SpanQuery.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/SpanQuery.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -73,7 +74,9 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, SpanQueryVariant>,
         SpanNot("span_not"),
         SpanOr("span_or"),
         SpanTerm("span_term"),
-        SpanWithin("span_within");
+        SpanWithin("span_within"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -89,6 +92,7 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, SpanQueryVariant>,
 
     private final Kind _kind;
     private final SpanQueryVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -100,14 +104,23 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, SpanQueryVariant>,
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public SpanQuery(SpanQueryVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._spanQueryKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private SpanQuery(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static SpanQuery of(Function<SpanQuery.Builder, ObjectBuilder<SpanQuery>> fn) {
@@ -274,10 +287,29 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, SpanQueryVariant>,
         return TaggedUnionUtils.get(this, Kind.SpanWithin);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         }
@@ -297,12 +329,14 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, SpanQueryVariant>,
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SpanQuery> {
         private Kind _kind;
         private SpanQueryVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(SpanQuery o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<SpanQuery> fieldMaskingSpan(SpanFieldMaskingQuery v) {
@@ -405,6 +439,19 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, SpanQueryVariant>,
             return this.spanWithin(fn.apply(new SpanWithinQuery.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<SpanQuery> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public SpanQuery build() {
             _checkSingleUse();
@@ -423,6 +470,9 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, SpanQueryVariant>,
         op.add(Builder::spanOr, SpanOrQuery._DESERIALIZER, "span_or");
         op.add(Builder::spanTerm, SpanTermQuery._DESERIALIZER, "span_term");
         op.add(Builder::spanWithin, SpanWithinQuery._DESERIALIZER, "span_within");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<SpanQuery> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -436,6 +486,7 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, SpanQueryVariant>,
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -444,6 +495,41 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, SpanQueryVariant>,
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         SpanQuery other = (SpanQuery) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements SpanQueryVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _spanQueryKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/cluster/remote_info/ClusterRemoteInfo.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/cluster/remote_info/ClusterRemoteInfo.java
@@ -266,7 +266,9 @@ public class ClusterRemoteInfo implements TaggedUnion<ClusterRemoteInfo.Kind, Cl
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         ClusterRemoteInfo other = (ClusterRemoteInfo) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/cluster/remote_info/ClusterRemoteInfo.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/cluster/remote_info/ClusterRemoteInfo.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -64,7 +65,9 @@ public class ClusterRemoteInfo implements TaggedUnion<ClusterRemoteInfo.Kind, Cl
      */
     public enum Kind implements JsonEnum {
         Proxy("proxy"),
-        Sniff("sniff");
+        Sniff("sniff"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -80,6 +83,7 @@ public class ClusterRemoteInfo implements TaggedUnion<ClusterRemoteInfo.Kind, Cl
 
     private final Kind _kind;
     private final ClusterRemoteInfoVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -91,14 +95,23 @@ public class ClusterRemoteInfo implements TaggedUnion<ClusterRemoteInfo.Kind, Cl
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public ClusterRemoteInfo(ClusterRemoteInfoVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._clusterRemoteInfoKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private ClusterRemoteInfo(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static ClusterRemoteInfo of(Function<ClusterRemoteInfo.Builder, ObjectBuilder<ClusterRemoteInfo>> fn) {
@@ -137,6 +150,25 @@ public class ClusterRemoteInfo implements TaggedUnion<ClusterRemoteInfo.Kind, Cl
         return TaggedUnionUtils.get(this, Kind.Sniff);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         mapper.serialize(_value, generator);
@@ -155,12 +187,14 @@ public class ClusterRemoteInfo implements TaggedUnion<ClusterRemoteInfo.Kind, Cl
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ClusterRemoteInfo> {
         private Kind _kind;
         private ClusterRemoteInfoVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(ClusterRemoteInfo o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<ClusterRemoteInfo> proxy(ClusterRemoteProxyInfo v) {
@@ -183,6 +217,19 @@ public class ClusterRemoteInfo implements TaggedUnion<ClusterRemoteInfo.Kind, Cl
             return this.sniff(fn.apply(new ClusterRemoteSniffInfo.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<ClusterRemoteInfo> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public ClusterRemoteInfo build() {
             _checkSingleUse();
@@ -194,6 +241,9 @@ public class ClusterRemoteInfo implements TaggedUnion<ClusterRemoteInfo.Kind, Cl
         op.add(Builder::proxy, ClusterRemoteProxyInfo._DESERIALIZER, "proxy");
         op.add(Builder::sniff, ClusterRemoteSniffInfo._DESERIALIZER, "sniff");
         op.setTypeProperty("mode", null);
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<ClusterRemoteInfo> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -207,6 +257,7 @@ public class ClusterRemoteInfo implements TaggedUnion<ClusterRemoteInfo.Kind, Cl
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -215,6 +266,41 @@ public class ClusterRemoteInfo implements TaggedUnion<ClusterRemoteInfo.Kind, Cl
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         ClusterRemoteInfo other = (ClusterRemoteInfo) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements ClusterRemoteInfoVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _clusterRemoteInfoKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/FieldSuggester.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/FieldSuggester.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -67,7 +68,9 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
     public enum Kind implements JsonEnum {
         Completion("completion"),
         Phrase("phrase"),
-        Term("term");
+        Term("term"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -83,6 +86,7 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
 
     private final Kind _kind;
     private final FieldSuggesterVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -92,6 +96,13 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
     @Override
     public final FieldSuggesterVariant _get() {
         return _value;
+    }
+
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
     }
 
     @Nullable
@@ -106,6 +117,7 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
     public FieldSuggester(FieldSuggesterVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._fieldSuggesterKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
         this.prefix = null;
         this.regex = null;
         this.text = null;
@@ -117,6 +129,7 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
         this.text = builder.text;
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static FieldSuggester of(Function<FieldSuggester.Builder, ObjectBuilder<FieldSuggester>> fn) {
@@ -195,6 +208,25 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
         return TaggedUnionUtils.get(this, Kind.Term);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
@@ -212,7 +244,7 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
             generator.writeKey("text");
             generator.write(this.text);
         }
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         }
@@ -232,6 +264,7 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
     public static class Builder extends ObjectBuilderBase {
         private Kind _kind;
         private FieldSuggesterVariant _value;
+        private String _customKind;
         @Nullable
         private String prefix;
         @Nullable
@@ -247,6 +280,7 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
             this.text = o.text;
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         /**
@@ -306,6 +340,19 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
             return this.term(fn.apply(new TermSuggester.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ContainerBuilder _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return new ContainerBuilder();
+        }
+
         protected FieldSuggester build() {
             _checkSingleUse();
             return new FieldSuggester(this);
@@ -355,6 +402,9 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
         op.add(Builder::completion, CompletionSuggester._DESERIALIZER, "completion");
         op.add(Builder::phrase, PhraseSuggester._DESERIALIZER, "phrase");
         op.add(Builder::term, TermSuggester._DESERIALIZER, "term");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<FieldSuggester> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -368,6 +418,7 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         result = 31 * result + Objects.hashCode(this.prefix);
         result = 31 * result + Objects.hashCode(this.regex);
         result = 31 * result + Objects.hashCode(this.text);
@@ -381,8 +432,44 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, FieldSug
         FieldSuggester other = (FieldSuggester) o;
         return Objects.equals(this._kind, other._kind)
             && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind)
             && Objects.equals(this.prefix, other.prefix)
             && Objects.equals(this.regex, other.regex)
             && Objects.equals(this.text, other.text);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements FieldSuggesterVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _fieldSuggesterKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/SmoothingModel.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/SmoothingModel.java
@@ -303,7 +303,9 @@ public class SmoothingModel implements TaggedUnion<SmoothingModel.Kind, Smoothin
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         SmoothingModel other = (SmoothingModel) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/SmoothingModel.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/SmoothingModel.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -66,7 +67,9 @@ public class SmoothingModel implements TaggedUnion<SmoothingModel.Kind, Smoothin
     public enum Kind implements JsonEnum {
         Laplace("laplace"),
         LinearInterpolation("linear_interpolation"),
-        StupidBackoff("stupid_backoff");
+        StupidBackoff("stupid_backoff"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -82,6 +85,7 @@ public class SmoothingModel implements TaggedUnion<SmoothingModel.Kind, Smoothin
 
     private final Kind _kind;
     private final SmoothingModelVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -93,14 +97,23 @@ public class SmoothingModel implements TaggedUnion<SmoothingModel.Kind, Smoothin
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public SmoothingModel(SmoothingModelVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._smoothingModelKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private SmoothingModel(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static SmoothingModel of(Function<SmoothingModel.Builder, ObjectBuilder<SmoothingModel>> fn) {
@@ -155,10 +168,29 @@ public class SmoothingModel implements TaggedUnion<SmoothingModel.Kind, Smoothin
         return TaggedUnionUtils.get(this, Kind.StupidBackoff);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         }
@@ -178,12 +210,14 @@ public class SmoothingModel implements TaggedUnion<SmoothingModel.Kind, Smoothin
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SmoothingModel> {
         private Kind _kind;
         private SmoothingModelVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(SmoothingModel o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<SmoothingModel> laplace(LaplaceSmoothingModel v) {
@@ -220,6 +254,19 @@ public class SmoothingModel implements TaggedUnion<SmoothingModel.Kind, Smoothin
             return this.stupidBackoff(fn.apply(new StupidBackoffSmoothingModel.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<SmoothingModel> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public SmoothingModel build() {
             _checkSingleUse();
@@ -231,6 +278,9 @@ public class SmoothingModel implements TaggedUnion<SmoothingModel.Kind, Smoothin
         op.add(Builder::laplace, LaplaceSmoothingModel._DESERIALIZER, "laplace");
         op.add(Builder::linearInterpolation, LinearInterpolationSmoothingModel._DESERIALIZER, "linear_interpolation");
         op.add(Builder::stupidBackoff, StupidBackoffSmoothingModel._DESERIALIZER, "stupid_backoff");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<SmoothingModel> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -244,6 +294,7 @@ public class SmoothingModel implements TaggedUnion<SmoothingModel.Kind, Smoothin
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -252,6 +303,41 @@ public class SmoothingModel implements TaggedUnion<SmoothingModel.Kind, Smoothin
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         SmoothingModel other = (SmoothingModel) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements SmoothingModelVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _smoothingModelKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/Suggest.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/Suggest.java
@@ -44,6 +44,7 @@ import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 import org.opensearch.client.json.ExternallyTaggedUnion;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
@@ -64,7 +65,9 @@ public class Suggest<TDocument> implements TaggedUnion<Suggest.Kind, SuggestVari
     public enum Kind implements JsonEnum {
         Completion("completion"),
         Phrase("phrase"),
-        Term("term");
+        Term("term"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -80,6 +83,7 @@ public class Suggest<TDocument> implements TaggedUnion<Suggest.Kind, SuggestVari
 
     private final Kind _kind;
     private final SuggestVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -91,14 +95,23 @@ public class Suggest<TDocument> implements TaggedUnion<Suggest.Kind, SuggestVari
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public Suggest(SuggestVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._suggestKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private Suggest(Builder<TDocument> builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static <TDocument> Suggest<TDocument> of(Function<Suggest.Builder<TDocument>, ObjectBuilder<Suggest<TDocument>>> fn) {
@@ -153,6 +166,25 @@ public class Suggest<TDocument> implements TaggedUnion<Suggest.Kind, SuggestVari
         return TaggedUnionUtils.get(this, Kind.Term);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         mapper.serialize(_value, generator);
@@ -171,12 +203,14 @@ public class Suggest<TDocument> implements TaggedUnion<Suggest.Kind, SuggestVari
     public static class Builder<TDocument> extends ObjectBuilderBase implements ObjectBuilder<Suggest<TDocument>> {
         private Kind _kind;
         private SuggestVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(Suggest<TDocument> o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<Suggest<TDocument>> completion(CompletionSuggest<TDocument> v) {
@@ -211,6 +245,19 @@ public class Suggest<TDocument> implements TaggedUnion<Suggest.Kind, SuggestVari
             return this.term(fn.apply(new TermSuggest.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<Suggest<TDocument>> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public Suggest<TDocument> build() {
             _checkSingleUse();
@@ -226,7 +273,11 @@ public class Suggest<TDocument> implements TaggedUnion<Suggest.Kind, SuggestVari
         deserializers.put("phrase", PhraseSuggest._DESERIALIZER);
         deserializers.put("term", TermSuggest._DESERIALIZER);
 
-        return new ExternallyTaggedUnion.Deserializer<>(deserializers, Suggest<TDocument>::new).typedKeys();
+        return new ExternallyTaggedUnion.Deserializer<>(
+            deserializers,
+            Suggest<TDocument>::new,
+            (t, d) -> new Builder<TDocument>()._custom(t, d).build()
+        ).typedKeys();
     }
 
     @Override
@@ -234,6 +285,7 @@ public class Suggest<TDocument> implements TaggedUnion<Suggest.Kind, SuggestVari
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -242,6 +294,41 @@ public class Suggest<TDocument> implements TaggedUnion<Suggest.Kind, SuggestVari
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Suggest<?> other = (Suggest<?>) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements SuggestVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _suggestKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/Suggest.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/Suggest.java
@@ -294,7 +294,9 @@ public class Suggest<TDocument> implements TaggedUnion<Suggest.Kind, SuggestVari
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Suggest<?> other = (Suggest<?>) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/indices/update_aliases/Action.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/indices/update_aliases/Action.java
@@ -302,7 +302,9 @@ public class Action implements TaggedUnion<Action.Kind, ActionVariant>, PlainJso
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Action other = (Action) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/indices/update_aliases/Action.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/indices/update_aliases/Action.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -69,7 +70,9 @@ public class Action implements TaggedUnion<Action.Kind, ActionVariant>, PlainJso
     public enum Kind implements JsonEnum {
         Add("add"),
         Remove("remove"),
-        RemoveIndex("remove_index");
+        RemoveIndex("remove_index"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -85,6 +88,7 @@ public class Action implements TaggedUnion<Action.Kind, ActionVariant>, PlainJso
 
     private final Kind _kind;
     private final ActionVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -96,14 +100,23 @@ public class Action implements TaggedUnion<Action.Kind, ActionVariant>, PlainJso
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public Action(ActionVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._actionKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private Action(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static Action of(Function<Action.Builder, ObjectBuilder<Action>> fn) {
@@ -158,10 +171,29 @@ public class Action implements TaggedUnion<Action.Kind, ActionVariant>, PlainJso
         return TaggedUnionUtils.get(this, Kind.RemoveIndex);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         }
@@ -181,12 +213,14 @@ public class Action implements TaggedUnion<Action.Kind, ActionVariant>, PlainJso
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Action> {
         private Kind _kind;
         private ActionVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(Action o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<Action> add(AddAction v) {
@@ -219,6 +253,19 @@ public class Action implements TaggedUnion<Action.Kind, ActionVariant>, PlainJso
             return this.removeIndex(fn.apply(new RemoveIndexAction.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<Action> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public Action build() {
             _checkSingleUse();
@@ -230,6 +277,9 @@ public class Action implements TaggedUnion<Action.Kind, ActionVariant>, PlainJso
         op.add(Builder::add, AddAction._DESERIALIZER, "add");
         op.add(Builder::remove, RemoveAction._DESERIALIZER, "remove");
         op.add(Builder::removeIndex, RemoveIndexAction._DESERIALIZER, "remove_index");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<Action> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -243,6 +293,7 @@ public class Action implements TaggedUnion<Action.Kind, ActionVariant>, PlainJso
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -251,6 +302,41 @@ public class Action implements TaggedUnion<Action.Kind, ActionVariant>, PlainJso
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Action other = (Action) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements ActionVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _actionKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/ingest/Processor.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/ingest/Processor.java
@@ -1142,7 +1142,9 @@ public class Processor implements TaggedUnion<Processor.Kind, ProcessorVariant>,
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Processor other = (Processor) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/ingest/Processor.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/ingest/Processor.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -97,7 +98,9 @@ public class Processor implements TaggedUnion<Processor.Kind, ProcessorVariant>,
         Trim("trim"),
         Uppercase("uppercase"),
         Urldecode("urldecode"),
-        UserAgent("user_agent");
+        UserAgent("user_agent"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -113,6 +116,7 @@ public class Processor implements TaggedUnion<Processor.Kind, ProcessorVariant>,
 
     private final Kind _kind;
     private final ProcessorVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -124,14 +128,23 @@ public class Processor implements TaggedUnion<Processor.Kind, ProcessorVariant>,
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public Processor(ProcessorVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._processorKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private Processor(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static Processor of(Function<Processor.Builder, ObjectBuilder<Processor>> fn) {
@@ -666,10 +679,29 @@ public class Processor implements TaggedUnion<Processor.Kind, ProcessorVariant>,
         return TaggedUnionUtils.get(this, Kind.UserAgent);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         }
@@ -689,12 +721,14 @@ public class Processor implements TaggedUnion<Processor.Kind, ProcessorVariant>,
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Processor> {
         private Kind _kind;
         private ProcessorVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(Processor o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<Processor> append(AppendProcessor v) {
@@ -1029,6 +1063,19 @@ public class Processor implements TaggedUnion<Processor.Kind, ProcessorVariant>,
             return this.userAgent(fn.apply(new UserAgentProcessor.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<Processor> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public Processor build() {
             _checkSingleUse();
@@ -1070,6 +1117,9 @@ public class Processor implements TaggedUnion<Processor.Kind, ProcessorVariant>,
         op.add(Builder::uppercase, UppercaseProcessor._DESERIALIZER, "uppercase");
         op.add(Builder::urldecode, UrlDecodeProcessor._DESERIALIZER, "urldecode");
         op.add(Builder::userAgent, UserAgentProcessor._DESERIALIZER, "user_agent");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<Processor> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -1083,6 +1133,7 @@ public class Processor implements TaggedUnion<Processor.Kind, ProcessorVariant>,
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -1091,6 +1142,41 @@ public class Processor implements TaggedUnion<Processor.Kind, ProcessorVariant>,
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         Processor other = (Processor) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements ProcessorVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _processorKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/PhaseResultsProcessor.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/PhaseResultsProcessor.java
@@ -275,7 +275,9 @@ public class PhaseResultsProcessor implements TaggedUnion<PhaseResultsProcessor.
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         PhaseResultsProcessor other = (PhaseResultsProcessor) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/PhaseResultsProcessor.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/PhaseResultsProcessor.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -65,7 +66,9 @@ public class PhaseResultsProcessor implements TaggedUnion<PhaseResultsProcessor.
      */
     public enum Kind implements JsonEnum {
         NormalizationProcessor("normalization-processor"),
-        ScoreRankerProcessor("score-ranker-processor");
+        ScoreRankerProcessor("score-ranker-processor"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -81,6 +84,7 @@ public class PhaseResultsProcessor implements TaggedUnion<PhaseResultsProcessor.
 
     private final Kind _kind;
     private final PhaseResultsProcessorVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -92,14 +96,23 @@ public class PhaseResultsProcessor implements TaggedUnion<PhaseResultsProcessor.
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public PhaseResultsProcessor(PhaseResultsProcessorVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._phaseResultsProcessorKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private PhaseResultsProcessor(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static PhaseResultsProcessor of(Function<PhaseResultsProcessor.Builder, ObjectBuilder<PhaseResultsProcessor>> fn) {
@@ -138,10 +151,29 @@ public class PhaseResultsProcessor implements TaggedUnion<PhaseResultsProcessor.
         return TaggedUnionUtils.get(this, Kind.ScoreRankerProcessor);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         }
@@ -161,12 +193,14 @@ public class PhaseResultsProcessor implements TaggedUnion<PhaseResultsProcessor.
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<PhaseResultsProcessor> {
         private Kind _kind;
         private PhaseResultsProcessorVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(PhaseResultsProcessor o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<PhaseResultsProcessor> normalizationProcessor(NormalizationPhaseResultsProcessor v) {
@@ -193,6 +227,19 @@ public class PhaseResultsProcessor implements TaggedUnion<PhaseResultsProcessor.
             return this.scoreRankerProcessor(fn.apply(new ScoreRankerPhaseResultsProcessor.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<PhaseResultsProcessor> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public PhaseResultsProcessor build() {
             _checkSingleUse();
@@ -203,6 +250,9 @@ public class PhaseResultsProcessor implements TaggedUnion<PhaseResultsProcessor.
     protected static void setupPhaseResultsProcessorDeserializer(ObjectDeserializer<Builder> op) {
         op.add(Builder::normalizationProcessor, NormalizationPhaseResultsProcessor._DESERIALIZER, "normalization-processor");
         op.add(Builder::scoreRankerProcessor, ScoreRankerPhaseResultsProcessor._DESERIALIZER, "score-ranker-processor");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<PhaseResultsProcessor> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -216,6 +266,7 @@ public class PhaseResultsProcessor implements TaggedUnion<PhaseResultsProcessor.
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -224,6 +275,41 @@ public class PhaseResultsProcessor implements TaggedUnion<PhaseResultsProcessor.
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         PhaseResultsProcessor other = (PhaseResultsProcessor) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements PhaseResultsProcessorVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _phaseResultsProcessorKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/RequestProcessor.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/RequestProcessor.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -68,7 +69,9 @@ public class RequestProcessor implements TaggedUnion<RequestProcessor.Kind, Requ
         FilterQuery("filter_query"),
         NeuralQueryEnricher("neural_query_enricher"),
         Oversample("oversample"),
-        Script("script");
+        Script("script"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -84,6 +87,7 @@ public class RequestProcessor implements TaggedUnion<RequestProcessor.Kind, Requ
 
     private final Kind _kind;
     private final RequestProcessorVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -95,14 +99,23 @@ public class RequestProcessor implements TaggedUnion<RequestProcessor.Kind, Requ
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public RequestProcessor(RequestProcessorVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._requestProcessorKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private RequestProcessor(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static RequestProcessor of(Function<RequestProcessor.Builder, ObjectBuilder<RequestProcessor>> fn) {
@@ -189,10 +202,29 @@ public class RequestProcessor implements TaggedUnion<RequestProcessor.Kind, Requ
         return TaggedUnionUtils.get(this, Kind.Script);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         }
@@ -212,12 +244,14 @@ public class RequestProcessor implements TaggedUnion<RequestProcessor.Kind, Requ
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<RequestProcessor> {
         private Kind _kind;
         private RequestProcessorVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(RequestProcessor o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<RequestProcessor> agenticQueryTranslator(AgenticQueryTranslatorRequestProcessor v) {
@@ -280,6 +314,19 @@ public class RequestProcessor implements TaggedUnion<RequestProcessor.Kind, Requ
             return this.script(fn.apply(new SearchScriptRequestProcessor.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<RequestProcessor> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public RequestProcessor build() {
             _checkSingleUse();
@@ -293,6 +340,9 @@ public class RequestProcessor implements TaggedUnion<RequestProcessor.Kind, Requ
         op.add(Builder::neuralQueryEnricher, NeuralQueryEnricherRequestProcessor._DESERIALIZER, "neural_query_enricher");
         op.add(Builder::oversample, OversampleRequestProcessor._DESERIALIZER, "oversample");
         op.add(Builder::script, SearchScriptRequestProcessor._DESERIALIZER, "script");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<RequestProcessor> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -306,6 +356,7 @@ public class RequestProcessor implements TaggedUnion<RequestProcessor.Kind, Requ
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -314,6 +365,41 @@ public class RequestProcessor implements TaggedUnion<RequestProcessor.Kind, Requ
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         RequestProcessor other = (RequestProcessor) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements RequestProcessorVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _requestProcessorKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/RequestProcessor.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/RequestProcessor.java
@@ -365,7 +365,9 @@ public class RequestProcessor implements TaggedUnion<RequestProcessor.Kind, Requ
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         RequestProcessor other = (RequestProcessor) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/ResponseProcessor.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/ResponseProcessor.java
@@ -485,7 +485,9 @@ public class ResponseProcessor implements TaggedUnion<ResponseProcessor.Kind, Re
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         ResponseProcessor other = (ResponseProcessor) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+        return Objects.equals(this._kind, other._kind)
+            && Objects.equals(this._value, other._value)
+            && Objects.equals(this._customKind, other._customKind);
     }
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/ResponseProcessor.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/ResponseProcessor.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonEnum;
 import org.opensearch.client.json.JsonpDeserializable;
 import org.opensearch.client.json.JsonpDeserializer;
@@ -72,7 +73,9 @@ public class ResponseProcessor implements TaggedUnion<ResponseProcessor.Kind, Re
         RetrievalAugmentedGeneration("retrieval_augmented_generation"),
         Sort("sort"),
         Split("split"),
-        TruncateHits("truncate_hits");
+        TruncateHits("truncate_hits"),
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null);
 
         private final String jsonValue;
 
@@ -88,6 +91,7 @@ public class ResponseProcessor implements TaggedUnion<ResponseProcessor.Kind, Re
 
     private final Kind _kind;
     private final ResponseProcessorVariant _value;
+    private final String _customKind;
 
     @Override
     public final Kind _kind() {
@@ -99,14 +103,23 @@ public class ResponseProcessor implements TaggedUnion<ResponseProcessor.Kind, Re
         return _value;
     }
 
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+
     public ResponseProcessor(ResponseProcessorVariant value) {
         this._kind = ApiTypeHelper.requireNonNull(value._responseProcessorKind(), this, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+        this._customKind = null;
     }
 
     private ResponseProcessor(Builder builder) {
         this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
         this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+        this._customKind = builder._customKind;
     }
 
     public static ResponseProcessor of(Function<ResponseProcessor.Builder, ObjectBuilder<ResponseProcessor>> fn) {
@@ -257,10 +270,29 @@ public class ResponseProcessor implements TaggedUnion<ResponseProcessor.Kind, Re
         return TaggedUnionUtils.get(this, Kind.TruncateHits);
     }
 
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public JsonData _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+
     @Override
     public void serialize(JsonGenerator generator, JsonpMapper mapper) {
         generator.writeStartObject();
-        generator.writeKey(_kind.jsonValue());
+        generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         if (_value instanceof JsonpSerializable) {
             ((JsonpSerializable) _value).serialize(generator, mapper);
         }
@@ -280,12 +312,14 @@ public class ResponseProcessor implements TaggedUnion<ResponseProcessor.Kind, Re
     public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ResponseProcessor> {
         private Kind _kind;
         private ResponseProcessorVariant _value;
+        private String _customKind;
 
         public Builder() {}
 
         private Builder(ResponseProcessor o) {
             this._kind = o._kind;
             this._value = o._value;
+            this._customKind = o._customKind;
         }
 
         public ObjectBuilder<ResponseProcessor> agenticContext(AgenticContextResponseProcessor v) {
@@ -392,6 +426,19 @@ public class ResponseProcessor implements TaggedUnion<ResponseProcessor.Kind, Re
             return this.truncateHits(fn.apply(new TruncateHitsResponseProcessor.Builder()).build());
         }
 
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public ObjectBuilder<ResponseProcessor> _custom(String type, JsonData data) {
+            this._kind = Kind._Custom;
+            this._customKind = ApiTypeHelper.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant(ApiTypeHelper.requireNonNull(data, this, "<custom variant data>"));
+            return this;
+        }
+
         @Override
         public ResponseProcessor build() {
             _checkSingleUse();
@@ -413,6 +460,9 @@ public class ResponseProcessor implements TaggedUnion<ResponseProcessor.Kind, Re
         op.add(Builder::sort, SortResponseProcessor._DESERIALIZER, "sort");
         op.add(Builder::split, SplitResponseProcessor._DESERIALIZER, "split");
         op.add(Builder::truncateHits, TruncateHitsResponseProcessor._DESERIALIZER, "truncate_hits");
+        op.setUnknownFieldHandler(
+            (builder, name, parser, mapper) -> builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper))
+        );
     }
 
     public static final JsonpDeserializer<ResponseProcessor> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
@@ -426,6 +476,7 @@ public class ResponseProcessor implements TaggedUnion<ResponseProcessor.Kind, Re
         int result = 17;
         result = 31 * result + Objects.hashCode(this._kind);
         result = 31 * result + Objects.hashCode(this._value);
+        result = 31 * result + Objects.hashCode(this._customKind);
         return result;
     }
 
@@ -434,6 +485,41 @@ public class ResponseProcessor implements TaggedUnion<ResponseProcessor.Kind, Re
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;
         ResponseProcessor other = (ResponseProcessor) o;
-        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value) && Objects.equals(this._customKind, other._customKind);
+    }
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements ResponseProcessorVariant, PlainJsonSerializable {
+        private final JsonData data;
+
+        CustomVariant(JsonData data) {
+            this.data = data;
+        }
+
+        public JsonData data() {
+            return data;
+        }
+
+        @Override
+        public Kind _responseProcessorKind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
     }
 }

--- a/java-client/src/main/java/org/opensearch/client/json/ExternallyTaggedUnion.java
+++ b/java-client/src/main/java/org/opensearch/client/json/ExternallyTaggedUnion.java
@@ -89,6 +89,7 @@ public class ExternallyTaggedUnion {
                 if (unKnownUnionCtor != null) {
                     return unKnownUnionCtor.apply(type, JsonData._DESERIALIZER.deserialize(parser, mapper, event));
                 }
+                throw new jakarta.json.JsonException("Unknown variant type '" + type + "'");
             }
 
             return unionCtor.apply(deserializer.deserialize(parser, mapper, event));
@@ -191,7 +192,11 @@ public class ExternallyTaggedUnion {
         if (mapper.attribute(JsonpMapperAttributes.SERIALIZE_TYPED_KEYS, true)) {
             for (Map.Entry<String, T> entry : map.entrySet()) {
                 T value = entry.getValue();
-                generator.writeKey(value._kind().jsonValue() + "#" + entry.getKey());
+                String type = value._kind().jsonValue();
+                if (type == null) {
+                    type = value._customKind();
+                }
+                generator.writeKey(type + "#" + entry.getKey());
                 value.serialize(generator, mapper);
             }
         } else {
@@ -223,7 +228,11 @@ public class ExternallyTaggedUnion {
                 if (list.isEmpty()) {
                     continue;
                 }
-                generator.writeKey(list.get(0)._kind().jsonValue() + "#" + entry.getKey());
+                String type = list.get(0)._kind().jsonValue();
+                if (type == null) {
+                    type = list.get(0)._customKind();
+                }
+                generator.writeKey(type + "#" + entry.getKey());
                 generator.writeStartArray();
                 for (T value : list) {
                     value.serialize(generator, mapper);

--- a/java-client/src/main/java/org/opensearch/client/json/JsonData.java
+++ b/java-client/src/main/java/org/opensearch/client/json/JsonData.java
@@ -108,5 +108,16 @@ public interface JsonData extends JsonpSerializable {
         return of(parser.getValue(), mapper);
     }
 
-    JsonpDeserializer<JsonData> _DESERIALIZER = JsonpDeserializer.of(EnumSet.allOf(JsonParser.Event.class), JsonData::from);
+    JsonpDeserializer<JsonData> _DESERIALIZER = new JsonpDeserializerBase<JsonData>(EnumSet.allOf(JsonParser.Event.class)) {
+        @Override
+        public JsonData deserialize(JsonParser parser, JsonpMapper mapper) {
+            return JsonData.from(parser, mapper);
+        }
+
+        @Override
+        public JsonData deserialize(JsonParser parser, JsonpMapper mapper, JsonParser.Event event) {
+            // Event already consumed — getValue() returns the current token's value tree
+            return JsonData.of(parser.getValue(), mapper);
+        }
+    };
 }

--- a/java-client/src/main/java/org/opensearch/client/util/TaggedUnion.java
+++ b/java-client/src/main/java/org/opensearch/client/util/TaggedUnion.java
@@ -42,4 +42,12 @@ public interface TaggedUnion<Tag extends Enum<?>, BaseType> {
     Tag _kind();
 
     BaseType _get();
+
+    /**
+     * Returns the actual type name for custom (plugin-provided) variant kinds whose
+     * {@code jsonValue} is {@code null}. Returns {@code null} for all built-in kinds.
+     */
+    default String _customKind() {
+        return null;
+    }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/model/CustomVariantTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/model/CustomVariantTest.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch.model;
+
+import jakarta.json.stream.JsonParser;
+import java.io.StringReader;
+import java.util.Map;
+import org.junit.Test;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchResponse;
+
+/**
+ * Tests that unknown/plugin-provided aggregation types deserialize into the {@code _Custom} variant
+ * instead of throwing or silently dropping data.
+ */
+public class CustomVariantTest extends ModelTestCase {
+
+    @Test
+    public void testUnknownAggregationTypeDeserializesToCustomVariant() {
+        // A response containing a fictional "my_plugin_agg" typed-key aggregation
+        String json = "{\"took\":1,\"timed_out\":false,"
+            + "\"_shards\":{\"total\":1,\"successful\":1,\"skipped\":0,\"failed\":0},"
+            + "\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"},\"hits\":[]},"
+            + "\"aggregations\":{\"my_plugin_agg#foo\":{\"custom_field\":42,\"label\":\"hello\"}}}";
+
+        JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
+        SearchResponse<Object> response = SearchResponse._DESERIALIZER.deserialize(parser, mapper);
+
+        Map<String, Aggregate> aggs = response.aggregations();
+        assertTrue("aggregation 'foo' should be present", aggs.containsKey("foo"));
+
+        Aggregate agg = aggs.get("foo");
+        assertEquals(Aggregate.Kind._Custom, agg._kind());
+        assertTrue(agg._isCustom());
+        assertEquals("my_plugin_agg", agg._customKind());
+
+        // The raw data is accessible and contains the original payload
+        JsonData data = agg._custom();
+        assertNotNull(data);
+        assertEquals(42, data.toJson().asJsonObject().getInt("custom_field"));
+        assertEquals("hello", data.toJson().asJsonObject().getString("label"));
+    }
+
+    @Test
+    public void testCustomVariantSerializesRoundTrip() {
+        // Build a custom variant programmatically
+        Aggregate agg = new Aggregate.Builder()._custom("my_plugin_agg", JsonData.of(Map.of("x", 1))).build();
+
+        assertTrue(agg._isCustom());
+        assertEquals("my_plugin_agg", agg._customKind());
+
+        // Serialize and verify it produces JSON
+        String json = toJson(agg);
+        assertNotNull(json);
+        assertTrue("serialized JSON should contain the payload", json.contains("\"x\""));
+    }
+
+    @Test
+    public void testKnownAggregationTypeStillWorks() {
+        // Sanity: a known type (avg) still deserializes normally
+        String json = "{\"took\":1,\"timed_out\":false,"
+            + "\"_shards\":{\"total\":1,\"successful\":1,\"skipped\":0,\"failed\":0},"
+            + "\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"},\"hits\":[]},"
+            + "\"aggregations\":{\"avg#bar\":{\"value\":3.14}}}";
+
+        SearchResponse<Object> response = fromJson(
+            json,
+            SearchResponse.createSearchResponseDeserializer(JsonpDeserializer.of(Object.class))
+        );
+
+        Aggregate agg = response.aggregations().get("bar");
+        assertEquals(Aggregate.Kind.Avg, agg._kind());
+        assertFalse(agg._isCustom());
+        assertNull(agg._customKind());
+        assertEquals(3.14, agg.avg().value(), 0.001);
+    }
+
+    @Test
+    public void testCustomAggregateTypedKeysRoundTrip() {
+        // Simulates a typed-keys response with a custom aggregation, then re-serializes
+        String json = "{\"took\":1,\"timed_out\":false,"
+            + "\"_shards\":{\"total\":1,\"successful\":1,\"skipped\":0,\"failed\":0},"
+            + "\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"},\"hits\":[]},"
+            + "\"aggregations\":{\"my_plugin_agg#metric\":{\"score\":99}}}";
+
+        SearchResponse<Object> response = fromJson(
+            json,
+            SearchResponse.createSearchResponseDeserializer(JsonpDeserializer.of(Object.class))
+        );
+
+        // Round-trip: serialize the response back to JSON
+        String reserialized = toJson(response);
+        // The typed-key format must use the custom type name, not "null"
+        assertTrue("typed-key must contain custom type name", reserialized.contains("my_plugin_agg#metric"));
+        assertTrue("payload must survive round-trip", reserialized.contains("\"score\""));
+    }
+
+    @Test
+    public void testCustomQueryVariantRoundTrip() {
+        // An internally-tagged query with a plugin-provided type
+        String json = "{\"my_plugin_query\":{\"param\":\"value\"}}";
+
+        Query query = fromJson(json, Query._DESERIALIZER);
+
+        assertTrue(query._isCustom());
+        assertEquals("my_plugin_query", query._customKind());
+        assertNotNull(query._custom());
+
+        // Round-trip serialization
+        String reserialized = toJson(query);
+        assertTrue("must contain custom type key", reserialized.contains("\"my_plugin_query\""));
+        assertTrue("must contain payload", reserialized.contains("\"param\""));
+    }
+
+    @Test
+    public void testCustomVariantEquality() {
+        Aggregate a = new Aggregate.Builder()._custom("type_a", JsonData.of(Map.of("x", 1))).build();
+        Aggregate b = new Aggregate.Builder()._custom("type_a", JsonData.of(Map.of("x", 1))).build();
+        Aggregate c = new Aggregate.Builder()._custom("type_b", JsonData.of(Map.of("x", 1))).build();
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c); // different _customKind
+    }
+}

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/model/TaggedUnionShape.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/model/TaggedUnionShape.java
@@ -158,6 +158,9 @@ public class TaggedUnionShape extends ObjectShapeBase {
         var fields = new ArrayList<Field>();
         fields.add(Field.builder().withName("_kind", true).withType(getMaterializedType().getNestedType("Kind")).build());
         fields.add(Field.builder().withName("_value", true).withType(getVariantBaseType()).build());
+        if (isDiscriminated()) {
+            fields.add(Field.builder().withName("_customKind", true).withType(Types.Java.Lang.String).build());
+        }
         fields.addAll(super.getHashableFields());
         return fields;
     }

--- a/java-codegen/src/main/resources/org/opensearch/client/codegen/templates/TaggedUnionShape.mustache
+++ b/java-codegen/src/main/resources/org/opensearch/client/codegen/templates/TaggedUnionShape.mustache
@@ -3,7 +3,9 @@
      * {@link {{className}}} variant kinds.
      */
     public enum Kind{{#discriminated}} implements {{TYPES.Client.Json.JsonEnum}}{{/discriminated}} {
-        {{#variants}}{{#pascalCase}}{{name}}{{/pascalCase}}{{#discriminated}}({{#quoted}}{{name}}{{/quoted}}){{/discriminated}}{{^-last}},{{/-last}}{{/variants}}
+        {{#variants}}{{#pascalCase}}{{name}}{{/pascalCase}}{{#discriminated}}({{#quoted}}{{name}}{{/quoted}}){{/discriminated}}{{^-last}},{{/-last}}{{/variants}}{{#discriminated}},
+        /** A custom variant type not natively supported by this client. */
+        _Custom(null){{/discriminated}}
         {{#discriminated}};
 
         private final String jsonValue;
@@ -25,6 +27,9 @@
 
     private final Kind _kind;
     private final {{variantBaseType}} _value;
+{{#discriminated}}
+    private final String _customKind;
+{{/discriminated}}
 
     @Override
     public final Kind _kind() {
@@ -35,6 +40,15 @@
     public final {{variantBaseType}} _get() {
         return _value;
     }
+{{#discriminated}}
+
+    /**
+     * Returns the actual type name when {@code _kind() == Kind._Custom}, otherwise {@code null}.
+     */
+    public final String _customKind() {
+        return _customKind;
+    }
+{{/discriminated}}
 {{#hasFields}}
     {{>ObjectShape/Fields}}
 
@@ -54,6 +68,9 @@
             this._value = null;
         }
     {{/isOptionalExternallyDiscriminated}}
+    {{#discriminated}}
+        this._customKind = null;
+    {{/discriminated}}
     {{#fields}}
         this.{{name}} = null;
     {{/fields}}
@@ -84,6 +101,9 @@
             this._value = null;
         }
     {{/isOptionalExternallyDiscriminated}}
+    {{#discriminated}}
+        this._customKind = builder._customKind;
+    {{/discriminated}}
     }
 
     public static{{#typeParameters}} {{.}}{{/typeParameters}} {{selfType}} of({{selfType.builderFnType}} fn) {
@@ -125,6 +145,27 @@
     }
 
 {{/variants}}
+{{#discriminated}}
+
+    /**
+     * Is this variant instance of kind {@code _custom}?
+     */
+    public boolean _isCustom() {
+        return _kind == Kind._Custom;
+    }
+
+    /**
+     * Get the raw JSON data for a custom (plugin-provided) variant type.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code _custom} kind.
+     */
+    public {{TYPES.Client.Json.JsonData}} _custom() {
+        if (_kind != Kind._Custom) {
+            throw new IllegalStateException("Expected variant kind '_custom' but got '" + _kind + "'");
+        }
+        return ((CustomVariant) _value).data();
+    }
+{{/discriminated}}
 
     {{>TaggedUnionShape/Serialize}}
 
@@ -138,6 +179,9 @@
     public static class Builder{{#typeParameters}}{{.}}{{/typeParameters}} extends {{#extendsOtherShape}}{{extendsType}}.AbstractBuilder<Builder>{{/extendsOtherShape}}{{^extendsOtherShape}}{{TYPES.Client.Util.ObjectBuilderBase}}{{/extendsOtherShape}}{{#needsContainerBuilder}}{{#isOptionalExternallyDiscriminated}} implements {{TYPES.Client.Util.ObjectBuilder}}<{{selfType}}>{{/isOptionalExternallyDiscriminated}}{{/needsContainerBuilder}}{{^needsContainerBuilder}} implements {{TYPES.Client.Util.ObjectBuilder}}<{{selfType}}>{{/needsContainerBuilder}} {
         private Kind _kind;
         private {{variantBaseType}} _value;
+    {{#discriminated}}
+        private String _customKind;
+    {{/discriminated}}
         {{>ObjectShape/Builder/Fields}}
 
         public Builder() {}
@@ -146,6 +190,9 @@
             {{>ObjectShape/Builder/CopyCtorImpl}}
             this._kind = o._kind;
             this._value = o._value;
+        {{#discriminated}}
+            this._customKind = o._customKind;
+        {{/discriminated}}
         }
 
     {{#extendsOtherShape}}
@@ -171,6 +218,21 @@
         {{/type.hasBuilder}}
 
     {{/variants}}
+    {{#discriminated}}
+        /**
+         * Set a custom (plugin-provided) variant.
+         *
+         * @param type the variant type name as returned by the server
+         * @param data the raw JSON body of the variant result
+         */
+        public {{^needsContainerBuilder}}{{TYPES.Client.Util.ObjectBuilder}}<{{selfType}}>{{/needsContainerBuilder}}{{#needsContainerBuilder}}ContainerBuilder{{/needsContainerBuilder}} _custom(String type, {{TYPES.Client.Json.JsonData}} data) {
+            this._kind = Kind._Custom;
+            this._customKind = {{TYPES.Client.Util.ApiTypeHelper}}.requireNonNull(type, this, "<custom variant type>");
+            this._value = new CustomVariant({{TYPES.Client.Util.ApiTypeHelper}}.requireNonNull(data, this, "<custom variant data>"));
+            return {{^needsContainerBuilder}}this{{/needsContainerBuilder}}{{#needsContainerBuilder}}new ContainerBuilder(){{/needsContainerBuilder}};
+        }
+
+    {{/discriminated}}
         {{^needsContainerBuilder}}@Override
         public{{/needsContainerBuilder}}{{#needsContainerBuilder}}{{#isOptionalExternallyDiscriminated}}public{{/isOptionalExternallyDiscriminated}}{{^isOptionalExternallyDiscriminated}}protected{{/isOptionalExternallyDiscriminated}}{{/needsContainerBuilder}} {{selfType}} build() {
             _checkSingleUse();
@@ -195,7 +257,73 @@
 
     {{>TaggedUnionShape/Deserialize}}
 
+{{#discriminated}}
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + {{TYPES.Java.Util.Objects}}.hashCode(this._kind);
+        result = 31 * result + {{TYPES.Java.Util.Objects}}.hashCode(this._value);
+        result = 31 * result + {{TYPES.Java.Util.Objects}}.hashCode(this._customKind);
+    {{#fields}}
+        result = 31 * result + {{TYPES.Java.Util.Objects}}.hashCode(this.{{name}});
+    {{/fields}}
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || this.getClass() != o.getClass()) return false;
+        {{className}}{{#typeParameters}}<?>{{/typeParameters}} other = ({{className}}{{#typeParameters}}<?>{{/typeParameters}}) o;
+        return {{TYPES.Java.Util.Objects}}.equals(this._kind, other._kind)
+            && {{TYPES.Java.Util.Objects}}.equals(this._value, other._value)
+            && {{TYPES.Java.Util.Objects}}.equals(this._customKind, other._customKind)
+    {{#fields}}
+            && {{TYPES.Java.Util.Objects}}.equals(this.{{name}}, other.{{name}})
+    {{/fields}}
+            ;
+    }
+{{/discriminated}}
+{{^discriminated}}
     {{>ObjectShape/HashCode}}
 
     {{>ObjectShape/Equals}}
+{{/discriminated}}
+{{#discriminated}}
+
+    // Wrapper so JsonData fits the variant interface slot for custom/plugin types
+    private static final class CustomVariant implements {{variantInterfaceType}}, {{TYPES.Client.Json.PlainJsonSerializable}} {
+        private final {{TYPES.Client.Json.JsonData}} data;
+
+        CustomVariant({{TYPES.Client.Json.JsonData}} data) {
+            this.data = data;
+        }
+
+        public {{TYPES.Client.Json.JsonData}} data() {
+            return data;
+        }
+
+        @Override
+        public Kind _{{#camelCase}}{{className}}{{/camelCase}}Kind() {
+            return Kind._Custom;
+        }
+
+        @Override
+        public void serialize({{TYPES.Jakarta.Json.Stream.JsonGenerator}} generator, {{TYPES.Client.Json.JsonpMapper}} mapper) {
+            data.serialize(generator, mapper);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return data.equals(((CustomVariant) o).data);
+        }
+    }
+{{/discriminated}}
 }

--- a/java-codegen/src/main/resources/org/opensearch/client/codegen/templates/TaggedUnionShape.mustache
+++ b/java-codegen/src/main/resources/org/opensearch/client/codegen/templates/TaggedUnionShape.mustache
@@ -257,38 +257,9 @@
 
     {{>TaggedUnionShape/Deserialize}}
 
-{{#discriminated}}
-    @Override
-    public int hashCode() {
-        int result = 17;
-        result = 31 * result + {{TYPES.Java.Util.Objects}}.hashCode(this._kind);
-        result = 31 * result + {{TYPES.Java.Util.Objects}}.hashCode(this._value);
-        result = 31 * result + {{TYPES.Java.Util.Objects}}.hashCode(this._customKind);
-    {{#fields}}
-        result = 31 * result + {{TYPES.Java.Util.Objects}}.hashCode(this.{{name}});
-    {{/fields}}
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || this.getClass() != o.getClass()) return false;
-        {{className}}{{#typeParameters}}<?>{{/typeParameters}} other = ({{className}}{{#typeParameters}}<?>{{/typeParameters}}) o;
-        return {{TYPES.Java.Util.Objects}}.equals(this._kind, other._kind)
-            && {{TYPES.Java.Util.Objects}}.equals(this._value, other._value)
-            && {{TYPES.Java.Util.Objects}}.equals(this._customKind, other._customKind)
-    {{#fields}}
-            && {{TYPES.Java.Util.Objects}}.equals(this.{{name}}, other.{{name}})
-    {{/fields}}
-            ;
-    }
-{{/discriminated}}
-{{^discriminated}}
     {{>ObjectShape/HashCode}}
 
     {{>ObjectShape/Equals}}
-{{/discriminated}}
 {{#discriminated}}
 
     // Wrapper so JsonData fits the variant interface slot for custom/plugin types

--- a/java-codegen/src/main/resources/org/opensearch/client/codegen/templates/TaggedUnionShape/Deserialize.mustache
+++ b/java-codegen/src/main/resources/org/opensearch/client/codegen/templates/TaggedUnionShape/Deserialize.mustache
@@ -14,6 +14,7 @@
         {{#singleKeyMap}}
             op.setKey(Builder::{{name}}, {{#type}}{{>Type/deserializer}}{{/type}});
         {{/singleKeyMap}}
+            op.setUnknownFieldHandler((builder, name, parser, mapper) -> builder._custom(name, {{TYPES.Client.Json.JsonData}}._DESERIALIZER.deserialize(parser, mapper)));
         }
 
         public static final {{TYPES.Client.Json.JsonpDeserializer}}<{{className}}> _DESERIALIZER = {{TYPES.Client.Json.ObjectBuilderDeserializer}}.lazy(Builder::new, {{className}}::setup{{className}}Deserializer, Builder::build);
@@ -43,6 +44,10 @@
     {{^typeParameters}}
         public static final {{TYPES.Client.Json.ExternallyTaggedUnion}}.TypedKeysDeserializer<{{className}}> _TYPED_KEYS_DESERIALIZER;
 
+        private static {{className}} _buildCustom(String type, {{TYPES.Client.Json.JsonData}} data) {
+            return new Builder()._custom(type, data).build();
+        }
+
         static {
     {{/typeParameters}}
             {{TYPES.Java.Util.Map}}<String, {{TYPES.Client.Json.JsonpDeserializer}}<? extends {{variantBaseType}}>> deserializers = new {{TYPES.Java.Util.HashMap}}<>();
@@ -51,10 +56,10 @@
             {{/variants}}
 
     {{#typeParameters}}
-            return new {{TYPES.Client.Json.ExternallyTaggedUnion}}.Deserializer<>(deserializers, {{selfType}}::new).typedKeys();
+            return new {{TYPES.Client.Json.ExternallyTaggedUnion}}.Deserializer<>(deserializers, {{selfType}}::new, (t, d) -> new Builder{{#typeParameters}}{{.}}{{/typeParameters}}()._custom(t, d).build()).typedKeys();
     {{/typeParameters}}
     {{^typeParameters}}
-            _TYPED_KEYS_DESERIALIZER = new {{TYPES.Client.Json.ExternallyTaggedUnion}}.Deserializer<>(deserializers, {{selfType}}::new).typedKeys();
+            _TYPED_KEYS_DESERIALIZER = new {{TYPES.Client.Json.ExternallyTaggedUnion}}.Deserializer<>(deserializers, {{selfType}}::new, {{className}}::_buildCustom).typedKeys();
     {{/typeParameters}}
         }
 {{/usesTypedKeys}}

--- a/java-codegen/src/main/resources/org/opensearch/client/codegen/templates/TaggedUnionShape/Serialize.mustache
+++ b/java-codegen/src/main/resources/org/opensearch/client/codegen/templates/TaggedUnionShape/Serialize.mustache
@@ -22,7 +22,7 @@ public void serialize({{TYPES.Jakarta.Json.Stream.JsonGenerator}} generator, {{T
             if (_kind != null) {
         {{/isOptionalExternallyDiscriminated}}
         {{#externallyDiscriminated}}
-            generator.writeKey(_kind.jsonValue());
+            generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
         {{/externallyDiscriminated}}
         if (_value instanceof {{TYPES.Client.Json.JsonpSerializable}}) {
         (({{TYPES.Client.Json.JsonpSerializable}}) _value).serialize(generator, mapper);


### PR DESCRIPTION
### Description

This PR adds a `_Custom` variant kind to all discriminated tagged unions (e.g. `Aggregate`, `Suggest`, `Query`, `Property`, `Processor`, `Analyzer`, `TokenFilterDefinition`) so that plugin-provided types are captured as raw JSON instead of causing deserialization failures.

When the server returns a discriminator value that isn't natively modeled, the client stores it as `Kind._Custom` with the original type name accessible via `_customKind()` and the raw JSON body via `_custom()`. This enables users to work with plugin-defined aggregations, queries, processors, etc. without waiting for a client release that models the new type.

### How It Works

**Reading a custom variant:**
```java
for (Map.Entry<String, Aggregate> entry : response.aggregations().entrySet()) {
    Aggregate agg = entry.getValue();
    if (agg._isCustom()) {
        String typeName = agg._customKind();   // e.g. "my_plugin_agg"
        JsonData rawData = agg._custom();      // raw JSON body
    }
}
```

**Building a custom variant:**
```java
Aggregate custom = new Aggregate.Builder()
    ._custom("my_plugin_agg", JsonData.of(Map.of("score", 42)))
    .build();
```

The same `_isCustom()`, `_customKind()`, `_custom()`, and `Builder._custom(type, data)` methods are available on every discriminated tagged union type.

### Changes

**Infrastructure (`java-client/src/main/java`):**
- `JsonData._DESERIALIZER`: Fix three-arg `deserialize` overload to correctly handle a pre-consumed parser event.
- `TaggedUnion`: Add default `_customKind()` method returning null for built-in kinds.
- `ExternallyTaggedUnion`: Use `_customKind()` fallback in typed-keys serialization when `jsonValue()` is null; accept `unknownVariantCtor` for graceful deserialization of unknown types.

**Code generation templates (`java-codegen/`):**
- `TaggedUnionShape.mustache`: Add `Kind._Custom(null)`, `_customKind` field, accessors, `CustomVariant` inner class with equals/hashCode, null-validated builder method, and updated equals/hashCode on the union itself.
- `Deserialize.mustache`: Wire `unknownFieldHandler` (internally-tagged) and `unknownVariantCtor` (externally-tagged).
- `Serialize.mustache`: Use `_customKind` when `Kind._Custom` for the JSON key.

**Documentation:** Added "Custom (Plugin-Provided) Variant Types" section to `guides/json.md`.

**Tests:** Added `CustomVariantTest` covering deserialization, typed-keys round-trip serialization, internally-tagged round-trip, builder API, and equality semantics.

### Related

This approach aligns with the Elasticsearch Java client's `OpenTaggedUnion` pattern, adapted for OpenSearch's typed variant interfaces.

On ElasticSearch, they specify whether an Tagged Union should be open or not. I took the approach to extend everything that is discriminated to offer as much flexibility as allowed by the plugins. 

### Issues Resolved

Closes:

- https://github.com/opensearch-project/opensearch-java/issues/540

<!-- NOTE 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


-->
