### PR TITLE
[Backport] [3.x] Fix release workflows to use pre-releases and update releasing.md with new process (#2010)

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,8 +10,8 @@ jobs:
     name: Draft a release
     runs-on: ubuntu-latest
     permissions:
-      issues: write # trstringer/manual-approval
-      contents: write # softprops/action-gh-release
+      issues: write
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -41,7 +41,7 @@ jobs:
       - name: Draft a release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         with:
-          draft: true
-          generate_release_notes: true
-          files: |
-            artifacts.tar.gz
+          immutableCreate: true
+          generateReleaseNotes: true
+          artifacts: "artifacts.tar.gz"
+          prerelease: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -83,7 +83,7 @@ Assuming the following current state.
 
 ### Automated Release
 
-The [release-drafter workflow](.github/workflows/release-drafter.yml) will be automatically kicked off and is responsible for drafting a new release on GitHub containing release artifacts. Before creating a draft release, this workflow creates a GitHub issue asking for approval from the [maintainers](MAINTAINERS.md). See sample [issue](https://github.com/gaiksaya/opensearch-java/issues/1). The maintainers need to approve in order to continue the workflow run. Once a release is drafted [opensearch-java-maven-sign-and-release](https://build.ci.opensearch.org/job/opensearch-java-maven-sign-and-release/) Jenkins workflow is triggered. The artifacts will be automatically signed and published to maven.
+The [release-drafter workflow](.github/workflows/release-drafter.yml) will be automatically kicked off and is responsible for drafting a new pre-release on GitHub containing release artifacts. Before creating a release, this workflow creates a GitHub issue asking for approval from the [maintainers](MAINTAINERS.md). See sample [issue](https://github.com/opensearch-project/opensearch-java/issues/2000). The maintainers need to approve in order to continue the workflow run. Once a pre-release is created [opensearch-java-maven-sign-and-release](https://build.ci.opensearch.org/job/opensearch-java-maven-sign-and-release/) Jenkins workflow is triggered. The artifacts will be automatically signed and published to maven. Once the above release workflow is successful, it creates a GitHub issue requesting maintainers to manually publish the pre-release to release on GitHub.
 
 ### CHANGELOG Entries
 

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@10.0.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@13.0.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -7,8 +7,7 @@ standardReleasePipelineWithGenericTrigger(
     overrideDockerImage: 'opensearchstaging/ci-runner:release-centos7-clients-v4',
     tokenIdCredential: 'jenkins-opensearch-java-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-java repository causing this workflow to run',
-    downloadReleaseAsset: true,
-    publishRelease: true) {
+    downloadReleaseAsset: true) {
         publishToMaven(
             signingArtifactsPath: "$WORKSPACE/repository/",
             mavenArtifactsPath: "$WORKSPACE/repository/",


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-java/pull/2010 to 3.x