### PR TITLE
Run model tests against both JSON mappers instead of picking one at r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fix `unitTest` task not running the tests in the `test` source set ([#2074](https://github.com/opensearch-project/opensearch-java/pull/2074))
+- Run model tests against both JSON mappers instead of picking one at random ([#2085](https://github.com/opensearch-project/opensearch-java/pull/2085))
 
 ## [Unreleased 3.x]
 ### Added

--- a/java-client/src/test/java/org/opensearch/client/opensearch/model/ModelTestCase.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/model/ModelTestCase.java
@@ -38,51 +38,45 @@ import jakarta.json.stream.JsonParser;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
-import java.util.Random;
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 
 /**
- * Base class for tests that encode/decode json
+ * Base class for tests that encode/decode json.
+ * Every test is run once per JsonpMapper implementation.
  */
+@RunWith(Parameterized.class)
 public abstract class ModelTestCase extends Assert {
 
-    // Same value for all tests in a test run
-    private static final int RAND = new Random().nextInt(100);
-
-    protected final JsonpMapper mapper;
-
-    private JsonpMapper setupMapper(int rand) {
-        // Randomly choose json-b or jackson
-        if (rand % 2 == 0) {
-            System.out.println("Using a JsonB mapper (rand = " + rand + ").");
-            return new JsonbJsonpMapper() {
-                @Override
-                public boolean ignoreUnknownFields() {
-                    return false;
-                }
-            };
-        } else {
-            System.out.println("Using a Jackson mapper (rand = " + rand + ").");
-            return new JacksonJsonpMapper() {
-                @Override
-                public boolean ignoreUnknownFields() {
-                    return false;
-                }
-            };
-        }
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> mappers() {
+        JsonpMapper jsonb = new JsonbJsonpMapper() {
+            @Override
+            public boolean ignoreUnknownFields() {
+                return false;
+            }
+        };
+        JsonpMapper jackson = new JacksonJsonpMapper() {
+            @Override
+            public boolean ignoreUnknownFields() {
+                return false;
+            }
+        };
+        return Arrays.asList(new Object[] { "json-b", jsonb }, new Object[] { "jackson", jackson });
     }
 
-    protected ModelTestCase() {
-        this(RAND);
-    }
+    @Parameterized.Parameter(0)
+    public String mapperName;
 
-    protected ModelTestCase(int rand) {
-        mapper = setupMapper(rand);
-    }
+    @Parameterized.Parameter(1)
+    public JsonpMapper mapper;
 
     protected <T> String toJson(T value) {
         return toJson(value, mapper);


### PR DESCRIPTION
### Description

`ModelTestCase` chooses between `JsonbJsonpMapper` and `JacksonJsonpMapper` with a single `Random` coin flip per JVM, so each test run exercises one serialization backend and never the other, chosen at random. A bug affecting only one mapper passes CI about half the time.

### Changes

- Replace the random mapper selection in `ModelTestCase` with JUnit 4 `Parameterized`, running every test against both mappers. `@RunWith` is inherited and the mapper is injected by field, so none of the 104 subclasses need changes.

Verified with `./gradlew :java-client:unitTest`: 426 tests become 604, with exactly 178 per mapper and 0 failures. Runs are now deterministic, and failures report which mapper broke (`testName[json-b]` / `testName[jackson]`). `spotlessJavaCheck` passes.

### Issues Resolved

Resolves #770

### Check List

- [x] All tests pass
- [x] Commits are signed per the DCO using `--signoff`
- [x] Changelog updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
