### PR TITLE
[Backport] [3.x] Bump io.github.classgraph:classgraph in /java-client (#2104)

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -260,7 +260,7 @@ dependencies {
     implementation("org.eclipse", "yasson", "2.0.2")
 
     // https://github.com/classgraph/classgraph
-    testImplementation("io.github.classgraph:classgraph:4.8.192")
+    testImplementation("io.github.classgraph:classgraph:4.8.193")
 
     // Eclipse 1.0
     testImplementation("junit", "junit" , "4.13.2") {

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -260,7 +260,7 @@ dependencies {
     implementation("org.eclipse", "yasson", "2.0.2")
 
     // https://github.com/classgraph/classgraph
-    testImplementation("io.github.classgraph:classgraph:4.8.181")
+    testImplementation("io.github.classgraph:classgraph:4.8.192")
 
     // Eclipse 1.0
     testImplementation("junit", "junit" , "4.13.2") {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/2104 to `3.x`