### PR TITLE
fix: allow indexed_shape-only geo/xy shape queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fix `unitTest` task not running the tests in the `test` source set ([#2074](https://github.com/opensearch-project/opensearch-java/pull/2074))
+- Allow pre-indexed shape queries by making `shape` optional on `GeoShapeQueryField` and `XyShapeQueryField` ([#2011](https://github.com/opensearch-project/opensearch-java/issues/2011))
 
 ## [Unreleased 3.x]
 ### Added

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/GeoShapeQueryField.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/GeoShapeQueryField.java
@@ -49,7 +49,6 @@ import org.opensearch.client.json.ObjectBuilderDeserializer;
 import org.opensearch.client.json.ObjectDeserializer;
 import org.opensearch.client.json.PlainJsonSerializable;
 import org.opensearch.client.opensearch._types.GeoShapeRelation;
-import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.CopyableBuilder;
 import org.opensearch.client.util.ObjectBuilder;
 import org.opensearch.client.util.ObjectBuilderBase;
@@ -67,7 +66,7 @@ public class GeoShapeQueryField implements PlainJsonSerializable, ToCopyableBuil
     @Nullable
     private final GeoShapeRelation relation;
 
-    @Nonnull
+    @Nullable
     private final GeoShape shape;
 
     // ---------------------------------------------------------------------------------------------
@@ -75,7 +74,7 @@ public class GeoShapeQueryField implements PlainJsonSerializable, ToCopyableBuil
     private GeoShapeQueryField(Builder builder) {
         this.indexedShape = builder.indexedShape;
         this.relation = builder.relation;
-        this.shape = ApiTypeHelper.requireNonNull(builder.shape, this, "shape");
+        this.shape = builder.shape;
     }
 
     public static GeoShapeQueryField of(Function<GeoShapeQueryField.Builder, ObjectBuilder<GeoShapeQueryField>> fn) {
@@ -99,9 +98,9 @@ public class GeoShapeQueryField implements PlainJsonSerializable, ToCopyableBuil
     }
 
     /**
-     * Required - API name: {@code shape}
+     * API name: {@code shape}
      */
-    @Nonnull
+    @Nullable
     public final GeoShape shape() {
         return this.shape;
     }
@@ -127,8 +126,10 @@ public class GeoShapeQueryField implements PlainJsonSerializable, ToCopyableBuil
             this.relation.serialize(generator, mapper);
         }
 
-        generator.writeKey("shape");
-        this.shape.serialize(generator, mapper);
+        if (this.shape != null) {
+            generator.writeKey("shape");
+            this.shape.serialize(generator, mapper);
+        }
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -152,6 +153,7 @@ public class GeoShapeQueryField implements PlainJsonSerializable, ToCopyableBuil
         private FieldLookup indexedShape;
         @Nullable
         private GeoShapeRelation relation;
+        @Nullable
         private GeoShape shape;
 
         public Builder() {}
@@ -201,16 +203,16 @@ public class GeoShapeQueryField implements PlainJsonSerializable, ToCopyableBuil
         }
 
         /**
-         * Required - API name: {@code shape}
+         * API name: {@code shape}
          */
         @Nonnull
-        public final Builder shape(GeoShape value) {
+        public final Builder shape(@Nullable GeoShape value) {
             this.shape = value;
             return this;
         }
 
         /**
-         * Required - API name: {@code shape}
+         * API name: {@code shape}
          */
         @Nonnull
         public final Builder shape(Function<GeoShape.Builder, ObjectBuilder<GeoShape>> fn) {
@@ -252,7 +254,7 @@ public class GeoShapeQueryField implements PlainJsonSerializable, ToCopyableBuil
         int result = 17;
         result = 31 * result + Objects.hashCode(this.indexedShape);
         result = 31 * result + Objects.hashCode(this.relation);
-        result = 31 * result + this.shape.hashCode();
+        result = 31 * result + Objects.hashCode(this.shape);
         return result;
     }
 
@@ -263,6 +265,6 @@ public class GeoShapeQueryField implements PlainJsonSerializable, ToCopyableBuil
         GeoShapeQueryField other = (GeoShapeQueryField) o;
         return Objects.equals(this.indexedShape, other.indexedShape)
             && Objects.equals(this.relation, other.relation)
-            && this.shape.equals(other.shape);
+            && Objects.equals(this.shape, other.shape);
     }
 }

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/XyShapeQueryField.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/_types/query_dsl/XyShapeQueryField.java
@@ -25,7 +25,6 @@ import org.opensearch.client.json.ObjectBuilderDeserializer;
 import org.opensearch.client.json.ObjectDeserializer;
 import org.opensearch.client.json.PlainJsonSerializable;
 import org.opensearch.client.opensearch._types.GeoShapeRelation;
-import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.client.util.CopyableBuilder;
 import org.opensearch.client.util.ObjectBuilder;
 import org.opensearch.client.util.ObjectBuilderBase;
@@ -43,7 +42,7 @@ public class XyShapeQueryField implements PlainJsonSerializable, ToCopyableBuild
     @Nullable
     private final GeoShapeRelation relation;
 
-    @Nonnull
+    @Nullable
     private final XyShape shape;
 
     // ---------------------------------------------------------------------------------------------
@@ -51,7 +50,7 @@ public class XyShapeQueryField implements PlainJsonSerializable, ToCopyableBuild
     private XyShapeQueryField(Builder builder) {
         this.indexedShape = builder.indexedShape;
         this.relation = builder.relation;
-        this.shape = ApiTypeHelper.requireNonNull(builder.shape, this, "shape");
+        this.shape = builder.shape;
     }
 
     public static XyShapeQueryField of(Function<XyShapeQueryField.Builder, ObjectBuilder<XyShapeQueryField>> fn) {
@@ -75,9 +74,9 @@ public class XyShapeQueryField implements PlainJsonSerializable, ToCopyableBuild
     }
 
     /**
-     * Required - API name: {@code shape}
+     * API name: {@code shape}
      */
-    @Nonnull
+    @Nullable
     public final XyShape shape() {
         return this.shape;
     }
@@ -103,8 +102,10 @@ public class XyShapeQueryField implements PlainJsonSerializable, ToCopyableBuild
             this.relation.serialize(generator, mapper);
         }
 
