### PR TITLE
Fix unitTest task not running the test source set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add transparent gRPC transport with HybridTransport (bulk over gRPC, REST fallback), translation layer, TLS, basic auth, AWS SigV4, and JWT support ([#2062](https://github.com/opensearch-project/opensearch-java/pull/2062))
 
 ### Fixed
+- Fix `unitTest` task not running the tests in the `test` source set ([#2074](https://github.com/opensearch-project/opensearch-java/pull/2074))
 
 ## [Unreleased 3.x]
 ### Added

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -157,8 +157,6 @@ tasks.test {
 }
 
 val unitTest = task<Test>("unitTest") {
-    testClassesDirs = sourceSets["test"].output.classesDirs
-    classpath = sourceSets["test"].runtimeClasspath
     filter {
         excludeTestsMatching("org.opensearch.client.opensearch.integTest.*")
     }
@@ -389,6 +387,7 @@ if (runtimeJavaVersion >= JavaVersion.VERSION_21) {
     java {
       compileClasspath += sourceSets.main.get().output + sourceSets.test.get().output
       runtimeClasspath += sourceSets.main.get().output + sourceSets.test.get().output
+      srcDir("src/test/java")
       srcDir("src/test/java11")
       srcDir("src/test/java21")
     }

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -157,6 +157,8 @@ tasks.test {
 }
 
 val unitTest = task<Test>("unitTest") {
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
     filter {
         excludeTestsMatching("org.opensearch.client.opensearch.integTest.*")
     }

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -420,7 +420,7 @@ if (runtimeJavaVersion >= JavaVersion.VERSION_21) {
  }
   
   tasks.named<Test>("unitTest") {
-    testClassesDirs += java21.output.classesDirs
+    testClassesDirs += java21.output.classesDirs + sourceSets.test.get().output.classesDirs
     classpath = sourceSets["java21"].runtimeClasspath
  }
 }

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -387,7 +387,6 @@ if (runtimeJavaVersion >= JavaVersion.VERSION_21) {
     java {
       compileClasspath += sourceSets.main.get().output + sourceSets.test.get().output
       runtimeClasspath += sourceSets.main.get().output + sourceSets.test.get().output
-      srcDir("src/test/java")
       srcDir("src/test/java11")
       srcDir("src/test/java21")
     }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_helpers/bulk/BulkIngesterTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_helpers/bulk/BulkIngesterTest.java
@@ -223,6 +223,21 @@ public class BulkIngesterTest extends Assert {
         assertEquals(5, ingester.requestCount());
     }
 
+    /**
+     * Waits for the periodic flusher to have emitted {@code expected} requests. Tests that add operations
+     * spaced apart in time cannot rely on sleeping longer than the flush interval: under load two operations
+     * can land in the same flush window, which coalesces them into a single request.
+     */
+    private static void awaitRequestCount(BulkIngester<?> ingester, long expected) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (ingester.requestCount() < expected) {
+            if (System.nanoTime() - deadline > 0) {
+                fail("Timed out waiting for " + expected + " requests, got " + ingester.requestCount());
+            }
+            Thread.sleep(5);
+        }
+    }
+
     @Test
     public void periodicFlushTest() throws Exception {
         TestTransport transport = new TestTransport();
@@ -237,11 +252,11 @@ public class BulkIngesterTest extends Assert {
                 .maxConcurrentRequests(Integer.MAX_VALUE - 1)
         );
 
-        // Add an operation every 100 ms to give time
-        // to the flushing timer to kick in.
+        // Add an operation at a time, waiting for the flushing timer to kick in
+        // before adding the next one so that each gets its own request.
         for (int i = 0; i < 10; i++) {
             ingester.add(operation);
-            Thread.sleep(100);
+            awaitRequestCount(ingester, i + 1);
         }
 
         ingester.close();
@@ -299,11 +314,11 @@ public class BulkIngesterTest extends Assert {
                 .listener(listener)
         );
 
-        // Add an operation every 100 ms to give time
-        // to the flushing timer to kick in.
+        // Add an operation at a time, waiting for the flushing timer to kick in
+        // before adding the next one so that each gets its own request.
         for (int i = 0; i < 10; i++) {
             ingester.add(operation);
-            Thread.sleep(100);
+            awaitRequestCount(ingester, i + 1);
         }
 
         ingester.close();


### PR DESCRIPTION
### Description

`./gradlew unitTest` runs 1 test class instead of 170. The tests under `src/test/java` are never executed locally or in CI. Nothing in CI runs the plain `test` task either (`test-unit.yml` runs `unitTest`, `build.yml` runs `build -x test`), so those ~200 test files are executed by no workflow at all.

`unitTest` resolves its test classes from the `java21` source set, which declares `src/test/java11` and `src/test/java21` but not `src/test/java`. So the main test source set is compiled but never run.

This is original wiring rather than a regression: `unitTest` has never had `testClassesDirs` set, having been a bare `task<Test>` with only a filter since 3b34f602 (Aug 2021), so it ran zero tests. [#968](https://github.com/opensearch-project/opensearch-java/pull/968) later moved the JDK source set wiring from `tasks.test` onto `unitTest`/`integrationTest`, which incidentally gave it the `java11`/`java21` classes. That is why it runs exactly one class today rather than none.

### Changes

Add the `test` source set's output to `unitTest`'s `testClassesDirs`, so the task resolves the tests in `src/test/java` alongside the JDK-specific source sets.

Also fix two timing-flaky tests that re-enabling the suite surfaced. `BulkIngesterTest.periodicFlushTest` and `failingListener` slept 100 ms between operations against a 50 ms flush interval and asserted exactly one request per operation. Under load two operations share a flush window and get coalesced. They now wait on `requestCount()` reaching the expected value rather than on wall-clock time, which is both deterministic and faster.

Verified with `./gradlew :java-client:unitTest`: this takes the run from 1 test class to 170 (426 tests, 0 failures on JDK 21 and JDK 25). An unconditionally failing test added under `src/test/java`, which still reports BUILD SUCCESSFUL on `main`, correctly fails the build with this change. `RequestOptionsTest` from `src/test/java11` still runs, no `integTest` classes leak into `unitTest`, and `spotlessJavaCheck` passes.

### Notes

One thing turned up while diagnosing this that is not addressed here, recorded in [#2075](https://github.com/opensearch-project/opensearch-java/issues/2075).

**Java 8.** This change lives inside the `runtimeJavaVersion >= 21` branch, so the JDK 8 path is untouched: `unitTest` still has no classpath there and continues to compile and run nothing, which is why `test-java8` stays green. Wiring that job up reveals that `java-client` no longer compiles under Java 8 at all, since `tools.jackson.core` ships Java 17 class files (`class file has wrong version 61.0, should be 52.0`), failing in `:java-client:compileJava` before tests are even considered. That looks like it dates to [#1810](https://github.com/opensearch-project/opensearch-java/pull/1810). Happy to open a separate issue if that is useful.

### Issues Resolved

Related to [#2075](https://github.com/opensearch-project/opensearch-java/issues/2075)

### Check List

* Commits are signed per the DCO using `--signoff`
* Changelog updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.