### PR TITLE
Add setRetryStrategy to ApacheHttpClient5TransportBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add document lifecycle guide and runnable sample ([#2017](https://github.com/opensearch-project/opensearch-java/pull/2017))
 - Add transparent gRPC transport with HybridTransport (bulk over gRPC, REST fallback), translation layer, TLS, basic auth, AWS SigV4, and JWT support ([#2062](https://github.com/opensearch-project/opensearch-java/pull/2062))
 - Add search over gRPC with match_all query support, SearchRequestConverter, SearchResponseConverter, and _source deserialization ([#2071](https://github.com/opensearch-project/opensearch-java/pull/2071))
+- Add `setAutomaticRetriesDisabled` to `ApacheHttpClient5TransportBuilder` to allow enabling automatic retries ([#2086](https://github.com/opensearch-project/opensearch-java/pull/2086))
 
 ### Fixed
 - Fix `unitTest` task not running the tests in the `test` source set ([#2074](https://github.com/opensearch-project/opensearch-java/pull/2074))

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5TransportBuilder.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5TransportBuilder.java
@@ -395,7 +395,7 @@ public class ApacheHttpClient5TransportBuilder {
                 .setTargetAuthenticationStrategy(DefaultAuthenticationStrategy.INSTANCE);
             if (automaticRetriesDisabled) {
                 // Keep behavior on par with the 4.x http client, which had no automatic retries
-                httpClientBuilder =  httpClientBuilder.disableAutomaticRetries();
+                httpClientBuilder = httpClientBuilder.disableAutomaticRetries();
             }
             if (httpClientConfigCallback != null) {
                 httpClientBuilder = httpClientConfigCallback.customizeHttpClient(httpClientBuilder);

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5TransportBuilder.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5TransportBuilder.java
@@ -395,7 +395,7 @@ public class ApacheHttpClient5TransportBuilder {
                 .setTargetAuthenticationStrategy(DefaultAuthenticationStrategy.INSTANCE);
             if (automaticRetriesDisabled) {
                 // Keep behavior on par with the 4.x http client, which had no automatic retries
-              httpClientBuilder =  httpClientBuilder.disableAutomaticRetries();
+                httpClientBuilder =  httpClientBuilder.disableAutomaticRetries();
             }
             if (httpClientConfigCallback != null) {
                 httpClientBuilder = httpClientConfigCallback.customizeHttpClient(httpClientBuilder);

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5TransportBuilder.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5TransportBuilder.java
@@ -395,7 +395,7 @@ public class ApacheHttpClient5TransportBuilder {
                 .setTargetAuthenticationStrategy(DefaultAuthenticationStrategy.INSTANCE);
             if (automaticRetriesDisabled) {
                 // Keep behavior on par with the 4.x http client, which had no automatic retries
-                httpClientBuilder.disableAutomaticRetries();
+              httpClientBuilder =  httpClientBuilder.disableAutomaticRetries();
             }
             if (httpClientConfigCallback != null) {
                 httpClientBuilder = httpClientConfigCallback.customizeHttpClient(httpClientBuilder);

--- a/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5TransportBuilder.java
+++ b/java-client/src/main/java/org/opensearch/client/transport/httpclient5/ApacheHttpClient5TransportBuilder.java
@@ -72,6 +72,7 @@ public class ApacheHttpClient5TransportBuilder {
     private HttpClientConfigCallback httpClientConfigCallback;
     private RequestConfigCallback requestConfigCallback;
     private ConnectionConfigCallback connectionConfigCallback;
+    private boolean automaticRetriesDisabled = true;
     private String pathPrefix;
     private NodeSelector nodeSelector = NodeSelector.ANY;
     private boolean strictDeprecationMode = false;
@@ -160,6 +161,19 @@ public class ApacheHttpClient5TransportBuilder {
     public ApacheHttpClient5TransportBuilder setConnectionConfigCallback(ConnectionConfigCallback connectionConfigCallback) {
         Objects.requireNonNull(connectionConfigCallback, "connectionConfigCallback must not be null");
         this.connectionConfigCallback = connectionConfigCallback;
+        return this;
+    }
+
+    /**
+     * Whether the http client should automatically retry requests. Automatic retries are disabled
+     * by default, on par with the previous 4.x http client.
+     *
+     * When enabled, the http client's default retry strategy is used, and a custom
+     * {@link org.apache.hc.client5.http.HttpRequestRetryStrategy} can be set through
+     * {@link HttpClientConfigCallback}.
+     */
+    public ApacheHttpClient5TransportBuilder setAutomaticRetriesDisabled(boolean automaticRetriesDisabled) {
+        this.automaticRetriesDisabled = automaticRetriesDisabled;
         return this;
     }
 
@@ -378,8 +392,11 @@ public class ApacheHttpClient5TransportBuilder {
             HttpAsyncClientBuilder httpClientBuilder = HttpAsyncClientBuilder.create()
                 .setDefaultRequestConfig(requestConfigBuilder.build())
                 .setConnectionManager(connectionManager)
-                .setTargetAuthenticationStrategy(DefaultAuthenticationStrategy.INSTANCE)
-                .disableAutomaticRetries();
+                .setTargetAuthenticationStrategy(DefaultAuthenticationStrategy.INSTANCE);
+            if (automaticRetriesDisabled) {
+                // Keep behavior on par with the 4.x http client, which had no automatic retries
+                httpClientBuilder.disableAutomaticRetries();
+            }
             if (httpClientConfigCallback != null) {
                 httpClientBuilder = httpClientConfigCallback.customizeHttpClient(httpClientBuilder);
             }

--- a/java-client/src/test/java/org/opensearch/client/transport/httpclient5/AutomaticRetriesTest.java
+++ b/java-client/src/test/java/org/opensearch/client/transport/httpclient5/AutomaticRetriesTest.java
@@ -1,0 +1,160 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.transport.httpclient5;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.util.TimeValue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.generic.Requests;
+import org.opensearch.client.opensearch.generic.Response;
+
+/**
+ * Tests that automatic retries can be enabled through
+ * {@link ApacheHttpClient5TransportBuilder#setAutomaticRetriesDisabled}, and that requests are
+ * not retried by default.
+ */
+public class AutomaticRetriesTest {
+    private ServerSocket serverSocket;
+    private ExecutorService serverExecutor;
+    private volatile boolean serverRunning;
+    private final AtomicInteger requestCount = new AtomicInteger();
+
+    @Before
+    public void startRawSocketServer() throws IOException {
+        serverSocket = new ServerSocket(0);
+        serverExecutor = Executors.newCachedThreadPool();
+        serverRunning = true;
+
+        serverExecutor.submit(() -> {
+            while (serverRunning) {
+                try {
+                    Socket clientSocket = serverSocket.accept();
+                    serverExecutor.submit(() -> handleClientRequest(clientSocket));
+                } catch (IOException e) {
+                    if (serverRunning) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        });
+    }
+
+    @After
+    public void stopRawSocketServer() throws IOException {
+        serverRunning = false;
+        if (serverSocket != null && !serverSocket.isClosed()) {
+            serverSocket.close();
+        }
+        serverExecutor.shutdownNow();
+    }
+
+    private void handleClientRequest(Socket clientSocket) {
+        try (InputStream in = clientSocket.getInputStream(); OutputStream out = clientSocket.getOutputStream()) {
+            readRequestHead(in);
+
+            String response;
+            if (requestCount.incrementAndGet() == 1) {
+                response = "HTTP/1.1 503 Service Unavailable\r\n" + "Content-Length: 0\r\n" + "Connection: close\r\n" + "\r\n";
+            } else {
+                String body = "{\"acknowledged\":true}";
+                response = "HTTP/1.1 200 OK\r\n"
+                    + "Content-Type: application/json\r\n"
+                    + "Content-Length: "
+                    + body.length()
+                    + "\r\n"
+                    + "Connection: close\r\n"
+                    + "\r\n"
+                    + body;
+            }
+            out.write(response.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+        } catch (IOException e) {
+            System.err.println("Server: Error handling client connection: " + e.getMessage());
+        } finally {
+            try {
+                clientSocket.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    // Reads the request line and headers, up to the terminating blank line
+    private static void readRequestHead(InputStream in) throws IOException {
+        int c;
+        int newLines = 0;
+        while (newLines < 2 && (c = in.read()) != -1) {
+            if (c == '\n') {
+                newLines++;
+            } else if (c != '\r') {
+                newLines = 0;
+            }
+        }
+    }
+
+    @Test
+    public void testDefaultRetryStrategyRetriesFailedRequest() throws IOException {
+        OpenSearchClient client = createClient(builder().setAutomaticRetriesDisabled(false));
+
+        Response response = client.generic().execute(Requests.builder().method("GET").endpoint("/").build());
+
+        assertEquals(200, response.getStatus());
+        assertEquals(2, requestCount.get());
+    }
+
+    @Test
+    public void testCustomRetryStrategySetThroughCallback() throws IOException {
+        OpenSearchClient client = createClient(
+            builder().setAutomaticRetriesDisabled(false)
+                .setHttpClientConfigCallback(
+                    httpClientBuilder -> httpClientBuilder.setRetryStrategy(
+                        new DefaultHttpRequestRetryStrategy(3, TimeValue.ofMilliseconds(50))
+                    )
+                )
+        );
+
+        Response response = client.generic().execute(Requests.builder().method("GET").endpoint("/").build());
+
+        assertEquals(200, response.getStatus());
+        assertEquals(2, requestCount.get());
+    }
+
+    @Test
+    public void testNoRetriesByDefault() {
+        OpenSearchClient client = createClient(builder());
+
+        assertThrows(ResponseException.class, () -> client.generic().execute(Requests.builder().method("GET").endpoint("/").build()));
+
+        assertEquals(1, requestCount.get());
+    }
+
+    private ApacheHttpClient5TransportBuilder builder() {
+        return ApacheHttpClient5TransportBuilder.builder(new HttpHost("http", "localhost", serverSocket.getLocalPort()));
+    }
+
+    private static OpenSearchClient createClient(ApacheHttpClient5TransportBuilder builder) {
+        return new OpenSearchClient(builder.build());
+    }
+}


### PR DESCRIPTION
### Description
The builder unconditionally calls `disableAutomaticRetries()` on the underlying `HttpAsyncClientBuilder`. In HttpClient 5 this flag cannot be undone, so a retry strategy set through `HttpClientConfigCallback` is silently ignored and there is no supported way to enable retries.

This adds a `setRetryStrategy(HttpRequestRetryStrategy)` option to the builder. When set, the strategy is passed through to the http client; when not set, retries stay disabled as before, keeping the default behavior on par with the 4.x http client.

A new `RetryStrategyTest` verifies both behaviors against a local socket server that fails the first request with a 503: with a retry strategy the request is transparently retried and succeeds, and by default the failure surfaces without a retry.

### Issues Resolved
Fixes #1738 

- [x] New functionality includes testing
- [x] API changes companion pull request created, if applicable
- [x] Commits are signed per the DCO using --signoff
- [x] Public documentation issue/PR created, if applicable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).