### PR TITLE
[Backport 3.x] Support named query scores in Hit.matchedQueries()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `org.apache.httpcomponents.client5:httpclient5` from 5.6 to 5.6.1 ([#1967](https://github.com/opensearch-project/opensearch-java/pull/1967))
 
 ### Changed
+- Breaking: Change typed shape of `Hit.matched_queries` to a `MatchedQueries` tagged union that carries either a `List<String>` (names) or a `Map<String, Double>` (scores), and send `include_named_queries_score` as a query parameter ([#2098](https://github.com/opensearch-project/opensearch-java/pull/2098))
 
 ### Deprecated
 

--- a/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/Hit.java
+++ b/java-client/src/generated/java/org/opensearch/client/opensearch/core/search/Hit.java
@@ -90,8 +90,8 @@ public class Hit<TDocument> implements PlainJsonSerializable, ToCopyableBuilder<
     @Nonnull
     private final Map<String, InnerHitsResult> innerHits;
 
-    @Nonnull
-    private final List<String> matchedQueries;
+    @Nullable
+    private final MatchedQueries matchedQueries;
 
     @Nonnull
     private final Map<String, JsonData> metaFields;
@@ -140,7 +140,7 @@ public class Hit<TDocument> implements PlainJsonSerializable, ToCopyableBuilder<
         this.ignoredFieldValues = ApiTypeHelper.unmodifiable(builder.ignoredFieldValues);
         this.index = builder.index;
         this.innerHits = ApiTypeHelper.unmodifiable(builder.innerHits);
-        this.matchedQueries = ApiTypeHelper.unmodifiable(builder.matchedQueries);
+        this.matchedQueries = builder.matchedQueries;
         this.metaFields = ApiTypeHelper.unmodifiable(builder.metaFields);
         this.nested = builder.nested;
         this.node = builder.node;
@@ -226,8 +226,8 @@ public class Hit<TDocument> implements PlainJsonSerializable, ToCopyableBuilder<
     /**
      * API name: {@code matched_queries}
      */
-    @Nonnull
-    public final List<String> matchedQueries() {
+    @Nullable
+    public final MatchedQueries matchedQueries() {
         return this.matchedQueries;
     }
 
@@ -418,13 +418,9 @@ public class Hit<TDocument> implements PlainJsonSerializable, ToCopyableBuilder<
             generator.writeEnd();
         }
 
-        if (ApiTypeHelper.isDefined(this.matchedQueries)) {
+        if (this.matchedQueries != null) {
             generator.writeKey("matched_queries");
-            generator.writeStartArray();
-            for (String item0 : this.matchedQueries) {
-                generator.write(item0);
-            }
-            generator.writeEnd();
+            this.matchedQueries.serialize(generator, mapper);
         }
 
         if (this.nested != null) {
@@ -516,7 +512,7 @@ public class Hit<TDocument> implements PlainJsonSerializable, ToCopyableBuilder<
         @Nullable
         private Map<String, InnerHitsResult> innerHits;
         @Nullable
-        private List<String> matchedQueries;
+        private MatchedQueries matchedQueries;
         @Nullable
         private Map<String, JsonData> metaFields;
         @Nullable
@@ -553,7 +549,7 @@ public class Hit<TDocument> implements PlainJsonSerializable, ToCopyableBuilder<
             this.ignoredFieldValues = _mapCopy(o.ignoredFieldValues);
             this.index = o.index;
             this.innerHits = _mapCopy(o.innerHits);
-            this.matchedQueries = _listCopy(o.matchedQueries);
+            this.matchedQueries = o.matchedQueries;
             this.metaFields = _mapCopy(o.metaFields);
             this.nested = o.nested;
             this.node = o.node;
@@ -577,7 +573,7 @@ public class Hit<TDocument> implements PlainJsonSerializable, ToCopyableBuilder<
             this.ignoredFieldValues = _mapCopy(o.ignoredFieldValues);
             this.index = o.index;
             this.innerHits = _mapCopy(o.innerHits);
-            this.matchedQueries = _listCopy(o.matchedQueries);
+            this.matchedQueries = o.matchedQueries;
             this.metaFields = _mapCopy(o.metaFields);
             this.nested = o.nested;
             this.node = o.node;
@@ -777,28 +773,19 @@ public class Hit<TDocument> implements PlainJsonSerializable, ToCopyableBuilder<
 
         /**
          * API name: {@code matched_queries}
-         *
-         * <p>
-         * Adds all elements of <code>list</code> to <code>matchedQueries</code>.
-         * </p>
          */
         @Nonnull
-        public final Builder<TDocument> matchedQueries(List<String> list) {
-            this.matchedQueries = _listAddAll(this.matchedQueries, list);
+        public final Builder<TDocument> matchedQueries(@Nullable MatchedQueries value) {
+            this.matchedQueries = value;
             return this;
         }
 
         /**
          * API name: {@code matched_queries}
-         *
-         * <p>
-         * Adds one or more values to <code>matchedQueries</code>.
-         * </p>
          */
         @Nonnull
-        public final Builder<TDocument> matchedQueries(String value, String... values) {
-            this.matchedQueries = _listAdd(this.matchedQueries, value, values);
-            return this;
+        public final Builder<TDocument> matchedQueries(Function<MatchedQueries.Builder, ObjectBuilder<MatchedQueries>> fn) {
+            return matchedQueries(fn.apply(new MatchedQueries.Builder()).build());
         }
 
         /**
@@ -1009,7 +996,7 @@ public class Hit<TDocument> implements PlainJsonSerializable, ToCopyableBuilder<
         );
         op.add(Builder::index, JsonpDeserializer.stringDeserializer(), "_index");
         op.add(Builder::innerHits, JsonpDeserializer.stringMapDeserializer(InnerHitsResult._DESERIALIZER), "inner_hits");
-        op.add(Builder::matchedQueries, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()), "matched_queries");
+        op.add(Builder::matchedQueries, MatchedQueries._DESERIALIZER, "matched_queries");
         op.add(Builder::nested, NestedIdentity._DESERIALIZER, "_nested");
         op.add(Builder::node, JsonpDeserializer.stringDeserializer(), "_node");
         op.add(Builder::primaryTerm, JsonpDeserializer.longDeserializer(), "_primary_term");

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/SearchRequest.java
@@ -1000,10 +1000,6 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
             this.highlight.serialize(generator, mapper);
 
         }
-        if (this.includeNamedQueriesScore != null) {
-            generator.writeKey("include_named_queries_score");
-            generator.write(this.includeNamedQueriesScore);
-        }
         if (ApiTypeHelper.isDefined(this.indicesBoost)) {
             generator.writeKey("indices_boost");
             generator.writeStartArray();
@@ -2501,7 +2497,6 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
         op.add(Builder::fields, JsonpDeserializer.arrayDeserializer(FieldAndFormat._DESERIALIZER), "fields");
         op.add(Builder::from, JsonpDeserializer.integerDeserializer(), "from");
         op.add(Builder::highlight, Highlight._DESERIALIZER, "highlight");
-        op.add(Builder::includeNamedQueriesScore, JsonpDeserializer.booleanDeserializer(), "include_named_queries_score");
         op.add(
             Builder::indicesBoost,
             JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringMapDeserializer(JsonpDeserializer.doubleDeserializer())),
@@ -2589,6 +2584,9 @@ public class SearchRequest extends RequestBase implements PlainJsonSerializable 
             }
             if (request.ignoreUnavailable != null) {
                 params.put("ignore_unavailable", String.valueOf(request.ignoreUnavailable));
+            }
+            if (request.includeNamedQueriesScore != null) {
+                params.put("include_named_queries_score", String.valueOf(request.includeNamedQueriesScore));
             }
             if (request.allowNoIndices != null) {
                 params.put("allow_no_indices", String.valueOf(request.allowNoIndices));

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/search/MatchedQueries.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/search/MatchedQueries.java
@@ -9,7 +9,12 @@
 package org.opensearch.client.opensearch.core.search;
 
 import jakarta.json.stream.JsonGenerator;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -37,7 +42,7 @@ import org.opensearch.client.util.TaggedUnionUtils;
  * </p>
  */
 @JsonpDeserializable
-public class MatchedQueries implements TaggedUnion<MatchedQueries.Kind, Object>, PlainJsonSerializable {
+public class MatchedQueries implements TaggedUnion<MatchedQueries.Kind, Object>, PlainJsonSerializable, List<String> {
 
     /**
      * {@link MatchedQueries} variant kinds.
@@ -203,5 +208,124 @@ public class MatchedQueries implements TaggedUnion<MatchedQueries.Kind, Object>,
         if (o == null || this.getClass() != o.getClass()) return false;
         MatchedQueries other = (MatchedQueries) o;
         return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+    }
+
+    @Override
+    public int size() {
+        return isNames() ? names().size() : scores().size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return isNames() ? names().isEmpty() : scores().isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return isNames() ? names().contains(o) : scores().containsKey(o);
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return isNames() ? names().iterator() : scores().keySet().iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return isNames() ? names().toArray() : scores().keySet().toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return isNames() ? names().toArray(a) : scores().keySet().toArray(a);
+    }
+
+    @Override
+    public boolean add(String e) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return isNames() ? names().containsAll(c) : scores().keySet().containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends String> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends String> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String get(int index) {
+        return isNames() ? names().get(index) : new ArrayList<>(scores().keySet()).get(index);
+    }
+
+    @Override
+    public String set(int index, String element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void add(int index, String element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String remove(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return isNames() ? names().indexOf(o) : new ArrayList<>(scores().keySet()).indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        return isNames() ? names().lastIndexOf(o) : new ArrayList<>(scores().keySet()).lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<String> listIterator() {
+        return listIterator(0);
+    }
+
+    @Override
+    public ListIterator<String> listIterator(int index) {
+        return isNames()
+            ? names().listIterator(index)
+            : Collections.unmodifiableList(new ArrayList<>(scores().keySet())).listIterator(index);
+    }
+
+    @Override
+    public List<String> subList(int fromIndex, int toIndex) {
+        return isNames()
+            ? names().subList(fromIndex, toIndex)
+            : Collections.unmodifiableList(new ArrayList<>(scores().keySet()).subList(fromIndex, toIndex));
     }
 }

--- a/java-client/src/main/java/org/opensearch/client/opensearch/core/search/MatchedQueries.java
+++ b/java-client/src/main/java/org/opensearch/client/opensearch/core/search/MatchedQueries.java
@@ -1,0 +1,207 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch.core.search;
+
+import jakarta.json.stream.JsonGenerator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.PlainJsonSerializable;
+import org.opensearch.client.json.UnionDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+import org.opensearch.client.util.TaggedUnion;
+import org.opensearch.client.util.TaggedUnionUtils;
+
+// typedef: core.search.MatchedQueries
+
+/**
+ * The names of queries that matched a hit, with optional per-query scores.
+ *
+ * <p>
+ * The server returns matched_queries in one of two shapes, and never both: an array of query names when
+ * {@code include_named_queries_score} is not set, or an object mapping query names to scores when
+ * {@code include_named_queries_score} is true.
+ * </p>
+ */
+@JsonpDeserializable
+public class MatchedQueries implements TaggedUnion<MatchedQueries.Kind, Object>, PlainJsonSerializable {
+
+    /**
+     * {@link MatchedQueries} variant kinds.
+     */
+    public enum Kind {
+        Names,
+        Scores
+    }
+
+    private final Kind _kind;
+    private final Object _value;
+
+    @Override
+    public final Kind _kind() {
+        return _kind;
+    }
+
+    @Override
+    public final Object _get() {
+        return _value;
+    }
+
+    private MatchedQueries(Kind kind, Object value) {
+        this._kind = kind;
+        this._value = value;
+    }
+
+    private MatchedQueries(Builder builder) {
+        this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
+        this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+    }
+
+    public static MatchedQueries of(Function<MatchedQueries.Builder, ObjectBuilder<MatchedQueries>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    public static MatchedQueries ofNames(List<String> names) {
+        return new MatchedQueries(Kind.Names, ApiTypeHelper.requireNonNull(names, MatchedQueries.class, "names"));
+    }
+
+    public static MatchedQueries ofScores(Map<String, Double> scores) {
+        return new MatchedQueries(Kind.Scores, ApiTypeHelper.requireNonNull(scores, MatchedQueries.class, "scores"));
+    }
+
+    /**
+     * Is this variant instance of kind {@code names}?
+     */
+    public boolean isNames() {
+        return _kind == Kind.Names;
+    }
+
+    /**
+     * Get the {@code names} variant value: the names of the queries that matched the hit, returned by the server when
+     * {@code include_named_queries_score} is not set.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code names} kind.
+     */
+    public List<String> names() {
+        return TaggedUnionUtils.get(this, Kind.Names);
+    }
+
+    /**
+     * Is this variant instance of kind {@code scores}?
+     */
+    public boolean isScores() {
+        return _kind == Kind.Scores;
+    }
+
+    /**
+     * Get the {@code scores} variant value: a map from matched query name to score, returned by the server when
+     * {@code include_named_queries_score} is true.
+     *
+     * @throws IllegalStateException if the current variant is not the {@code scores} kind.
+     */
+    public Map<String, Double> scores() {
+        return TaggedUnionUtils.get(this, Kind.Scores);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        switch (_kind) {
+            case Names:
+                generator.writeStartArray();
+                for (String name : (List<String>) _value) {
+                    generator.write(name);
+                }
+                generator.writeEnd();
+                break;
+            case Scores:
+                generator.writeStartObject();
+                for (Map.Entry<String, Double> entry : ((Map<String, Double>) _value).entrySet()) {
+                    generator.writeKey(entry.getKey());
+                    generator.write(entry.getValue());
+                }
+                generator.writeEnd();
+                break;
+        }
+    }
+
+    @Nonnull
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    @Nonnull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<MatchedQueries> {
+        private Kind _kind;
+        private Object _value;
+
+        public Builder() {}
+
+        private Builder(MatchedQueries o) {
+            this._kind = o._kind;
+            this._value = o._value;
+        }
+
+        public ObjectBuilder<MatchedQueries> names(List<String> v) {
+            this._kind = Kind.Names;
+            this._value = v;
+            return this;
+        }
+
+        public ObjectBuilder<MatchedQueries> scores(Map<String, Double> v) {
+            this._kind = Kind.Scores;
+            this._value = v;
+            return this;
+        }
+
+        @Override
+        public MatchedQueries build() {
+            _checkSingleUse();
+            return new MatchedQueries(this);
+        }
+    }
+
+    private static JsonpDeserializer<MatchedQueries> buildMatchedQueriesDeserializer() {
+        return new UnionDeserializer.Builder<MatchedQueries, Kind, Object>(MatchedQueries::new, false).addMember(
+            Kind.Names,
+            JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer())
+        ).addMember(Kind.Scores, JsonpDeserializer.stringMapDeserializer(JsonpDeserializer.doubleDeserializer())).build();
+    }
+
+    public static final JsonpDeserializer<MatchedQueries> _DESERIALIZER = JsonpDeserializer.lazy(
+        MatchedQueries::buildMatchedQueriesDeserializer
+    );
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + Objects.hashCode(this._kind);
+        result = 31 * result + Objects.hashCode(this._value);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || this.getClass() != o.getClass()) return false;
+        MatchedQueries other = (MatchedQueries) o;
+        return Objects.equals(this._kind, other._kind) && Objects.equals(this._value, other._value);
+    }
+}

--- a/java-client/src/test/java/org/opensearch/client/opensearch/core/search/MatchedQueriesTest.java
+++ b/java-client/src/test/java/org/opensearch/client/opensearch/core/search/MatchedQueriesTest.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client.opensearch.core.search;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.opensearch.client.opensearch.model.ModelTestCase.toJson;
+
+import jakarta.json.stream.JsonParser;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+
+public class MatchedQueriesTest {
+    private final JsonpMapper mapper = new JsonbJsonpMapper();
+    private final JsonpDeserializer<Hit<JsonData>> hitDeserializer = Hit.createHitDeserializer(JsonData._DESERIALIZER);
+
+    private Hit<JsonData> parseHit(String json) {
+        JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
+        return hitDeserializer.deserialize(parser, mapper);
+    }
+
+    @Test
+    public void deserializesArrayFormAsNamesVariant() {
+        Hit<JsonData> hit = parseHit("{\"_index\":\"i\",\"matched_queries\":[\"a\",\"b\"]}");
+        MatchedQueries mq = hit.matchedQueries();
+        assertTrue(mq.isNames());
+        assertFalse(mq.isScores());
+        assertEquals(Arrays.asList("a", "b"), mq.names());
+    }
+
+    @Test
+    public void deserializesObjectFormAsScoresVariant() {
+        Hit<JsonData> hit = parseHit("{\"_index\":\"i\",\"matched_queries\":{\"a\":1.5,\"b\":2.5}}");
+        MatchedQueries mq = hit.matchedQueries();
+        assertTrue(mq.isScores());
+        assertFalse(mq.isNames());
+        Map<String, Double> scores = mq.scores();
+        assertEquals(Double.valueOf(1.5), scores.get("a"));
+        assertEquals(Double.valueOf(2.5), scores.get("b"));
+    }
+
+    @Test
+    public void returnsNullWhenAbsent() {
+        Hit<JsonData> hit = parseHit("{\"_index\":\"i\"}");
+        assertNull(hit.matchedQueries());
+    }
+
+    @Test
+    public void serializesNamesVariantAsArray() {
+        Hit<JsonData> hit = parseHit("{\"_index\":\"i\",\"matched_queries\":[\"a\",\"b\"]}");
+        assertTrue(toJson(hit, mapper).contains("\"matched_queries\":[\"a\",\"b\"]"));
+    }
+
+    @Test
+    public void serializesScoresVariantAsObject() {
+        Map<String, Double> scores = new LinkedHashMap<>();
+        scores.put("a", 1.5);
+        scores.put("b", 2.5);
+        Hit<JsonData> hit = new Hit.Builder<JsonData>().index("i").matchedQueries(MatchedQueries.ofScores(scores)).build();
+        assertTrue(toJson(hit, mapper).contains("\"matched_queries\":{\"a\":1.5,\"b\":2.5}"));
+    }
+}

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/model/types/Types.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/model/types/Types.java
@@ -230,6 +230,16 @@ public final class Types {
                 public static final String PACKAGE = OpenSearch.PACKAGE + ".cat";
                 public static final Type CatRequestBase = type(PACKAGE, "CatRequestBase");
             }
+
+            public static final class Core {
+                public static final String PACKAGE = OpenSearch.PACKAGE + ".core";
+
+                public static final class Search {
+                    public static final String PACKAGE = Core.PACKAGE + ".search";
+
+                    public static final Type MatchedQueries = type(PACKAGE, "MatchedQueries");
+                }
+            }
         }
 
         public static final class Transport {

--- a/java-codegen/src/main/java/org/opensearch/client/codegen/transformer/overrides/Overrides.java
+++ b/java-codegen/src/main/java/org/opensearch/client/codegen/transformer/overrides/Overrides.java
@@ -169,6 +169,12 @@ public class Overrides {
                 .with(schema("_core.search", "Suggester"), so -> so.withShouldGenerate(ShouldGenerate.Always))
                 .with(schema("_core.search", "TermSuggestOption"), so -> so.withShouldGenerate(ShouldGenerate.Always))
                 .with(
+                    schema("_core.search", "Hit"),
+                    so -> so.withProperties(
+                        p -> p.with("matched_queries", po -> po.withMappedType(Types.Client.OpenSearch.Core.Search.MatchedQueries))
+                    )
+                )
+                .with(
                     schema("_core.search", "HitsMetadata"),
                     so -> so.withProperties(
                         p -> p.with(


### PR DESCRIPTION
### Description
Adds typed access to named query scores on `3.x`. `Hit.matched_queries` becomes a `MatchedQueries` tagged union carrying either names (`List<String>`) or scores (`Map<String, Double>`), and `include_named_queries_score` is sent as a query parameter so the server actually returns the scored map (previously it was placed in the request body, which the server does not honor: https://github.com/opensearch-project/OpenSearch/issues/22689).

Source-breaking on `3.x`, since `matched_queries()` now returns `MatchedQueries` instead of `List<String>`.

### Issues Resolved
#1805 (backport of #2098 to `3.x`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
