### PR TITLE
[Backport] [3.x] Bump Jackson to 2.22.2 / 3.2.2 (#2125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Dependencies
 - Bump `org.apache.httpcomponents.client5:httpclient5` from 5.6 to 5.6.1 ([#1967](https://github.com/opensearch-project/opensearch-java/pull/1967))
+- Bump Jackson to 2.22.2 / 3.2.2 ([#2125](https://github.com/opensearch-project/opensearch-java/pull/2125))
 
 ### Changed
 - Breaking: Change typed shape of `Hit.matched_queries` to a `MatchedQueries` tagged union that carries either a `List<String>` (names) or a `Map<String, Double>` (scores), and send `include_named_queries_score` as a query parameter ([#2098](https://github.com/opensearch-project/opensearch-java/pull/2098))

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -190,10 +190,10 @@ val integrationTest = task<Test>("integrationTest") {
 }
 
 dependencies {
-    val jacksonVersion = "2.21.2"
-    val jacksonDatabindVersion = "2.21.2"
-    val jackson3Version = "3.1.1"
-    val jackson3DatabindVersion = "3.1.1"
+    val jacksonVersion = "2.22.2"
+    val jacksonDatabindVersion = "2.22.2"
+    val jackson3Version = "3.2.2"
+    val jackson3DatabindVersion = "3.2.2"
 
     // Apache 2.0
     api("commons-logging:commons-logging:1.3.6")

--- a/java-codegen/build.gradle.kts
+++ b/java-codegen/build.gradle.kts
@@ -150,8 +150,8 @@ dependencies {
     implementation("org.apache.logging.log4j", "log4j-slf4j2-impl", "[2.17.1,3.0)")
 
     // Apache 2.0
-    implementation("com.fasterxml.jackson.core", "jackson-core", "2.17.1")
-    implementation("com.fasterxml.jackson.core", "jackson-databind", "2.17.1")
+    implementation("com.fasterxml.jackson.core", "jackson-core", "2.22.2")
+    implementation("com.fasterxml.jackson.core", "jackson-databind", "2.22.2")
 
     // Apache 2.0
     implementation("com.diffplug.spotless", "spotless-lib", "2.45.0")

--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     implementation("org.apache.logging.log4j", "log4j-core","[2.17.1,3.0)")
     implementation("org.apache.logging.log4j", "log4j-slf4j2-impl","[2.17.1,3.0)")
     implementation("commons-logging", "commons-logging", "1.2")
-    implementation("com.fasterxml.jackson.core", "jackson-databind", "2.15.2")
+    implementation("tools.jackson.core", "jackson-databind", "3.2.2")
     implementation("software.amazon.awssdk", "sdk-core", "[2.21,3.0)")
     implementation("software.amazon.awssdk", "auth", "[2.21,3.0)")
     implementation("software.amazon.awssdk", "http-auth-aws", "[2.21,3.0)")


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/2125 to 3.x