-        generator.writeKey("shape");
-        this.shape.serialize(generator, mapper);
+        if (this.shape != null) {
+            generator.writeKey("shape");
+            this.shape.serialize(generator, mapper);
+        }
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -128,6 +129,7 @@ public class XyShapeQueryField implements PlainJsonSerializable, ToCopyableBuild
         private FieldLookup indexedShape;
         @Nullable
         private GeoShapeRelation relation;
+        @Nullable
         private XyShape shape;
 
         public Builder() {}
@@ -177,16 +179,16 @@ public class XyShapeQueryField implements PlainJsonSerializable, ToCopyableBuild
         }
 
         /**
-         * Required - API name: {@code shape}
+         * API name: {@code shape}
          */
         @Nonnull
-        public final Builder shape(XyShape value) {
+        public final Builder shape(@Nullable XyShape value) {
             this.shape = value;
             return this;
         }
 
         /**
-         * Required - API name: {@code shape}
+         * API name: {@code shape}
          */
         @Nonnull
         public final Builder shape(Function<XyShape.Builder, ObjectBuilder<XyShape>> fn) {
@@ -228,7 +230,7 @@ public class XyShapeQueryField implements PlainJsonSerializable, ToCopyableBuild
         int result = 17;
         result = 31 * result + Objects.hashCode(this.indexedShape);
         result = 31 * result + Objects.hashCode(this.relation);
-        result = 31 * result + this.shape.hashCode();
+        result = 31 * result + Objects.hashCode(this.shape);
         return result;
     }
 
@@ -239,6 +241,6 @@ public class XyShapeQueryField implements PlainJsonSerializable, ToCopyableBuild
         XyShapeQueryField other = (XyShapeQueryField) o;
         return Objects.equals(this.indexedShape, other.indexedShape)
             && Objects.equals(this.relation, other.relation)
-            && this.shape.equals(other.shape);
+            && Objects.equals(this.shape, other.shape);
     }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/GeoShapeQueryFieldTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/GeoShapeQueryFieldTest.java
@@ -19,4 +19,15 @@ public class GeoShapeQueryFieldTest extends ModelTestCase {
 
         assertEquals(toJson(copied), toJson(origin));
     }
