### PR TITLE
[Backport 3.x] Fix unitTest task not running the test source set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fix `unitTest` task not running the tests in the `test` source set ([#2074](https://github.com/opensearch-project/opensearch-java/pull/2074))
 
 ### Security
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -419,7 +419,7 @@ if (runtimeJavaVersion >= JavaVersion.VERSION_21) {
  }
   
   tasks.named<Test>("unitTest") {
-    testClassesDirs += java21.output.classesDirs
+    testClassesDirs += java21.output.classesDirs + sourceSets.test.get().output.classesDirs
     classpath = sourceSets["java21"].runtimeClasspath
  }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_helpers/bulk/BulkIngesterTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_helpers/bulk/BulkIngesterTest.java
@@ -223,6 +223,21 @@ public class BulkIngesterTest extends Assert {
         assertEquals(5, ingester.requestCount());
     }
 
+    /**
+     * Waits for the periodic flusher to have emitted {@code expected} requests. Tests that add operations
+     * spaced apart in time cannot rely on sleeping longer than the flush interval: under load two operations
+     * can land in the same flush window, which coalesces them into a single request.
+     */
+    private static void awaitRequestCount(BulkIngester<?> ingester, long expected) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (ingester.requestCount() < expected) {
+            if (System.nanoTime() - deadline > 0) {
+                fail("Timed out waiting for " + expected + " requests, got " + ingester.requestCount());
+            }
+            Thread.sleep(5);
+        }
+    }
+
     @Test
     public void periodicFlushTest() throws Exception {
         TestTransport transport = new TestTransport();
@@ -237,11 +252,11 @@ public class BulkIngesterTest extends Assert {
                 .maxConcurrentRequests(Integer.MAX_VALUE - 1)
         );
 
-        // Add an operation every 100 ms to give time
-        // to the flushing timer to kick in.
+        // Add an operation at a time, waiting for the flushing timer to kick in
+        // before adding the next one so that each gets its own request.
         for (int i = 0; i < 10; i++) {
             ingester.add(operation);
-            Thread.sleep(100);
+            awaitRequestCount(ingester, i + 1);
         }
 
         ingester.close();
@@ -299,11 +314,11 @@ public class BulkIngesterTest extends Assert {
                 .listener(listener)
         );
 
-        // Add an operation every 100 ms to give time
-        // to the flushing timer to kick in.
+        // Add an operation at a time, waiting for the flushing timer to kick in
+        // before adding the next one so that each gets its own request.
         for (int i = 0; i < 10; i++) {
             ingester.add(operation);
-            Thread.sleep(100);
+            awaitRequestCount(ingester, i + 1);
         }
 
         ingester.close();


### PR DESCRIPTION
Backport of #2074 to `3.x`. The automated backport failed on a `CHANGELOG.md` conflict; `java-client/build.gradle.kts` and `BulkIngesterTest.java` cherry-picked cleanly.

The only manual change was placing the changelog entry under the existing `### Fixed` heading in `## [Unreleased 3.x]`, since the `4.x` section the original entry lived under does not exist on this branch.

Verified on this branch with `./gradlew :java-client:unitTest`: 169 classes, 425 tests, 0 failures, and `spotlessJavaCheck` passes.
