### PR TITLE
fix: update API spec download URL to api-spec.opensearch.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Run model tests against both JSON mappers instead of picking one at random ([#2085](https://github.com/opensearch-project/opensearch-java/pull/2085))
 - Fix currentSize calculation in BulkIngester ([#2113](https://github.com/opensearch-project/opensearch-java/pull/2113))
 
+### Changed
+- Updated API spec download URL to `https://api-spec.opensearch.org` ([#2116](https://github.com/opensearch-project/opensearch-java/pull/2116))
+
 ## [Unreleased 3.x]
 ### Added
 

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -72,7 +72,7 @@ application {
 val localSpecification = file("$projectDir/opensearch-openapi.yaml").toURI().toString()
 
 tasks.register<Download>("downloadLatestSpec") {
-    src("https://github.com/opensearch-project/opensearch-api-specification/releases/download/main-latest/opensearch-openapi.yaml")
+    src("https://api-spec.opensearch.org/opensearch-openapi.yaml")
     dest(localSpecification)
 }
 


### PR DESCRIPTION
### Description

Update the OpenAPI spec download URL in the code generator from the GitHub release assets URL to the new canonical location at `https://api-spec.opensearch.org/opensearch-openapi.yaml`.

The `opensearch-api-specification` repo now publishes the spec at this new URL (see opensearch-project/opensearch-api-specification#1200).

### Changes

- `java-codegen/build.gradle.kts`: Updated spec `src()` URL

### Related

- opensearch-project/opensearch-api-specification#1200
- opensearch-project/opensearch-php#420
- opensearch-project/opensearch-net#1030

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).