+
+    @Test
+    public void indexedShapeOnly() {
+        GeoShapeQueryField field = new GeoShapeQueryField.Builder().indexedShape(
+            i -> i.id("id").index("shapes").path("location")
+        ).build();
+
+        assertNull(field.shape());
+        assertEquals("id", field.indexedShape().id());
+        assertEquals("{\"indexed_shape\":{\"id\":\"id\",\"index\":\"shapes\",\"path\":\"location\"}}", toJson(field));
+    }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/GeoShapeQueryFieldTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/GeoShapeQueryFieldTest.java
@@ -22,9 +22,7 @@ public class GeoShapeQueryFieldTest extends ModelTestCase {
 
     @Test
     public void indexedShapeOnly() {
-        GeoShapeQueryField field = new GeoShapeQueryField.Builder().indexedShape(
-            i -> i.id("id").index("shapes").path("location")
-        ).build();
+        GeoShapeQueryField field = new GeoShapeQueryField.Builder().indexedShape(i -> i.id("id").index("shapes").path("location")).build();
 
         assertNull(field.shape());
         assertEquals("id", field.indexedShape().id());

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/XyShapeQueryFieldTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/XyShapeQueryFieldTest.java
@@ -43,4 +43,14 @@ public class XyShapeQueryFieldTest extends ModelTestCase {
 
         assertEquals(toJson(copied), toJson(origin));
     }
+
+    @Test
+    public void indexedShapeOnly() {
+        XyShapeQueryField field = new XyShapeQueryField.Builder().indexedShape(i -> i.id("id").index("shapes").path("location"))
+            .build();
+
+        assertNull(field.shape());
+        assertEquals("id", field.indexedShape().id());
+        assertEquals("{\"indexed_shape\":{\"id\":\"id\",\"index\":\"shapes\",\"path\":\"location\"}}", toJson(field));
+    }
 }

--- a/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/XyShapeQueryFieldTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/_types/query_dsl/XyShapeQueryFieldTest.java
@@ -46,8 +46,7 @@ public class XyShapeQueryFieldTest extends ModelTestCase {
 
     @Test
     public void indexedShapeOnly() {
-        XyShapeQueryField field = new XyShapeQueryField.Builder().indexedShape(i -> i.id("id").index("shapes").path("location"))
-            .build();
+        XyShapeQueryField field = new XyShapeQueryField.Builder().indexedShape(i -> i.id("id").index("shapes").path("location")).build();
 
         assertNull(field.shape());
         assertEquals("id", field.indexedShape().id());

--- a/java-codegen/opensearch-openapi.yaml
+++ b/java-codegen/opensearch-openapi.yaml
@@ -48620,8 +48620,6 @@ components:
           $ref: '#/components/schemas/_common.query_dsl___GeoShape'
         relation:
           $ref: '#/components/schemas/_common___GeoShapeRelation'
-      required:
-        - shape
     _common.query_dsl___GeoValidationMethod:
       type: string
       enum:
@@ -50318,8 +50316,6 @@ components:
           $ref: '#/components/schemas/_common.query_dsl___XyShape'
         relation:
           $ref: '#/components/schemas/_common___GeoShapeRelation'
-      required:
-        - shape
     _common.query_dsl___ZeroTermsQuery:
       type: string
       enum:


### PR DESCRIPTION
### Description

Fixes #2011.

`GeoShapeQueryField` (and the sibling `XyShapeQueryField`) currently mark `shape` as required. OpenSearch documents that a geo/xy shape query may use either an inline `shape` **or** a pre-indexed shape via `indexed_shape` (not both). Because the generated builder enforces `shape`, callers cannot construct valid pre-indexed shape queries:

```java
new Query.Builder()
    .geoShape(g -> g
        .field("location")
        .shape(s -> s.indexedShape(i -> i.index("shapes").id("id").path("location")))
    )
    .build();
```

### Changes

- Remove `required: [shape]` from `_common.query_dsl___GeoShapeQueryField` and `_common.query_dsl___XyShapeQueryField` in `java-codegen/opensearch-openapi.yaml`
- Update generated `GeoShapeQueryField` / `XyShapeQueryField` so `shape` is `@Nullable` (no `ApiTypeHelper.requireNonNull`, conditional serialization, null-safe equals/hashCode)
- Add unit coverage for `indexed_shape`-only construction/serialization
- CHANGELOG entry under Unreleased 4.x Fixed

### Related

- Upstream API-spec discussion: opensearch-project/opensearch-api-specification#1160 / #1161 (same schema correction). This client PR unblocks users of the generated DSL until the next full spec refresh.

### Testing

```
./gradlew :java-client:test \
  --tests org.opensearch.client.opensearch._types.query_dsl.GeoShapeQueryFieldTest \
  --tests org.opensearch.client.opensearch._types.query_dsl.XyShapeQueryFieldTest
```

Temurin 21 / macOS — 4 tests, 0 failures (`toBuilder` + `indexedShapeOnly` for both classes).

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented if needed (N/A — aligns client with existing API docs)
- [x] API changes companion issue/PR for [opensearch-api-specification](https://github.com/opensearch-project/opensearch-api-specification) (prior attempt #1161)
- [x] Commits are signed per DCO with `Signed-off-by`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.