### PR TITLE
Fix unitTest task not running the test source set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add transparent gRPC transport with HybridTransport (bulk over gRPC, REST fallback), translation layer, TLS, basic auth, AWS SigV4, and JWT support ([#2062](https://github.com/opensearch-project/opensearch-java/pull/2062))
 
 ### Fixed
+- Fix `unitTest` task not running the tests in the `test` source set ([#2069](https://github.com/opensearch-project/opensearch-java/pull/2069))
 
 ## [Unreleased 3.x]
 ### Added

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -157,6 +157,8 @@ tasks.test {
 }
 
 val unitTest = task<Test>("unitTest") {
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
     filter {
         excludeTestsMatching("org.opensearch.client.opensearch.integTest.*")
     }


### PR DESCRIPTION
### Description

`./gradlew unitTest` runs 1 test class instead of 170 — the tests under `src/test/java` are never executed, locally or in CI.

`unitTest` is created with `task<Test>("unitTest")`, which has no `testClassesDirs` or `classpath`. The only place they get populated is the JDK-21 block, which appends to that empty base:

```kotlin
tasks.named<Test>("unitTest") {
    testClassesDirs += java21.output.classesDirs
    classpath = sourceSets["java21"].runtimeClasspath
}
```

So the task resolves to the `java21` source set alone. This is a regression from #968, where those two lines were moved off `tasks.test` — whose `testClassesDirs` the java plugin populates, making `+=` correct — and onto `unitTest`/`integrationTest`, which have no base.

### Changes

Set `testClassesDirs` and `classpath` on `unitTest` from the `test` source set, so the JDK-21 block appends to it rather than defines it.

`./gradlew :java-client:unitTest` on JDK 21 (Temurin 21.0.11), counted from `java-client/build/test-results/unitTest/`:

| | classes | tests | failures |
|---|---|---|---|
| before | 1 | 1 | 0 |
| after | 170 | 426 | 0 |

All 426 pass, so no other change is needed to re-enable them. `RequestOptionsTest` from `src/test/java11` still runs, and the `excludeTestsMatching` filter still keeps `integTest` classes out.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
