### PR TITLE
[Backport 3.x] fix: update API spec download URL to api-spec.opensearch.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Security
 
-## [Unreleased 2.x]
+### Changed
+- Updated API spec download URL to `https://api-spec.opensearch.org` ([#2116](https://github.com/opensearch-project/opensearch-java/pull/2116))
+
+## [Unreleased 3.x]
 ### Added
 
 ### Dependencies

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -72,7 +72,7 @@ application {
 val localSpecification = file("$projectDir/opensearch-openapi.yaml").toURI().toString()
 
 tasks.register<Download>("downloadLatestSpec") {
-    src("https://github.com/opensearch-project/opensearch-api-specification/releases/download/main-latest/opensearch-openapi.yaml")
+    src("https://api-spec.opensearch.org/opensearch-openapi.yaml")
     dest(localSpecification)
 }
 


### PR DESCRIPTION
Cherry-pick of 0a84bf66 onto `3.x` from #2116 
